### PR TITLE
JMEOS v1.3 

### DIFF
--- a/hs_err_pid17967.log
+++ b/hs_err_pid17967.log
@@ -1,0 +1,4450 @@
+#
+# A fatal error has been detected by the Java Runtime Environment:
+#
+#  SIGSEGV (0xb) at pc=0x00007f2035280350, pid=17967, tid=17969
+#
+# JRE version: OpenJDK Runtime Environment Corretto-21.0.6.7.1 (21.0.6+7) (build 21.0.6+7-LTS)
+# Java VM: OpenJDK 64-Bit Server VM Corretto-21.0.6.7.1 (21.0.6+7-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
+# Problematic frame:
+# C  [libmeos.so+0x4b350]  ensure_span_isof_type+0x0
+#
+# Core dump will be written. Default location: Core dumps may be processed with "/wsl-capture-crash %t %E %p %s" (or dumping to /usr/local/jmeos/core.17967)
+#
+# If you would like to submit a bug report, please visit:
+#   https://github.com/corretto/corretto-21/issues/
+# The crash happened outside the Java Virtual Machine in native code.
+# See problematic frame for where to report the bug.
+#
+
+---------------  S U M M A R Y ------------
+
+Command Line: -javaagent:/root/.m2/repository/org/jacoco/org.jacoco.agent/0.8.11/org.jacoco.agent-0.8.11-runtime.jar=destfile=/usr/local/jmeos/target/jacoco.exec /usr/local/jmeos/target/surefire/surefirebooter-20250905100721159_3.jar /usr/local/jmeos/target/surefire 2025-09-05T10-07-20_570-jvmRun1 surefire-20250905100721159_1tmp surefire_0-20250905100721159_2tmp
+
+Host: AMD Ryzen 7 7800X3D 8-Core Processor, 16 cores, 15G, Debian GNU/Linux 12 (bookworm)
+Time: Fri Sep  5 10:07:25 2025 UTC elapsed time: 4.318716 seconds (0d 0h 0m 4s)
+
+---------------  T H R E A D  ---------------
+
+Current thread (0x00007f20b402cd40):  JavaThread "main"             [_thread_in_native, id=17969, stack(0x00007f20b9e20000,0x00007f20b9f20000) (1024K)]
+
+Stack: [0x00007f20b9e20000,0x00007f20b9f20000],  sp=0x00007f20b9f1ba98,  free space=1006k
+Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+C  [libmeos.so+0x4b350]  ensure_span_isof_type+0x0
+Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
+j  functions.functions$MeosLibrary$jnr$ffi$0.floatspan_out$jni$235(JI)J+0
+j  functions.functions$MeosLibrary$jnr$ffi$0.floatspan_out(Ljnr/ffi/Pointer;I)Ljava/lang/String;+29
+j  functions.functions.floatspan_out(Ljnr/ffi/Pointer;I)Ljava/lang/String;+12
+j  types.collections.number.FloatSpan.toString(I)Ljava/lang/String;+12
+j  collections.number.FloatSpanSetTest.testSpans()V+70
+j  java.lang.invoke.LambdaForm$DMH+0x00007f203c218c00.invokeVirtual(Ljava/lang/Object;Ljava/lang/Object;)V+10 java.base@21.0.6
+j  java.lang.invoke.LambdaForm$MH+0x00007f203c219400.invoke(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;+31 java.base@21.0.6
+J 3593 c1 jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object; java.base@21.0.6 (92 bytes) @ 0x00007f209d02fd04 [0x00007f209d02e0e0+0x0000000000001c24]
+J 5273 c1 org.junit.platform.commons.util.ReflectionUtils.invokeMethod(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object; (128 bytes) @ 0x00007f209d36a5dc [0x00007f209d369a40+0x0000000000000b9c]
+J 5993 c1 org.junit.jupiter.engine.execution.MethodInvocation.proceed()Ljava/lang/Object; (28 bytes) @ 0x00007f209d4a54c4 [0x00007f209d4a5360+0x0000000000000164]
+J 5206 c1 org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed()Ljava/lang/Object; (26 bytes) @ 0x00007f209d346764 [0x00007f209d3465e0+0x0000000000000184]
+J 5414 c1 org.junit.jupiter.engine.extension.TimeoutExtension.intercept(Lorg/junit/jupiter/api/extension/InvocationInterceptor$Invocation;Lorg/junit/jupiter/api/extension/ReflectiveInvocationContext;Lorg/junit/jupiter/api/extension/ExtensionContext;Lorg/junit/jupiter/engine/extension/TimeoutDuration;Lorg/junit/jupiter/engine/extension/TimeoutExtension$TimeoutProvider;)Ljava/lang/Object; (63 bytes) @ 0x00007f209d3acbc4 [0x00007f209d3ac980+0x0000000000000244]
+J 5413 c1 org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(Lorg/junit/jupiter/api/extension/InvocationInterceptor$Invocation;Lorg/junit/jupiter/api/extension/ReflectiveInvocationContext;Lorg/junit/jupiter/api/extension/ExtensionContext;Lorg/junit/jupiter/engine/extension/TimeoutExtension$TimeoutProvider;)Ljava/lang/Object; (52 bytes) @ 0x00007f209d3ab6d4 [0x00007f209d3ab380+0x0000000000000354]
+j  org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(Lorg/junit/jupiter/api/extension/InvocationInterceptor$Invocation;Lorg/junit/jupiter/api/extension/ReflectiveInvocationContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)V+14
+j  org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor$$Lambda+0x00007f203c103030.apply(Lorg/junit/jupiter/api/extension/InvocationInterceptor;Lorg/junit/jupiter/api/extension/InvocationInterceptor$Invocation;Lorg/junit/jupiter/api/extension/ReflectiveInvocationContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)V+5
+J 5410 c1 org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(Lorg/junit/jupiter/engine/execution/InterceptingExecutableInvoker$ReflectiveInterceptorCall$VoidMethodInterceptorCall;Lorg/junit/jupiter/api/extension/InvocationInterceptor;Lorg/junit/jupiter/api/extension/InvocationInterceptor$Invocation;Lorg/junit/jupiter/api/extension/ReflectiveInvocationContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)Ljava/lang/Void; (23 bytes) @ 0x00007f209d3aa00c [0x00007f209d3a9ec0+0x000000000000014c]
+J 5409 c1 org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall$$Lambda+0x00007f203c103430.apply(Lorg/junit/jupiter/api/extension/InvocationInterceptor;Lorg/junit/jupiter/api/extension/InvocationInterceptor$Invocation;Lorg/junit/jupiter/api/extension/ReflectiveInvocationContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)Ljava/lang/Object; (13 bytes) @ 0x00007f209d3aa944 [0x00007f209d3aa8c0+0x0000000000000084]
+J 5204 c1 org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(Lorg/junit/jupiter/engine/execution/InterceptingExecutableInvoker$ReflectiveInterceptorCall;Lorg/junit/jupiter/api/extension/ReflectiveInvocationContext;Lorg/junit/jupiter/api/extension/ExtensionContext;Lorg/junit/jupiter/api/extension/InvocationInterceptor;Lorg/junit/jupiter/api/extension/InvocationInterceptor$Invocation;)Ljava/lang/Object; (23 bytes) @ 0x00007f209d34618c [0x00007f209d346040+0x000000000000014c]
+J 5203 c1 org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$$Lambda+0x00007f203c1838c8.apply(Lorg/junit/jupiter/api/extension/InvocationInterceptor;Lorg/junit/jupiter/api/extension/InvocationInterceptor$Invocation;)Ljava/lang/Object; (18 bytes) @ 0x00007f209d345ce4 [0x00007f209d345c40+0x00000000000000a4]
+J 5202 c1 org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed()Ljava/lang/Object; (26 bytes) @ 0x00007f209d345274 [0x00007f209d345160+0x0000000000000114]
+J 5227 c1 org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(Lorg/junit/jupiter/api/extension/InvocationInterceptor$Invocation;)Ljava/lang/Object; (34 bytes) @ 0x00007f209d34f424 [0x00007f209d34f2e0+0x0000000000000144]
+J 5022 c1 org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(Lorg/junit/jupiter/api/extension/InvocationInterceptor$Invocation;Lorg/junit/jupiter/engine/execution/InvocationInterceptorChain$InterceptorCall;Ljava/util/List;)Ljava/lang/Object; (65 bytes) @ 0x00007f209d2e9e34 [0x00007f209d2e9c80+0x00000000000001b4]
+J 5021 c1 org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(Lorg/junit/jupiter/api/extension/InvocationInterceptor$Invocation;Lorg/junit/jupiter/engine/extension/ExtensionRegistry;Lorg/junit/jupiter/engine/execution/InvocationInterceptorChain$InterceptorCall;)Ljava/lang/Object; (60 bytes) @ 0x00007f209d2e96c4 [0x00007f209d2e93a0+0x0000000000000324]
+J 5019 c1 org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(Lorg/junit/jupiter/api/extension/InvocationInterceptor$Invocation;Lorg/junit/jupiter/api/extension/ReflectiveInvocationContext;Lorg/junit/jupiter/api/extension/ExtensionContext;Lorg/junit/jupiter/engine/extension/ExtensionRegistry;Lorg/junit/jupiter/engine/execution/InterceptingExecutableInvoker$ReflectiveInterceptorCall;)Ljava/lang/Object; (30 bytes) @ 0x00007f209d2e4b24 [0x00007f209d2e4540+0x00000000000005e4]
+J 5989 c1 org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(Ljava/lang/reflect/Method;Ljava/lang/Object;Lorg/junit/jupiter/api/extension/ExtensionContext;Lorg/junit/jupiter/engine/extension/ExtensionRegistry;Lorg/junit/jupiter/engine/execution/InterceptingExecutableInvoker$ReflectiveInterceptorCall;)Ljava/lang/Object; (98 bytes) @ 0x00007f209d4a46b4 [0x00007f209d4a40c0+0x00000000000005f4]
+J 5987 c1 org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(Lorg/junit/jupiter/api/extension/ExtensionContext;Lorg/junit/jupiter/engine/execution/JupiterEngineExecutionContext;)V (103 bytes) @ 0x00007f209d4a2394 [0x00007f209d4a2140+0x0000000000000254]
+J 5986 c1 org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor$$Lambda+0x00007f203c188a80.execute()V (16 bytes) @ 0x00007f209d4a025c [0x00007f209d4a01c0+0x000000000000009c]
+J 5672 c2 org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(Lorg/junit/platform/engine/support/hierarchical/ThrowableCollector$Executable;)V (48 bytes) @ 0x00007f20a4804434 [0x00007f20a48043c0+0x0000000000000074]
+J 5984 c1 org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(Lorg/junit/jupiter/engine/execution/JupiterEngineExecutionContext;Lorg/junit/platform/engine/support/hierarchical/Node$DynamicTestExecutor;)V (50 bytes) @ 0x00007f209d4a116c [0x00007f209d4a0b60+0x000000000000060c]
+J 5973 c1 org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(Lorg/junit/jupiter/engine/execution/JupiterEngineExecutionContext;Lorg/junit/platform/engine/support/hierarchical/Node$DynamicTestExecutor;)Lorg/junit/jupiter/engine/execution/JupiterEngineExecutionContext; (166 bytes) @ 0x00007f209d49c40c [0x00007f209d49bea0+0x000000000000056c]
+J 5972 c1 org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(Lorg/junit/platform/engine/support/hierarchical/EngineExecutionContext;Lorg/junit/platform/engine/support/hierarchical/Node$DynamicTestExecutor;)Lorg/junit/platform/engine/support/hierarchical/EngineExecutionContext; (21 bytes) @ 0x00007f209d49a48c [0x00007f209d49a260+0x000000000000022c]
+J 5553 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6()V (205 bytes) @ 0x00007f209d3f07dc [0x00007f209d3efba0+0x0000000000000c3c]
+J 5552 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda+0x00007f203c11ecb8.execute()V (8 bytes) @ 0x00007f209d3e984c [0x00007f209d3e97c0+0x000000000000008c]
+J 5672 c2 org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(Lorg/junit/platform/engine/support/hierarchical/ThrowableCollector$Executable;)V (48 bytes) @ 0x00007f20a4804434 [0x00007f20a48043c0+0x0000000000000074]
+J 5550 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(Lorg/junit/platform/engine/support/hierarchical/EngineExecutionContext;)V (51 bytes) @ 0x00007f209d3ea9bc [0x00007f209d3ea4a0+0x000000000000051c]
+J 5548 c1 org.junit.platform.engine.support.hierarchical.Node.around(Lorg/junit/platform/engine/support/hierarchical/EngineExecutionContext;Lorg/junit/platform/engine/support/hierarchical/Node$Invocation;)V (19 bytes) @ 0x00007f209d3e67a4 [0x00007f209d3e6660+0x0000000000000144]
+J 5546 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9()V (29 bytes) @ 0x00007f209d3e719c [0x00007f209d3e6ca0+0x00000000000004fc]
+J 5545 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda+0x00007f203c11e698.execute()V (8 bytes) @ 0x00007f209d3e5acc [0x00007f209d3e5a40+0x000000000000008c]
+J 5672 c2 org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(Lorg/junit/platform/engine/support/hierarchical/ThrowableCollector$Executable;)V (48 bytes) @ 0x00007f20a4804434 [0x00007f20a48043c0+0x0000000000000074]
+J 5514 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively()V (49 bytes) @ 0x00007f209d3d51f4 [0x00007f209d3d4c60+0x0000000000000594]
+J 5235 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask.execute()V (270 bytes) @ 0x00007f209d357834 [0x00007f209d357300+0x0000000000000534]
+J 6279 c1 org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService$$Lambda+0x00007f203c11f780.accept(Ljava/lang/Object;)V (10 bytes) @ 0x00007f209d502d0c [0x00007f209d502b40+0x00000000000001cc]
+J 6051 c2 java.util.ArrayList.forEach(Ljava/util/function/Consumer;)V java.base@21.0.6 (74 bytes) @ 0x00007f20a482f598 [0x00007f20a482f4a0+0x00000000000000f8]
+j  org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(Ljava/util/List;)V+10
+J 5553 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6()V (205 bytes) @ 0x00007f209d3f0e54 [0x00007f209d3efba0+0x00000000000012b4]
+J 5552 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda+0x00007f203c11ecb8.execute()V (8 bytes) @ 0x00007f209d3e984c [0x00007f209d3e97c0+0x000000000000008c]
+J 5672 c2 org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(Lorg/junit/platform/engine/support/hierarchical/ThrowableCollector$Executable;)V (48 bytes) @ 0x00007f20a4804434 [0x00007f20a48043c0+0x0000000000000074]
+J 5550 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(Lorg/junit/platform/engine/support/hierarchical/EngineExecutionContext;)V (51 bytes) @ 0x00007f209d3ea9bc [0x00007f209d3ea4a0+0x000000000000051c]
+J 5548 c1 org.junit.platform.engine.support.hierarchical.Node.around(Lorg/junit/platform/engine/support/hierarchical/EngineExecutionContext;Lorg/junit/platform/engine/support/hierarchical/Node$Invocation;)V (19 bytes) @ 0x00007f209d3e67a4 [0x00007f209d3e6660+0x0000000000000144]
+J 5546 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9()V (29 bytes) @ 0x00007f209d3e719c [0x00007f209d3e6ca0+0x00000000000004fc]
+J 5545 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda+0x00007f203c11e698.execute()V (8 bytes) @ 0x00007f209d3e5acc [0x00007f209d3e5a40+0x000000000000008c]
+J 5672 c2 org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(Lorg/junit/platform/engine/support/hierarchical/ThrowableCollector$Executable;)V (48 bytes) @ 0x00007f20a4804434 [0x00007f20a48043c0+0x0000000000000074]
+J 5514 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively()V (49 bytes) @ 0x00007f209d3d51f4 [0x00007f209d3d4c60+0x0000000000000594]
+J 5235 c1 org.junit.platform.engine.support.hierarchical.NodeTestTask.execute()V (270 bytes) @ 0x00007f209d357834 [0x00007f209d357300+0x0000000000000534]
+J 6279 c1 org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService$$Lambda+0x00007f203c11f780.accept(Ljava/lang/Object;)V (10 bytes) @ 0x00007f209d502d0c [0x00007f209d502b40+0x00000000000001cc]
+j  java.util.ArrayList.forEach(Ljava/util/function/Consumer;)V+46 java.base@21.0.6
+j  org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(Ljava/util/List;)V+10
+j  org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6()V+170
+j  org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda+0x00007f203c11ecb8.execute()V+4
+j  org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(Lorg/junit/platform/engine/support/hierarchical/ThrowableCollector$Executable;)V+5
+j  org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(Lorg/junit/platform/engine/support/hierarchical/EngineExecutionContext;)V+24
+j  org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda+0x00007f203c11eaa0.invoke(Lorg/junit/platform/engine/support/hierarchical/EngineExecutionContext;)V+5
+j  org.junit.platform.engine.support.hierarchical.Node.around(Lorg/junit/platform/engine/support/hierarchical/EngineExecutionContext;Lorg/junit/platform/engine/support/hierarchical/Node$Invocation;)V+7
+j  org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9()V+18
+j  org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda+0x00007f203c11e698.execute()V+4
+j  org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(Lorg/junit/platform/engine/support/hierarchical/ThrowableCollector$Executable;)V+5
+j  org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively()V+40
+j  org.junit.platform.engine.support.hierarchical.NodeTestTask.execute()V+108
+j  org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(Lorg/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorService$TestTask;)Ljava/util/concurrent/Future;+5
+j  org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute()Ljava/util/concurrent/Future;+107
+j  org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(Lorg/junit/platform/engine/ExecutionRequest;)V+55
+j  org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(Lorg/junit/platform/engine/TestDescriptor;Lorg/junit/platform/engine/EngineExecutionListener;Lorg/junit/platform/engine/ConfigurationParameters;Lorg/junit/platform/engine/TestEngine;)V+35
+j  org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(Lorg/junit/platform/launcher/core/LauncherDiscoveryResult;Lorg/junit/platform/engine/EngineExecutionListener;)V+183
+j  org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(Lorg/junit/platform/launcher/core/InternalTestPlan;Lorg/junit/platform/engine/EngineExecutionListener;Lorg/junit/platform/launcher/TestExecutionListener;)V+108
+j  org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(Lorg/junit/platform/launcher/core/InternalTestPlan;Lorg/junit/platform/launcher/TestExecutionListener;)V+11
+j  org.junit.platform.launcher.core.EngineExecutionOrchestrator$$Lambda+0x00007f203c10ac78.accept(Ljava/lang/Object;)V+12
+j  org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(Lorg/junit/platform/engine/ConfigurationParameters;Lorg/junit/platform/launcher/core/ListenerRegistry;Ljava/util/function/Consumer;)V+80
+j  org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(Lorg/junit/platform/launcher/core/InternalTestPlan;[Lorg/junit/platform/launcher/TestExecutionListener;)V+40
+j  org.junit.platform.launcher.core.DefaultLauncher.execute(Lorg/junit/platform/launcher/core/InternalTestPlan;[Lorg/junit/platform/launcher/TestExecutionListener;)V+11
+j  org.junit.platform.launcher.core.DefaultLauncher.execute(Lorg/junit/platform/launcher/LauncherDiscoveryRequest;[Lorg/junit/platform/launcher/TestExecutionListener;)V+57
+j  org.junit.platform.launcher.core.DelegatingLauncher.execute(Lorg/junit/platform/launcher/LauncherDiscoveryRequest;[Lorg/junit/platform/launcher/TestExecutionListener;)V+11
+j  org.apache.maven.surefire.junitplatform.LazyLauncher.execute(Lorg/junit/platform/launcher/LauncherDiscoveryRequest;[Lorg/junit/platform/launcher/TestExecutionListener;)V+11
+j  org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(Lorg/apache/maven/surefire/api/util/TestsToRun;Lorg/apache/maven/surefire/junitplatform/RunListenerAdapter;)V+120
+j  org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(Lorg/apache/maven/surefire/api/util/TestsToRun;Lorg/apache/maven/surefire/junitplatform/RunListenerAdapter;)V+8
+j  org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(Ljava/lang/Object;)Lorg/apache/maven/surefire/api/suite/RunResult;+146
+j  org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess()V+12
+j  org.apache.maven.surefire.booter.ForkedBooter.execute()V+5
+j  org.apache.maven.surefire.booter.ForkedBooter.run(Lorg/apache/maven/surefire/booter/ForkedBooter;[Ljava/lang/String;)V+49
+j  org.apache.maven.surefire.booter.ForkedBooter.main([Ljava/lang/String;)V+20
+v  ~StubRoutines::call_stub 0x00007f20a3d11cc6
+
+siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x0000000001010b0d
+
+Registers:
+RAX=0x0000000000000001, RBX=0x0000000001010b0d, RCX=0x000000000000000f, RDX=0x0000000001010b0d
+RSP=0x00007f20b9f1ba98, RBP=0x000000000000000f, RSI=0x000000000000000d, RDI=0x0000000001010b0d
+R8 =0x00007f203b4496a0, R9 =0x0000000000000000, R10=0x00007f20a3d1da91, R11=0x0000000713c3bb38
+R12=0x0000000000000000, R13=0x00007f2037e000f8, R14=0x00007f20b9f1bb60, R15=0x00007f20b402cd40
+RIP=0x00007f2035280350, EFLAGS=0x0000000000010202, CSGSFS=0x002b000000000033, ERR=0x0000000000000004
+  TRAPNO=0x000000000000000e
+
+XMM[0]=0x00007f20b402cd40 0x00007f203b4496a0
+XMM[1]=0x294fe48100acab9f 0x14e8c84188303fdf
+XMM[2]=0x0c98f5818685ba9f 0x4a319941fc018edf
+XMM[3]=0xee830681e1ddc99f 0x59db6a41e191dddf
+XMM[4]=0x000e178101b4d89f 0x34e63b4167e12cdf
+XMM[5]=0x95aaf3af4ce46cce 0xfc060bee63fa7256
+XMM[6]=0xce81297653fbeaf1 0x0a163ef240ae8190
+XMM[7]=0x08349766fe5e555a 0x34d9feea69c7bbf1
+XMM[8]=0x06a91bf9c28876ce 0xefd3b12f3ae01af3
+XMM[9]=0x1c251eb91c251eb9 0x1c251eb96dafd911
+XMM[10]=0x0000000000000000 0x00000000518aba58
+XMM[11]=0xf40dc30bf40dc30b 0xf40dc30b61bd9c1c
+XMM[12]=0x0000000000000000 0x000000006dafd911
+XMM[13]=0x0000000000000000 0xc056800000000000
+XMM[14]=0x0000000000000000 0x3f05a659d392c215
+XMM[15]=0x0000000000000000 0x3feff606d6db69e9
+  MXCSR=0x00001fa2
+
+
+Register to memory mapping:
+
+RAX=0x0000000000000001 is an unknown value
+RBX=0x0000000001010b0d is an unknown value
+RCX=0x000000000000000f is an unknown value
+RDX=0x0000000001010b0d is an unknown value
+RSP=0x00007f20b9f1ba98 is pointing into the stack for thread: 0x00007f20b402cd40
+RBP=0x000000000000000f is an unknown value
+RSI=0x000000000000000d is an unknown value
+RDI=0x0000000001010b0d is an unknown value
+R8 ={method} {0x00007f203b4496a0} 'next' '()Ljava/lang/Object;' in 'java/util/Iterator'
+R9 =0x0 is null
+R10=0x00007f20a3d1da91 is at code_begin+1009 in an Interpreter codelet
+native method entry point (kind = native)  [0x00007f20a3d1d6a0, 0x00007f20a3d1e210]  2928 bytes
+R11=0x0000000713c3bb38 is an oop: java.lang.Class
+{0x0000000713c3bb38} - klass: 'java/lang/Class'
+ - ---- fields (total size 56 words):
+ - private volatile transient 'classRedefinedCount' 'I' @12  0 (0x00000000)
+ - injected 'klass' 'J' @16  139776423821312 (0x00007f203c170000)
+ - injected 'array_klass' 'J' @24  0 (0x0000000000000000)
+ - injected 'oop_size' 'I' @32  56 (0x00000038)
+ - injected 'static_oop_field_count' 'I' @36  84 (0x00000054)
+ - private volatile transient 'cachedConstructor' 'Ljava/lang/reflect/Constructor;' @40  null (0x00000000)
+ - private transient 'name' 'Ljava/lang/String;' @44  "functions.functions$MeosLibrary$jnr$ffi$0"{0x0000000713c3bcf8} (0xe278779f)
+ - private transient 'module' 'Ljava/lang/Module;' @48  a 'java/lang/Module'{0x000000070d357c88} (0xe1a6af91)
+ - private final 'classLoader' 'Ljava/lang/ClassLoader;' @52  a 'jnr/ffi/provider/jffi/AsmClassLoader'{0x000000070d357c30} (0xe1a6af86)
+ - private transient 'classData' 'Ljava/lang/Object;' @56  null (0x00000000)
+ - private transient 'packageName' 'Ljava/lang/String;' @60  "functions"{0x000000070d096190} (0xe1a12c32)
+ - private final 'componentType' 'Ljava/lang/Class;' @64  null (0x00000000)
+ - private volatile transient 'reflectionData' 'Ljava/lang/ref/SoftReference;' @68  a 'java/lang/ref/SoftReference'{0x0000000713c3bd50} (0xe27877aa)
+ - private volatile transient 'genericInfo' 'Lsun/reflect/generics/repository/ClassRepository;' @72  null (0x00000000)
+ - private volatile transient 'enumConstants' '[Ljava/lang/Object;' @76  null (0x00000000)
+ - private volatile transient 'enumConstantDirectory' 'Ljava/util/Map;' @80  null (0x00000000)
+ - private volatile transient 'annotationData' 'Ljava/lang/Class$AnnotationData;' @84  null (0x00000000)
+ - private volatile transient 'annotationType' 'Lsun/reflect/annotation/AnnotationType;' @88  null (0x00000000)
+ - transient 'classValueMap' 'Ljava/lang/ClassValue$ClassValueMap;' @92  null (0x00000000)
+ - injected 'protection_domain' 'Ljava/lang/Object;' @96  a 'java/security/ProtectionDomain'{0x000000070d358548} (0xe1a6b0a9)
+ - injected 'signers_name' 'Ljava/lang/Object;' @100  null (0x00000000)
+ - injected 'source_file' 'Ljava/lang/Object;' @104  null (0x00000000)
+ - injected '<init_lock>' 'Ljava/lang/Object;' @108  null (0x00000000)
+ - signature: Lfunctions/functions$MeosLibrary$jnr$ffi$0;
+ - ---- static fields (84):
+ - private static final 'error_1' 'Ljava/lang/String;' @112  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_2' 'Ljava/lang/String;' @116  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_3' 'Ljava/lang/String;' @120  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_4' 'Ljava/lang/String;' @124  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_5' 'Ljava/lang/String;' @128  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_6' 'Ljava/lang/String;' @132  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_7' 'Ljava/lang/String;' @136  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_8' 'Ljava/lang/String;' @140  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_9' 'Ljava/lang/String;' @144  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_10' 'Ljava/lang/String;' @148  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_11' 'Ljava/lang/String;' @152  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_12' 'Ljava/lang/String;' @156  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_13' 'Ljava/lang/String;' @160  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_14' 'Ljava/lang/String;' @164  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_15' 'Ljava/lang/String;' @168  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_16' 'Ljava/lang/String;' @172  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_17' 'Ljava/lang/String;' @176  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_18' 'Ljava/lang/String;' @180  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_19' 'Ljava/lang/String;' @184  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_20' 'Ljava/lang/String;' @188  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_21' 'Ljava/lang/String;' @192  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_22' 'Ljava/lang/String;' @196  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_23' 'Ljava/lang/String;' @200  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_24' 'Ljava/lang/String;' @204  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_25' 'Ljava/lang/String;' @208  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_26' 'Ljava/lang/String;' @212  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_27' 'Ljava/lang/String;' @216  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_28' 'Ljava/lang/String;' @220  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_29' 'Ljava/lang/String;' @224  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_30' 'Ljava/lang/String;' @228  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_31' 'Ljava/lang/String;' @232  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_32' 'Ljava/lang/String;' @236  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_33' 'Ljava/lang/String;' @240  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_34' 'Ljava/lang/String;' @244  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_35' 'Ljava/lang/String;' @248  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_36' 'Ljava/lang/String;' @252  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_37' 'Ljava/lang/String;' @256  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_38' 'Ljava/lang/String;' @260  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_39' 'Ljava/lang/String;' @264  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_40' 'Ljava/lang/String;' @268  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_41' 'Ljava/lang/String;' @272  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_42' 'Ljava/lang/String;' @276  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_43' 'Ljava/lang/String;' @280  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_44' 'Ljava/lang/String;' @284  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_45' 'Ljava/lang/String;' @288  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_46' 'Ljava/lang/String;' @292  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_47' 'Ljava/lang/String;' @296  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_48' 'Ljava/lang/String;' @300  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_49' 'Ljava/lang/String;' @304  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_50' 'Ljava/lang/String;' @308  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_51' 'Ljava/lang/String;' @312  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_52' 'Ljava/lang/String;' @316  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_53' 'Ljava/lang/String;' @320  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_54' 'Ljava/lang/String;' @324  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_55' 'Ljava/lang/String;' @328  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_56' 'Ljava/lang/String;' @332  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_57' 'Ljava/lang/String;' @336  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_58' 'Ljava/lang/String;' @340  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_59' 'Ljava/lang/String;' @344  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_60' 'Ljava/lang/String;' @348  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_61' 'Ljava/lang/String;' @352  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_62' 'Ljava/lang/String;' @356  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_63' 'Ljava/lang/String;' @360  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_64' 'Ljava/lang/String;' @364  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_65' 'Ljava/lang/String;' @368  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_66' 'Ljava/lang/String;' @372  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_67' 'Ljava/lang/String;' @376  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_68' 'Ljava/lang/String;' @380  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_69' 'Ljava/lang/String;' @384  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_70' 'Ljava/lang/String;' @388  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_71' 'Ljava/lang/String;' @392  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_72' 'Ljava/lang/String;' @396  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_73' 'Ljava/lang/String;' @400  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_74' 'Ljava/lang/String;' @404  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_75' 'Ljava/lang/String;' @408  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_76' 'Ljava/lang/String;' @412  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_77' 'Ljava/lang/String;' @416  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_78' 'Ljava/lang/String;' @420  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_79' 'Ljava/lang/String;' @424  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_80' 'Ljava/lang/String;' @428  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_81' 'Ljava/lang/String;' @432  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_82' 'Ljava/lang/String;' @436  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_83' 'Ljava/lang/String;' @440  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+ - private static final 'error_84' 'Ljava/lang/String;' @444  "unknown"{0x000000070d357cc0} (0xe1a6af98)
+R12=0x0 is null
+R13={method} {0x00007f2037e000f8} 'floatspan_out$jni$235' '(JI)J' in 'functions/functions$MeosLibrary$jnr$ffi$0'
+R14=0x00007f20b9f1bb60 is pointing into the stack for thread: 0x00007f20b402cd40
+R15=0x00007f20b402cd40 is a thread
+
+Top of Stack: (sp=0x00007f20b9f1ba98)
+0x00007f20b9f1ba98:   00007f20352e4021 00007f20b9f1bb50
+0x00007f20b9f1baa8:   00007f2037e000f8 00007f20b9f1bb30
+0x00007f20b9f1bab8:   00007f20340a41ee 0000000000000014
+0x00007f20b9f1bac8:   00007f20a3d1dac0 00007f203b4496a0
+0x00007f20b9f1bad8:   00007f20b402cd40 00007f203b489600
+0x00007f20b9f1bae8:   00007f20b9f1bae8 0000000000000000
+0x00007f20b9f1baf8:   0000000000000006 00007f2037f00000
+0x00007f20b9f1bb08:   0000000000000000 0000000713c3bb38
+0x00007f20b9f1bb18:   00007f2037e000f8 0000000000000000
+0x00007f20b9f1bb28:   00007f20b9f1bb50 00007f20b9f1bbb0
+0x00007f20b9f1bb38:   00007f20a3d1925e 0000000713c3bb38
+0x00007f20b9f1bb48:   00007f20a3d1afd6 000000000000000f
+0x00007f20b9f1bb58:   0000000001010b0d 0000000000000000
+0x00007f20b9f1bb68:   00007f20b9f1bb68 00007f2037e001b5
+0x00007f20b9f1bb78:   000000000000000a 00007f2037f00000
+0x00007f20b9f1bb88:   0000000000000000 0000000713c3bb38
+0x00007f20b9f1bb98:   00007f2037e001f8 00007f20b9f1bb50
+0x00007f20b9f1bba8:   00007f20b9f1bbf0 00007f20b9f1bc50
+0x00007f20b9f1bbb8:   00007f20a3d19798 0000000000000000
+0x00007f20b9f1bbc8:   0000000000000000 0000000000000000
+0x00007f20b9f1bbd8:   0000000000000000 0000000000000000
+0x00007f20b9f1bbe8:   0000000000000000 000000000000000f
+0x00007f20b9f1bbf8:   000000071aed7de0 0000000713c871f8
+0x00007f20b9f1bc08:   00007f20b9f1bc08 00007f2037936e04
+0x00007f20b9f1bc18:   0000000000000005 00007f20379c0000
+0x00007f20b9f1bc28:   0000000000000000 000000070d56a5a0
+0x00007f20b9f1bc38:   00007f2037936e30 00007f20b9f1bbf0
+0x00007f20b9f1bc48:   00007f20b9f1bc70 00007f20b9f1bcc8
+0x00007f20b9f1bc58:   00007f20a3d192f2 000000070d3e0318
+0x00007f20b9f1bc68:   0000000000000000 000000000000000f
+0x00007f20b9f1bc78:   000000071aed7de0 00007f20b9f1bc80
+0x00007f20b9f1bc88:   00007f2037783e9c 0000000000000005
+
+Instructions: (pc=0x00007f2035280350)
+0x00007f2035280250:   89 de 31 c9 5b 5d 41 5c 41 5d 41 5e 41 5f e9 ad
+0x00007f2035280260:   d2 fe ff 0f 1f 44 00 00 48 83 c4 18 4c 89 f7 5b
+0x00007f2035280270:   5d 41 5c 41 5d 41 5e 41 5f e9 d2 05 ff ff 66 90
+0x00007f2035280280:   55 48 89 f5 53 48 89 fb 48 83 ec 08 e8 4f b7 fe
+0x00007f2035280290:   ff 84 c0 74 3b 48 89 ef e8 43 b7 fe ff 84 c0 74
+0x00007f20352802a0:   2f 48 89 ee 48 89 df e8 94 c2 fe ff 84 c0 74 20
+0x00007f20352802b0:   48 83 c4 08 48 89 ee 48 89 df ba 02 00 00 00 5b
+0x00007f20352802c0:   5d e9 9a e5 ff ff 66 2e 0f 1f 84 00 00 00 00 00
+0x00007f20352802d0:   48 83 c4 08 31 c0 5b 5d c3 0f 1f 80 00 00 00 00
+0x00007f20352802e0:   55 53 48 89 f3 48 83 ec 28 48 89 e5 48 89 ee e8
+0x00007f20352802f0:   ec f2 fe ff 48 89 de 48 89 ef e8 f1 d7 fe ff 48
+0x00007f2035280300:   83 c4 28 5b 5d c3 66 2e 0f 1f 84 00 00 00 00 00
+0x00007f2035280310:   41 54 55 53 48 89 f3 48 83 ec 40 48 89 e5 4c 8d
+0x00007f2035280320:   64 24 20 48 89 ee e8 b5 f2 fe ff 4c 89 e6 48 89
+0x00007f2035280330:   df e8 aa f2 fe ff 4c 89 e6 48 89 ef e8 3f b6 fe
+0x00007f2035280340:   ff 48 83 c4 40 5b 5d 41 5c c3 66 0f 1f 44 00 00
+0x00007f2035280350:   0f b6 17 39 f2 74 31 48 83 ec 08 89 f7 e8 1e ea
+0x00007f2035280360:   fe ff be 0b 00 00 00 bf 15 00 00 00 48 8d 15 78
+0x00007f2035280370:   bc 10 00 48 89 c1 31 c0 e8 73 ef fe ff 31 c0 48
+0x00007f2035280380:   83 c4 08 c3 0f 1f 40 00 b8 01 00 00 00 c3 66 90
+0x00007f2035280390:   0f b6 57 01 39 f2 74 48 55 53 48 89 fb 89 f7 48
+0x00007f20352803a0:   83 ec 08 e8 d8 e9 fe ff 0f b6 3b 48 89 c5 e8 cd
+0x00007f20352803b0:   e9 fe ff 49 89 e8 be 0b 00 00 00 48 8d 15 66 bc
+0x00007f20352803c0:   10 00 48 89 c1 bf 15 00 00 00 31 c0 e8 1f ef fe
+0x00007f20352803d0:   ff 48 83 c4 08 31 c0 5b 5d c3 66 0f 1f 44 00 00
+0x00007f20352803e0:   b8 01 00 00 00 c3 66 2e 0f 1f 84 00 00 00 00 00
+0x00007f20352803f0:   55 b8 01 00 00 00 53 48 89 fb 48 83 ec 08 0f b6
+0x00007f2035280400:   3e 40 38 3b 74 30 e8 75 e9 fe ff 0f b6 3b 48 89
+0x00007f2035280410:   c5 e8 6a e9 fe ff 49 89 e8 be 0b 00 00 00 48 8d
+0x00007f2035280420:   15 3b bc 10 00 48 89 c1 bf 15 00 00 00 31 c0 e8
+0x00007f2035280430:   bc ee fe ff 31 c0 48 83 c4 08 5b 5d c3 0f 1f 00
+0x00007f2035280440:   48 85 f6 74 19 48 8b 47 08 48 89 06 0f b6 47 02
+
+
+Stack slot to memory mapping:
+
+stack at sp + 0 slots: 0x00007f20352e4021: floatspan_out+0x0000000000000021 in /usr/local/lib/libmeos.so at 0x00007f2035235000
+stack at sp + 1 slots: 0x00007f20b9f1bb50 is pointing into the stack for thread: 0x00007f20b402cd40
+stack at sp + 2 slots: {method} {0x00007f2037e000f8} 'floatspan_out$jni$235' '(JI)J' in 'functions/functions$MeosLibrary$jnr$ffi$0'
+stack at sp + 3 slots: 0x00007f20b9f1bb30 is pointing into the stack for thread: 0x00007f20b402cd40
+stack at sp + 4 slots: 0x00007f20340a41ee points into unknown readable memory: 48 89
+stack at sp + 5 slots: 0x0000000000000014 is an unknown value
+stack at sp + 6 slots: 0x00007f20a3d1dac0 is at code_begin+1056 in an Interpreter codelet
+native method entry point (kind = native)  [0x00007f20a3d1d6a0, 0x00007f20a3d1e210]  2928 bytes
+stack at sp + 7 slots: {method} {0x00007f203b4496a0} 'next' '()Ljava/lang/Object;' in 'java/util/Iterator'
+
+
+Compiled method (c1) 4848 3593   !   3       jdk.internal.reflect.DirectMethodHandleAccessor::invoke (92 bytes)
+ total in heap  [0x00007f209d02dc10,0x00007f209d031ee0] = 17104
+ relocation     [0x00007f209d02dd68,0x00007f209d02e0d8] = 880
+ main code      [0x00007f209d02e0e0,0x00007f209d0309a8] = 10440
+ stub code      [0x00007f209d0309a8,0x00007f209d030ad0] = 296
+ oops           [0x00007f209d030ad0,0x00007f209d030af8] = 40
+ metadata       [0x00007f209d030af8,0x00007f209d030b68] = 112
+ scopes data    [0x00007f209d030b68,0x00007f209d031020] = 1208
+ scopes pcs     [0x00007f209d031020,0x00007f209d031600] = 1504
+ dependencies   [0x00007f209d031600,0x00007f209d031608] = 8
+ handler table  [0x00007f209d031608,0x00007f209d031e18] = 2064
+ nul chk table  [0x00007f209d031e18,0x00007f209d031ee0] = 200
+
+[Constant Pool (empty)]
+
+[MachCode]
+[Entry Point]
+  # {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor'
+  # this:     rsi:rsi   = 'jdk/internal/reflect/DirectMethodHandleAccessor'
+  # parm0:    rdx:rdx   = 'java/lang/Object'
+  # parm1:    rcx:rcx   = '[Ljava/lang/Object;'
+  #           [sp+0x150]  (sp of caller)
+  0x00007f209d02e0e0: 448b 5608 | 49bb 0000 | 003b 207f | 0000 4d03 | d34c 3bd0
+
+  0x00007f209d02e0f4: ;   {runtime_call ic_miss_stub}
+  0x00007f209d02e0f4: 0f85 8611 | d306 660f | 1f44 0000
+[Verified Entry Point]
+  0x00007f209d02e100: 8984 2400 | c0fe ff55 | 4881 ec40 | 0100 0090 | 4181 7f20 | 0100 0000
+
+  0x00007f209d02e118: ;   {runtime_call StubRoutines (final stubs)}
+  0x00007f209d02e118: 7405 e801 | 91d1 0648 | 89b4 24a8 | 0000 0048 | 8994 24b8 | 0000 0048 | 898c 24b0
+
+  0x00007f209d02e134: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e134: 0000 0048 | bfe0 2ed1 | 3720 7f00 | 008b 9ff4 | 0000 0083 | c302 899f | f400 0000 | 81e3 fe07
+  0x00007f209d02e154: 0000 85db | 0f84 fb22 | 0000 488b
+
+  0x00007f209d02e160: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e160: fe48 bbe0 | 2ed1 3720 | 7f00 0048 | 8383 3801
+
+  0x00007f209d02e170: ;   {metadata(method data for {method} {0x00007f203b3c5228} 'isStatic' '()Z' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e170: 0000 0148 | bf38 2ad1 | 3720 7f00 | 008b 9ff4 | 0000 0083 | c302 899f | f400 0000 | 81e3 feff
+  0x00007f209d02e190: 1f00 85db | 0f84 e022 | 0000 8b7e | 1081 e700 | 0200 0081 | ff00 0200
+
+  0x00007f209d02e1a8: ;   {metadata(method data for {method} {0x00007f203b3c5228} 'isStatic' '()Z' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e1a8: 0048 bf38 | 2ad1 3720 | 7f00 0048 | c7c3 3801 | 0000 7507 | 48c7 c348 | 0100 0048 | 8b04 1f48
+  0x00007f209d02e1c8: 8d40 0148 | 8904 1f0f | 851a 0000
+
+  0x00007f209d02e1d4: ;   {metadata(method data for {method} {0x00007f203b3c5228} 'isStatic' '()Z' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e1d4: 0048 bf38 | 2ad1 3720 | 7f00 00ff | 8758 0100 | 00bf 0100 | 0000 e905 | 0000 00bf | 0000 0000
+  0x00007f209d02e1f4: 83e7 0185
+
+  0x00007f209d02e1f8: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e1f8: ff48 bfe0 | 2ed1 3720 | 7f00 0048 | c7c3 7001 | 0000 7507 | 48c7 c380 | 0100 0048 | 8b04 1f48
+  0x00007f209d02e218: 8d40 0148 | 8904 1f0f | 85d5 0000 | 0048 8bfe
+
+  0x00007f209d02e228: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e228: 48bb e02e | d137 207f | 0000 4883 | 8390 0100
+
+  0x00007f209d02e238: ;   {metadata(method data for {method} {0x00007f203b3c5178} 'checkReceiver' '(Ljava/lang/Object;)V' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e238: 0001 48bf | 4032 d137 | 207f 0000 | 8b9f f400 | 0000 83c3 | 0289 9ff4 | 0000 0081 | e3fe ff1f
+  0x00007f209d02e258: 0085 db0f | 843a 2200 | 008b 7e14 | 48c1 e703
+
+  0x00007f209d02e268: ; implicit exception: dispatches to 0x00007f209d0304bc
+  0x00007f209d02e268: 483b 0248
+
+  0x00007f209d02e26c: ;   {metadata(method data for {method} {0x00007f203b3c5178} 'checkReceiver' '(Ljava/lang/Object;)V' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e26c: 8bda 48b8 | 4032 d137 | 207f 0000 | 4883 8038 | 0100 0001 | 8b5a 0849 | ba00 0000 | 3b20 7f00
+  0x00007f209d02e28c: 0049 03da | 488b 5b70 | 488b 1b48 | 3b07 488b
+
+  0x00007f209d02e29c: ;   {metadata(method data for {method} {0x00007f203b3c5178} 'checkReceiver' '(Ljava/lang/Object;)V' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e29c: c749 b840 | 32d1 3720 | 7f00 0049 | 8380 7001 | 0000 0148 | 8bd3 488b
+
+  0x00007f209d02e2b4: ;   {optimized virtual_call}
+  0x00007f209d02e2b4: f766 90e8
+
+  0x00007f209d02e2b8: ; ImmutableOopMap {[168]=Oop [176]=Oop [184]=Oop }
+                      ;*invokevirtual isAssignableFrom {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::checkReceiver@8 (line 196)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@9 (line 99)
+  0x00007f209d02e2b8: 043f 4407
+
+  0x00007f209d02e2bc: ;   {other}
+  0x00007f209d02e2bc: 0f1f 8400 | ac06 0000
+
+  0x00007f209d02e2c4: ;   {metadata(method data for {method} {0x00007f203b3c5178} 'checkReceiver' '(Ljava/lang/Object;)V' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e2c4: 85c0 48be | 4032 d137 | 207f 0000 | 48c7 c2b8 | 0100 0074 | 0748 c7c2 | a801 0000 | 488b 3c16
+  0x00007f209d02e2e4: 488d 7f01 | 4889 3c16 | 0f84 f71f | 0000 488b | b424 a800 | 0000 8b56
+
+  0x00007f209d02e2fc: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e2fc: 0c48 bfe0 | 2ed1 3720 | 7f00 0048 | 8387 c801 | 0000 0148 | 8bf2 488b | 9424 b000 | 0000 0f1f
+  0x00007f209d02e31c: ;   {static_call}
+  0x00007f209d02e31c: 4400 00e8
+
+  0x00007f209d02e320: ; ImmutableOopMap {[168]=Oop [176]=Oop [184]=Oop }
+                      ;*invokestatic checkArgumentCount {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@17 (line 101)
+  0x00007f209d02e320: bcb4 ffff
+
+  0x00007f209d02e324: ;   {other}
+  0x00007f209d02e324: 0f1f 8400 | 1407 0001 | 488b b424 | a800 0000
+
+  0x00007f209d02e334: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e334: 488b fe48 | bbe0 2ed1 | 3720 7f00 | 0048 8383 | d801 0000
+
+  0x00007f209d02e348: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e348: 0148 bf60 | 34d1 3720 | 7f00 008b | 9ff4 0000 | 0083 c302 | 899f f400 | 0000 81e3 | feff 1f00
+  0x00007f209d02e368: 85db 0f84 | 5621 0000
+
+  0x00007f209d02e370: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e370: 8b7e 0c48 | bb60 34d1 | 3720 7f00 | 0048 c7c0 | 4001 0000 | 85ff 488b | d048 c7c0 | 5001 0000
+  0x00007f209d02e390: 480f 45c2 | 83ff 0148 | 8bd0 48c7 | c060 0100 | 0048 0f45 | c283 ff02 | 488b d048 | c7c0 7001
+  0x00007f209d02e3b0: 0000 480f | 45c2 83ff | 0348 8bd0 | 48c7 c080 | 0100 0048 | 0f45 c248 | 8b14 0349 | c7c2 0100
+  0x00007f209d02e3d0: 0000 4903 | d248 8914 | 0385 ff0f | 84f1 1500 | 0083 ff01 | 0f84 700f | 0000 83ff | 020f 84a7
+  0x00007f209d02e3f0: 0800 0083 | ff03 0f84 | 3406 0000 | 488b 9424 | b800 0000 | 8b7e 1848 | c1e7 0348 | 89bc 24c0
+  0x00007f209d02e410: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e410: 0000 0048 | bb60 34d1 | 3720 7f00 | 0048 8d9b | c003 0000 | 4885 d275 | 0ef6 4308 | 0175 4ff0
+  0x00007f209d02e430: 4883 4b08 | 01eb 478b | 4208 49ba | 0000 003b | 207f 0000 | 4903 c24c | 8bd0 4833 | 4308 48a9
+  0x00007f209d02e450: fcff ffff | 7428 a802 | 7524 48f7 | 4308 feff | ffff 7416 | 498b c248 | 3343 0848 | a9fc ffff
+  0x00007f209d02e470: ff74 0b48 | 834b 0802 | eb04 4889
+
+  0x00007f209d02e47c: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02e47c: 4308 48bb | 7815 3037 | 207f 0000 | 488d 9be0 | 0200 0048 | 85ff 750c | f603 0175 | 49f0 4883
+  0x00007f209d02e49c: 0b01 eb42 | 8b47 0849 | ba00 0000 | 3b20 7f00 | 0049 03c2 | 4c8b d048 | 3303 48a9 | fcff ffff
+  0x00007f209d02e4bc: 7424 a802 | 7520 48f7 | 03fe ffff | ff74 1449 | 8bc2 4833 | 0348 a9fc | ffff ff74 | 0948 830b
+  0x00007f209d02e4dc: 02eb 0348 | 8903 4885 | d275 0ef6 | 4310 0175 | 4ff0 4883 | 4b10 01eb | 478b 4208 | 49ba 0000
+  0x00007f209d02e4fc: 003b 207f | 0000 4903 | c24c 8bd0 | 4833 4310 | 48a9 fcff | ffff 7428 | a802 7524 | 48f7 4310
+  0x00007f209d02e51c: feff ffff | 7416 498b | c248 3343 | 1048 a9fc | ffff ff74 | 0b48 834b | 1002 eb04 | 4889 4310
+  0x00007f209d02e53c: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e53c: 48bb 6034 | d137 207f | 0000 4883 | 8388 0300
+
+  0x00007f209d02e54c: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02e54c: 0001 48bb | 7815 3037 | 207f 0000 | 8b83 f400 | 0000 83c0 | 0289 83f4 | 0000 0025 | feff 1f00
+  0x00007f209d02e56c: 85c0 0f84 | 731f 0000
+
+  0x00007f209d02e574: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02e574: 48bb 7815 | 3037 207f | 0000 488d | 9bb8 0100 | 0048 85ff | 750e f643 | 0801 754f | f048 834b
+  0x00007f209d02e594: 0801 eb47 | 8b47 0849 | ba00 0000 | 3b20 7f00 | 0049 03c2 | 4c8b d048 | 3343 0848 | a9fc ffff
+  0x00007f209d02e5b4: ff74 28a8 | 0275 2448 | f743 08fe | ffff ff74 | 1649 8bc2 | 4833 4308 | 48a9 fcff | ffff 740b
+  0x00007f209d02e5d4: 4883 4b08 | 02eb 0448
+
+  0x00007f209d02e5dc: ;   {oop(a 'java/lang/invoke/MethodType'{0x000000070d16cf38} = (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;)}
+  0x00007f209d02e5dc: 8943 0848 | b838 cf16 | 0d07 0000 | 0048 85c0 | 750c f643 | 1801 7506 | f048 834b
+
+  0x00007f209d02e5f8: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02e5f8: 1801 48bb | 7815 3037 | 207f 0000 | 4883 83a8 | 0100 0001
+
+  0x00007f209d02e60c: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02e60c: 48bb 482f | 2537 207f | 0000 8b8b | f400 0000 | 83c1 0289 | 8bf4 0000 | 0081 e1fe | ff1f 0085
+  0x00007f209d02e62c: c90f 84d5 | 1e00 0048 | 3b07 488b
+
+  0x00007f209d02e638: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02e638: df48 b948 | 2f25 3720 | 7f00 008b | 5b08 49ba | 0000 003b | 207f 0000 | 4903 da48 | 3b99 4801
+  0x00007f209d02e658: 0000 750d | 4883 8150 | 0100 0001 | e960 0000 | 0048 3b99 | 5801 0000 | 750d 4883 | 8160 0100
+  0x00007f209d02e678: 0001 e94a | 0000 0048 | 83b9 4801 | 0000 0075 | 1748 8999 | 4801 0000 | 48c7 8150 | 0100 0001
+  0x00007f209d02e698: 0000 00e9 | 2900 0000 | 4883 b958 | 0100 0000 | 7517 4889 | 9958 0100 | 0048 c781 | 6001 0000
+  0x00007f209d02e6b8: 0100 0000 | e908 0000 | 0048 8381 | 3801 0000 | 018b 5f10 | 48c1 e303
+
+  0x00007f209d02e6d0: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02e6d0: 483b d848 | b848 2f25 | 3720 7f00 | 0048 c7c1 | 8001 0000 | 7507 48c7 | c170 0100 | 004c 8b04
+  0x00007f209d02e6f0: 084d 8d40 | 014c 8904 | 080f 8580
+
+  0x00007f209d02e6fc: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02e6fc: 1700 0048 | bb78 1530 | 3720 7f00 | 0048 8d9b | f001 0000 | 8b47 0849 | ba00 0000 | 3b20 7f00
+  0x00007f209d02e71c: 0049 03c2 | 4c8b d048 | 3343 0848 | a9fc ffff | ff74 28a8 | 0275 2448 | f743 08fe | ffff ff74
+  0x00007f209d02e73c: 1649 8bc2 | 4833 4308 | 48a9 fcff | ffff 740b | 4883 4b08 | 02eb 0448
+
+  0x00007f209d02e754: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02e754: 8943 0848 | bb78 1530 | 3720 7f00 | 0048 8383 | e001 0000
+
+  0x00007f209d02e768: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02e768: 0148 bbe8 | 2a25 3720 | 7f00 008b | 83f4 0000 | 0083 c002 | 8983 f400 | 0000 25fe | ff1f 0085
+  0x00007f209d02e788: c00f 849f
+
+  0x00007f209d02e78c: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02e78c: 1d00 0048 | bbe8 2a25 | 3720 7f00 | 0048 8383 | 3801 0000
+
+  0x00007f209d02e7a0: ;   {metadata(method data for {method} {0x00007f203b096bb8} 'isCompileConstant' '(Ljava/lang/Object;)Z' in 'java/lang/invoke/MethodHandleImpl')}
+  0x00007f209d02e7a0: 0148 bb28 | 3225 3720 | 7f00 008b | 83f4 0000 | 0083 c002 | 8983 f400 | 0000 25fe | ff1f 0085
+  0x00007f209d02e7c0: c00f 8488
+
+  0x00007f209d02e7c4: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02e7c4: 1d00 0048 | bbe8 2a25 | 3720 7f00 | 00ff 8348 | 0100 008b | 5f14 48c1 | e303 8b5b | 1c48 c1e3
+  0x00007f209d02e7e4: 0348 85db
+
+  0x00007f209d02e7e8: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02e7e8: 48bb e82a | 2537 207f | 0000 48c7 | c068 0100 | 0075 0748 | c7c0 7801 | 0000 488b | 0c03 488d
+  0x00007f209d02e808: 4901 4889 | 0c03 0f85 | 2800 0000
+
+  0x00007f209d02e814: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02e814: 48bb e82a | 2537 207f | 0000 4883 | 8388 0100 | 0001 488b | f766 0f1f
+
+  0x00007f209d02e82c: ;   {static_call}
+  0x00007f209d02e82c: 4400 00e8
+
+  0x00007f209d02e830: ; ImmutableOopMap {[168]=Oop [176]=Oop [184]=Oop [192]=Oop }
+                      ;*invokestatic maybeCustomize {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers::checkCustomized@19 (line 627)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@14
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@104 (line 157)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d02e830: 8c8b c0ff
+
+  0x00007f209d02e834: ;   {other}
+  0x00007f209d02e834: 0f1f 8400 | 240c 0002 | 488b 8c24 | b000 0000 | 488b 9424 | b800 0000
+
+  0x00007f209d02e84c: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02e84c: 48be 7815 | 3037 207f | 0000 488d | b640 0200 | 0048 85d2 | 750e f646 | 0801 7553 | f048 834e
+  0x00007f209d02e86c: 0801 eb4b | 8b7a 0849 | ba00 0000 | 3b20 7f00 | 0049 03fa | 4c8b d748 | 337e 0848 | f7c7 fcff
+  0x00007f209d02e88c: ffff 742b | 40f6 c702 | 7525 48f7 | 4608 feff | ffff 7417 | 498b fa48 | 337e 0848 | f7c7 fcff
+  0x00007f209d02e8ac: ffff 740b | 4883 4e08 | 02eb 0448 | 897e 0848 | 85c9 750e | f646 1801 | 7553 f048 | 834e 1801
+  0x00007f209d02e8cc: eb4b 8b79 | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03fa 4c8b | d748 337e | 1848 f7c7 | fcff ffff
+  0x00007f209d02e8ec: 742b 40f6 | c702 7525 | 48f7 4618 | feff ffff | 7417 498b | fa48 337e | 1848 f7c7 | fcff ffff
+  0x00007f209d02e90c: 740b 4883 | 4e18 02eb | 0448 897e | 1848 8bbc | 24c0 0000
+
+  0x00007f209d02e920: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02e920: 0048 be78 | 1530 3720 | 7f00 0048 | 8386 0802 | 0000 0148 | 8bb4 24c0 | 0000 000f
+
+  0x00007f209d02e93c: ;   {optimized virtual_call}
+  0x00007f209d02e93c: 1f40 00e8
+
+  0x00007f209d02e940: ; ImmutableOopMap {[168]=Oop }
+                      ;*invokevirtual invokeBasic {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@20
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@104 (line 157)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d02e940: 3c14 4407
+
+  0x00007f209d02e944: ;   {other}
+  0x00007f209d02e944: 0f1f 8400 | 340d 0003
+
+  0x00007f209d02e94c: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02e94c: 48ba 7815 | 3037 207f | 0000 488d | 9260 0200 | 0048 85c0 | 750c f602 | 0175 4cf0 | 4883 0a01
+  0x00007f209d02e96c: eb45 8b48 | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03ca 4c8b | d148 330a | 48f7 c1fc | ffff ff74
+  0x00007f209d02e98c: 26f6 c102 | 7521 48f7 | 02fe ffff | ff74 1549 | 8bca 4833 | 0a48 f7c1 | fcff ffff | 7409 4883
+  0x00007f209d02e9ac: 0a02 eb03
+
+  0x00007f209d02e9b0: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02e9b0: 4889 0a48 | ba60 34d1 | 3720 7f00 | 0048 8d92 | e003 0000 | 4885 c075 | 0cf6 0201 | 754c f048
+  0x00007f209d02e9d0: 830a 01eb | 458b 4808 | 49ba 0000 | 003b 207f | 0000 4903 | ca4c 8bd1 | 4833 0a48 | f7c1 fcff
+  0x00007f209d02e9f0: ffff 7426 | f6c1 0275 | 2148 f702 | feff ffff | 7415 498b | ca48 330a | 48f7 c1fc | ffff ff74
+  0x00007f209d02ea10: 0948 830a | 02eb 0348 | 890a 4881 | c440 0100
+
+  0x00007f209d02ea20: ;   {poll_return}
+  0x00007f209d02ea20: 005d 493b | a748 0400 | 000f 8746 | 1b00 00c3 | 488b 8c24 | b000 0000 | 488b 9424 | b800 0000
+  0x00007f209d02ea40: 8b5e 1848 | c1e3 0383 | 790c 000f | 8644 1b00 | 0044 8b41 | 1049 c1e0 | 0383 790c | 010f 8644
+  0x00007f209d02ea60: 1b00 0044 | 8b49 1449 | c1e1 0383 | 790c 020f | 8644 1b00 | 008b 7918 | 48c1 e703 | 0f1f 4000
+  0x00007f209d02ea80: ;   {oop(a 'java/lang/invoke/MethodType'{0x000000070d013420} = (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;)}
+  0x00007f209d02ea80: 48b8 2034 | 010d 0700 | 0000 483b
+
+  0x00007f209d02ea8c: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02ea8c: 0348 b960 | 34d1 3720 | 7f00 0048 | 8d89 4003 | 0000 4885 | d275 0ef6 | 4108 0175 | 54f0 4883
+  0x00007f209d02eaac: 4908 01eb | 4c44 8b5a | 0849 ba00 | 0000 3b20 | 7f00 004d | 03da 4d8b | d34c 3359 | 0849 f7c3
+  0x00007f209d02eacc: fcff ffff | 742b 41f6 | c302 7525 | 48f7 4108 | feff ffff | 7417 4d8b | da4c 3359 | 0849 f7c3
+  0x00007f209d02eaec: fcff ffff | 740b 4883 | 4908 02eb | 044c 8959 | 084d 85c0 | 750e f641 | 1801 7554 | f048 8349
+  0x00007f209d02eb0c: 1801 eb4c | 458b 5808 | 49ba 0000 | 003b 207f | 0000 4d03 | da4d 8bd3 | 4c33 5918 | 49f7 c3fc
+  0x00007f209d02eb2c: ffff ff74 | 2b41 f6c3 | 0275 2548 | f741 18fe | ffff ff74 | 174d 8bda | 4c33 5918 | 49f7 c3fc
+  0x00007f209d02eb4c: ffff ff74 | 0b48 8349 | 1802 eb04 | 4c89 5918
+
+  0x00007f209d02eb5c: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02eb5c: 488b cb49 | bb60 34d1 | 3720 7f00 | 008b 4908 | 49ba 0000 | 003b 207f | 0000 4903 | ca49 3b8b
+  0x00007f209d02eb7c: 1803 0000 | 750d 4983 | 8320 0300 | 0001 e960 | 0000 0049 | 3b8b 2803 | 0000 750d | 4983 8330
+  0x00007f209d02eb9c: 0300 0001 | e94a 0000 | 0049 83bb | 1803 0000 | 0075 1749 | 898b 1803 | 0000 49c7 | 8320 0300
+  0x00007f209d02ebbc: 0001 0000 | 00e9 2900 | 0000 4983 | bb28 0300 | 0000 7517 | 4989 8b28 | 0300 0049 | c783 3003
+  0x00007f209d02ebdc: 0000 0100 | 0000 e908 | 0000 0049 | 8383 0803 | 0000 0149 | 8bc8 4d8b | c14c 8bcf | 488b f848
+  0x00007f209d02ebfc: ;   {optimized virtual_call}
+  0x00007f209d02ebfc: 8bf3 90e8
+
+  0x00007f209d02ec00: ; ImmutableOopMap {[168]=Oop }
+                      ;*invokevirtual invokeExact {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@92 (line 156)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d02ec00: 9cbf 4200
+
+  0x00007f209d02ec04: ;   {other}
+  0x00007f209d02ec04: 0f1f 8400 | f40f 0004
+
+  0x00007f209d02ec0c: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02ec0c: 48be 6034 | d137 207f | 0000 488d | b660 0300 | 0048 85c0 | 750c f606 | 0175 4df0 | 4883 0e01
+  0x00007f209d02ec2c: eb46 8b78 | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03fa 4c8b | d748 333e | 48f7 c7fc | ffff ff74
+  0x00007f209d02ec4c: 2740 f6c7 | 0275 2148 | f706 feff | ffff 7415 | 498b fa48 | 333e 48f7 | c7fc ffff | ff74 0948
+  0x00007f209d02ec6c: 830e 02eb | 0348 893e
+
+  0x00007f209d02ec74: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02ec74: 48be 6034 | d137 207f | 0000 ff86 | 7003 0000 | 4881 c440 | 0100 005d
+
+  0x00007f209d02ec8c: ;   {poll_return}
+  0x00007f209d02ec8c: 493b a748 | 0400 000f | 8750 1900 | 00c3 488b | 8c24 b000 | 0000 488b | 9424 b800 | 0000 8b7e
+  0x00007f209d02ecac: 1848 c1e7 | 0348 89bc | 24d0 0000 | 0083 790c | 000f 8646 | 1900 008b | 5910 48c1 | e303 4889
+  0x00007f209d02eccc: 9c24 c800 | 0000 8379 | 0c01 0f86 | 3f19 0000 | 8b41 1448 | c1e0 0348 | 8984 24d8
+
+  0x00007f209d02ece8: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02ece8: 0000 0048 | b960 34d1 | 3720 7f00 | 0048 8d89 | c002 0000 | 4885 d275 | 0ef6 4108 | 0175 54f0
+  0x00007f209d02ed08: 4883 4908 | 01eb 4c44 | 8b42 0849 | ba00 0000 | 3b20 7f00 | 004d 03c2 | 4d8b d04c | 3341 0849
+  0x00007f209d02ed28: f7c0 fcff | ffff 742b | 41f6 c002 | 7525 48f7 | 4108 feff | ffff 7417 | 4d8b c24c | 3341 0849
+  0x00007f209d02ed48: f7c0 fcff | ffff 740b | 4883 4908 | 02eb 044c
+
+  0x00007f209d02ed58: ;   {metadata(method data for {method} {0x00007f20374052b0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/LambdaForm$MH+0x00007f203c003000')}
+  0x00007f209d02ed58: 8941 0848 | b900 80c8 | 3720 7f00 | 0048 8d89 | e802 0000 | 4885 ff75 | 0cf6 0101 | 754e f048
+  0x00007f209d02ed78: 8309 01eb | 4744 8b47 | 0849 ba00 | 0000 3b20 | 7f00 004d | 03c2 4d8b | d04c 3301 | 49f7 c0fc
+  0x00007f209d02ed98: ffff ff74 | 2741 f6c0 | 0275 2148 | f701 feff | ffff 7415 | 4d8b c24c | 3301 49f7 | c0fc ffff
+  0x00007f209d02edb8: ff74 0948 | 8309 02eb | 034c 8901 | 4885 d275 | 0ef6 4110 | 0175 54f0 | 4883 4910 | 01eb 4c44
+  0x00007f209d02edd8: 8b42 0849 | ba00 0000 | 3b20 7f00 | 004d 03c2 | 4d8b d04c | 3341 1049 | f7c0 fcff | ffff 742b
+  0x00007f209d02edf8: 41f6 c002 | 7525 48f7 | 4110 feff | ffff 7417 | 4d8b c24c | 3341 1049 | f7c0 fcff | ffff 740b
+  0x00007f209d02ee18: 4883 4910 | 02eb 044c
+
+  0x00007f209d02ee20: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02ee20: 8941 1048 | b960 34d1 | 3720 7f00 | 0048 8381 | 8802 0000
+
+  0x00007f209d02ee34: ;   {metadata(method data for {method} {0x00007f20374052b0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/LambdaForm$MH+0x00007f203c003000')}
+  0x00007f209d02ee34: 0148 b900 | 80c8 3720 | 7f00 0044 | 8b81 f400 | 0000 4183 | c002 4489 | 81f4 0000 | 0041 81e0
+  0x00007f209d02ee54: feff 1f00 | 4585 c00f | 84cc 1700
+
+  0x00007f209d02ee60: ;   {metadata(method data for {method} {0x00007f20374052b0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/LambdaForm$MH+0x00007f203c003000')}
+  0x00007f209d02ee60: 0048 b900 | 80c8 3720 | 7f00 0048 | 8d89 b801 | 0000 4885 | ff75 0ef6 | 4108 0175 | 54f0 4883
+  0x00007f209d02ee80: 4908 01eb | 4c44 8b47 | 0849 ba00 | 0000 3b20 | 7f00 004d | 03c2 4d8b | d04c 3341 | 0849 f7c0
+  0x00007f209d02eea0: fcff ffff | 742b 41f6 | c002 7525 | 48f7 4108 | feff ffff | 7417 4d8b | c24c 3341 | 0849 f7c0
+  0x00007f209d02eec0: fcff ffff | 740b 4883 | 4908 02eb | 044c 8941
+
+  0x00007f209d02eed0: ;   {oop(a 'java/lang/invoke/MethodType'{0x000000070d013218} = (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;)}
+  0x00007f209d02eed0: 0849 b818 | 3201 0d07 | 0000 004d | 85c0 750c | f641 1801 | 7506 f048 | 8349 1801
+
+  0x00007f209d02eeec: ;   {metadata(method data for {method} {0x00007f20374052b0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/LambdaForm$MH+0x00007f203c003000')}
+  0x00007f209d02eeec: 48b9 0080 | c837 207f | 0000 4883 | 81a8 0100
+
+  0x00007f209d02eefc: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02eefc: 0001 48b9 | 482f 2537 | 207f 0000 | 448b 89f4 | 0000 0041 | 83c1 0244 | 8989 f400 | 0000 4181
+  0x00007f209d02ef1c: e1fe ff1f | 0045 85c9 | 0f84 2417 | 0000 483b | 0748 8bcf
+
+  0x00007f209d02ef30: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02ef30: 49b9 482f | 2537 207f | 0000 8b49 | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03ca 493b | 8948 0100
+  0x00007f209d02ef50: 0075 0d49 | 8381 5001 | 0000 01e9 | 6000 0000 | 493b 8958 | 0100 0075 | 0d49 8381 | 6001 0000
+  0x00007f209d02ef70: 01e9 4a00 | 0000 4983 | b948 0100 | 0000 7517 | 4989 8948 | 0100 0049 | c781 5001 | 0000 0100
+  0x00007f209d02ef90: 0000 e929 | 0000 0049 | 83b9 5801 | 0000 0075 | 1749 8989 | 5801 0000 | 49c7 8160 | 0100 0001
+  0x00007f209d02efb0: 0000 00e9 | 0800 0000 | 4983 8138 | 0100 0001 | 8b4f 1048 | c1e1 0349
+
+  0x00007f209d02efc8: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02efc8: 3bc8 49b8 | 482f 2537 | 207f 0000 | 49c7 c180 | 0100 0075 | 0749 c7c1 | 7001 0000 | 4f8b 1c08
+  0x00007f209d02efe8: 4d8d 5b01 | 4f89 1c08 | 0f85 490e
+
+  0x00007f209d02eff4: ;   {metadata(method data for {method} {0x00007f20374052b0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/LambdaForm$MH+0x00007f203c003000')}
+  0x00007f209d02eff4: 0000 48b9 | 0080 c837 | 207f 0000 | 488d 89f0 | 0100 0044 | 8b47 0849 | ba00 0000 | 3b20 7f00
+  0x00007f209d02f014: 004d 03c2 | 4d8b d04c | 3341 0849 | f7c0 fcff | ffff 742b | 41f6 c002 | 7525 48f7 | 4108 feff
+  0x00007f209d02f034: ffff 7417 | 4d8b c24c | 3341 0849 | f7c0 fcff | ffff 740b | 4883 4908 | 02eb 044c
+
+  0x00007f209d02f050: ;   {metadata(method data for {method} {0x00007f20374052b0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/LambdaForm$MH+0x00007f203c003000')}
+  0x00007f209d02f050: 8941 0848 | b900 80c8 | 3720 7f00 | 0048 8381 | e001 0000
+
+  0x00007f209d02f064: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02f064: 0148 b9e8 | 2a25 3720 | 7f00 0044 | 8b81 f400 | 0000 4183 | c002 4489 | 81f4 0000 | 0041 81e0
+  0x00007f209d02f084: feff 1f00 | 4585 c00f | 84e3 1500
+
+  0x00007f209d02f090: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02f090: 0048 b9e8 | 2a25 3720 | 7f00 0048 | 8381 3801
+
+  0x00007f209d02f0a0: ;   {metadata(method data for {method} {0x00007f203b096bb8} 'isCompileConstant' '(Ljava/lang/Object;)Z' in 'java/lang/invoke/MethodHandleImpl')}
+  0x00007f209d02f0a0: 0000 0148 | b928 3225 | 3720 7f00 | 0044 8b81 | f400 0000 | 4183 c002 | 4489 81f4 | 0000 0041
+  0x00007f209d02f0c0: 81e0 feff | 1f00 4585 | c00f 84c6
+
+  0x00007f209d02f0cc: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02f0cc: 1500 0048 | b9e8 2a25 | 3720 7f00 | 00ff 8148 | 0100 008b | 4f14 48c1 | e103 8b49 | 1c48 c1e1
+  0x00007f209d02f0ec: 0348 85c9
+
+  0x00007f209d02f0f0: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02f0f0: 48b9 e82a | 2537 207f | 0000 49c7 | c068 0100 | 0075 0749 | c7c0 7801 | 0000 4e8b | 0c01 4d8d
+  0x00007f209d02f110: 4901 4e89 | 0c01 0f85 | 2800 0000
+
+  0x00007f209d02f11c: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02f11c: 48b9 e82a | 2537 207f | 0000 4883 | 8188 0100 | 0001 488b | f766 0f1f
+
+  0x00007f209d02f134: ;   {static_call}
+  0x00007f209d02f134: 4400 00e8
+
+  0x00007f209d02f138: ; ImmutableOopMap {[168]=Oop [184]=Oop [200]=Oop [208]=Oop [216]=Oop }
+                      ;*invokestatic maybeCustomize {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers::checkCustomized@19 (line 627)
+                      ; - java.lang.invoke.LambdaForm$MH/0x00007f203c003000::invokeExact_MT@15
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@72 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d02f138: 8482 c0ff
+
+  0x00007f209d02f13c: ;   {other}
+  0x00007f209d02f13c: 0f1f 8400 | 2c15 0005 | 488b 9c24 | c800 0000 | 488b 9424 | b800 0000
+
+  0x00007f209d02f154: ;   {metadata(method data for {method} {0x00007f20374052b0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/LambdaForm$MH+0x00007f203c003000')}
+  0x00007f209d02f154: 48b9 0080 | c837 207f | 0000 488d | 8940 0200 | 0048 85d2 | 750e f641 | 0801 7554 | f048 8349
+  0x00007f209d02f174: 0801 eb4c | 448b 4208 | 49ba 0000 | 003b 207f | 0000 4d03 | c24d 8bd0 | 4c33 4108 | 49f7 c0fc
+  0x00007f209d02f194: ffff ff74 | 2b41 f6c0 | 0275 2548 | f741 08fe | ffff ff74 | 174d 8bc2 | 4c33 4108 | 49f7 c0fc
+  0x00007f209d02f1b4: ffff ff74 | 0b48 8349 | 0802 eb04 | 4c89 4108 | 4885 db75 | 0ef6 4118 | 0175 54f0 | 4883 4918
+  0x00007f209d02f1d4: 01eb 4c44 | 8b43 0849 | ba00 0000 | 3b20 7f00 | 004d 03c2 | 4d8b d04c | 3341 1849 | f7c0 fcff
+  0x00007f209d02f1f4: ffff 742b | 41f6 c002 | 7525 48f7 | 4118 feff | ffff 7417 | 4d8b c24c | 3341 1849 | f7c0 fcff
+  0x00007f209d02f214: ffff 740b | 4883 4918 | 02eb 044c | 8941 1848 | 8bbc 24d0
+
+  0x00007f209d02f228: ;   {metadata(method data for {method} {0x00007f20374052b0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/LambdaForm$MH+0x00007f203c003000')}
+  0x00007f209d02f228: 0000 0048 | b900 80c8 | 3720 7f00 | 0048 8381 | 0802 0000 | 0148 8bcb | 4c8b 8424 | d800 0000
+  0x00007f209d02f248: 488b b424 | d000 0000 | 0f1f 8000
+
+  0x00007f209d02f254: ;   {optimized virtual_call}
+  0x00007f209d02f254: 0000 00e8
+
+  0x00007f209d02f258: ; ImmutableOopMap {[168]=Oop }
+                      ;*invokevirtual invokeBasic {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.LambdaForm$MH/0x00007f203c003000::invokeExact_MT@22
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@72 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d02f258: 2436 4407
+
+  0x00007f209d02f25c: ;   {other}
+  0x00007f209d02f25c: 0f1f 8400 | 4c16 0006
+
+  0x00007f209d02f264: ;   {metadata(method data for {method} {0x00007f20374052b0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/LambdaForm$MH+0x00007f203c003000')}
+  0x00007f209d02f264: 48be 0080 | c837 207f | 0000 488d | b660 0200 | 0048 85c0 | 750c f606 | 0175 4df0 | 4883 0e01
+  0x00007f209d02f284: eb46 8b78 | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03fa 4c8b | d748 333e | 48f7 c7fc | ffff ff74
+  0x00007f209d02f2a4: 2740 f6c7 | 0275 2148 | f706 feff | ffff 7415 | 498b fa48 | 333e 48f7 | c7fc ffff | ff74 0948
+  0x00007f209d02f2c4: 830e 02eb | 0348 893e
+
+  0x00007f209d02f2cc: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02f2cc: 48be 6034 | d137 207f | 0000 488d | b6e0 0200 | 0048 85c0 | 750c f606 | 0175 4df0 | 4883 0e01
+  0x00007f209d02f2ec: eb46 8b78 | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03fa 4c8b | d748 333e | 48f7 c7fc | ffff ff74
+  0x00007f209d02f30c: 2740 f6c7 | 0275 2148 | f706 feff | ffff 7415 | 498b fa48 | 333e 48f7 | c7fc ffff | ff74 0948
+  0x00007f209d02f32c: 830e 02eb | 0348 893e
+
+  0x00007f209d02f334: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02f334: 48be 6034 | d137 207f | 0000 ff86 | f002 0000 | 4881 c440 | 0100 005d
+
+  0x00007f209d02f34c: ;   {poll_return}
+  0x00007f209d02f34c: 493b a748 | 0400 000f | 8762 1300 | 00c3 488b | 8c24 b000 | 0000 488b | 9424 b800 | 0000 8b7e
+  0x00007f209d02f36c: 1848 c1e7 | 0348 89bc | 24e8 0000 | 0083 790c | 000f 8658 | 1300 008b | 5910 48c1 | e303 4889
+  0x00007f209d02f38c: 9c24 e000
+
+  0x00007f209d02f390: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02f390: 0000 48b8 | 6034 d137 | 207f 0000 | 488d 8040 | 0200 0048 | 85d2 750e | f640 0801 | 7552 f048
+  0x00007f209d02f3b0: 8348 0801 | eb4a 8b4a | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03ca 4c8b | d148 3348 | 0848 f7c1
+  0x00007f209d02f3d0: fcff ffff | 742a f6c1 | 0275 2548 | f740 08fe | ffff ff74 | 1749 8bca | 4833 4808 | 48f7 c1fc
+  0x00007f209d02f3f0: ffff ff74 | 0b48 8348 | 0802 eb04 | 4889 4808
+
+  0x00007f209d02f400: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02f400: 48b8 7815 | 3037 207f | 0000 488d | 80e0 0200 | 0048 85ff | 750c f600 | 0175 4cf0 | 4883 0801
+  0x00007f209d02f420: eb45 8b4f | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03ca 4c8b | d148 3308 | 48f7 c1fc | ffff ff74
+  0x00007f209d02f440: 26f6 c102 | 7521 48f7 | 00fe ffff | ff74 1549 | 8bca 4833 | 0848 f7c1 | fcff ffff | 7409 4883
+  0x00007f209d02f460: 0802 eb03 | 4889 0848 | 85d2 750e | f640 1001 | 7552 f048 | 8348 1001 | eb4a 8b4a | 0849 ba00
+  0x00007f209d02f480: 0000 3b20 | 7f00 0049 | 03ca 4c8b | d148 3348 | 1048 f7c1 | fcff ffff | 742a f6c1 | 0275 2548
+  0x00007f209d02f4a0: f740 10fe | ffff ff74 | 1749 8bca | 4833 4810 | 48f7 c1fc | ffff ff74 | 0b48 8348 | 1002 eb04
+  0x00007f209d02f4c0: 4889 4810
+
+  0x00007f209d02f4c4: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02f4c4: 48b8 6034 | d137 207f | 0000 4883 | 8008 0200
+
+  0x00007f209d02f4d4: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02f4d4: 0001 48b8 | 7815 3037 | 207f 0000 | 8b88 f400 | 0000 83c1 | 0289 88f4 | 0000 0081 | e1fe ff1f
+  0x00007f209d02f4f4: 0085 c90f | 84f0 1100
+
+  0x00007f209d02f4fc: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02f4fc: 0048 b878 | 1530 3720 | 7f00 0048 | 8d80 b801 | 0000 4885 | ff75 0ef6 | 4008 0175 | 52f0 4883
+  0x00007f209d02f51c: 4808 01eb | 4a8b 4f08 | 49ba 0000 | 003b 207f | 0000 4903 | ca4c 8bd1 | 4833 4808 | 48f7 c1fc
+  0x00007f209d02f53c: ffff ff74 | 2af6 c102 | 7525 48f7 | 4008 feff | ffff 7417 | 498b ca48 | 3348 0848 | f7c1 fcff
+  0x00007f209d02f55c: ffff 740b | 4883 4808 | 02eb 0448
+
+  0x00007f209d02f568: ;   {oop(a 'java/lang/invoke/MethodType'{0x000000070d013000} = (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;)}
+  0x00007f209d02f568: 8948 0848 | b900 3001 | 0d07 0000 | 0048 85c9 | 750c f640 | 1801 7506 | f048 8348
+
+  0x00007f209d02f584: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02f584: 1801 48b8 | 7815 3037 | 207f 0000 | 4883 80a8 | 0100 0001
+
+  0x00007f209d02f598: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02f598: 48b8 482f | 2537 207f | 0000 448b | 80f4 0000 | 0041 83c0 | 0244 8980 | f400 0000 | 4181 e0fe
+  0x00007f209d02f5b8: ff1f 0045 | 85c0 0f84 | 4a11 0000
+
+  0x00007f209d02f5c4: ; implicit exception: dispatches to 0x00007f209d03072f
+  0x00007f209d02f5c4: 483b 0748
+
+  0x00007f209d02f5c8: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02f5c8: 8bc7 49b8 | 482f 2537 | 207f 0000 | 8b40 0849 | ba00 0000 | 3b20 7f00 | 0049 03c2 | 493b 8048
+  0x00007f209d02f5e8: 0100 0075 | 0d49 8380 | 5001 0000 | 01e9 6000 | 0000 493b | 8058 0100 | 0075 0d49 | 8380 6001
+  0x00007f209d02f608: 0000 01e9 | 4a00 0000 | 4983 b848 | 0100 0000 | 7517 4989 | 8048 0100 | 0049 c780 | 5001 0000
+  0x00007f209d02f628: 0100 0000 | e929 0000 | 0049 83b8 | 5801 0000 | 0075 1749 | 8980 5801 | 0000 49c7 | 8060 0100
+  0x00007f209d02f648: 0001 0000 | 00e9 0800 | 0000 4983 | 8038 0100 | 0001 8b47 | 1048 c1e0 | 0348 3bc1
+
+  0x00007f209d02f664: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02f664: 48b9 482f | 2537 207f | 0000 49c7 | c080 0100 | 0075 0749 | c7c0 7001 | 0000 4e8b | 0c01 4d8d
+  0x00007f209d02f684: 4901 4e89 | 0c01 0f85 | 6f07 0000
+
+  0x00007f209d02f690: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02f690: 48b8 7815 | 3037 207f | 0000 488d | 80f0 0100 | 008b 4f08 | 49ba 0000 | 003b 207f | 0000 4903
+  0x00007f209d02f6b0: ca4c 8bd1 | 4833 4808 | 48f7 c1fc | ffff ff74 | 2af6 c102 | 7525 48f7 | 4008 feff | ffff 7417
+  0x00007f209d02f6d0: 498b ca48 | 3348 0848 | f7c1 fcff | ffff 740b | 4883 4808 | 02eb 0448
+
+  0x00007f209d02f6e8: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02f6e8: 8948 0848 | b878 1530 | 3720 7f00 | 0048 8380 | e001 0000
+
+  0x00007f209d02f6fc: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02f6fc: 0148 b8e8 | 2a25 3720 | 7f00 008b | 88f4 0000 | 0083 c102 | 8988 f400 | 0000 81e1 | feff 1f00
+  0x00007f209d02f71c: 85c9 0f84 | 1010 0000
+
+  0x00007f209d02f724: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02f724: 48b8 e82a | 2537 207f | 0000 4883 | 8038 0100
+
+  0x00007f209d02f734: ;   {metadata(method data for {method} {0x00007f203b096bb8} 'isCompileConstant' '(Ljava/lang/Object;)Z' in 'java/lang/invoke/MethodHandleImpl')}
+  0x00007f209d02f734: 0001 48b8 | 2832 2537 | 207f 0000 | 8b88 f400 | 0000 83c1 | 0289 88f4 | 0000 0081 | e1fe ff1f
+  0x00007f209d02f754: 0085 c90f | 84f8 0f00
+
+  0x00007f209d02f75c: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02f75c: 0048 b8e8 | 2a25 3720 | 7f00 00ff | 8048 0100 | 008b 4714 | 48c1 e003
+
+  0x00007f209d02f774: ; implicit exception: dispatches to 0x00007f209d030776
+  0x00007f209d02f774: 8b40 1c48 | c1e0 0348
+
+  0x00007f209d02f77c: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02f77c: 85c0 48b8 | e82a 2537 | 207f 0000 | 48c7 c168 | 0100 0075 | 0748 c7c1 | 7801 0000 | 4c8b 0408
+  0x00007f209d02f79c: 4d8d 4001 | 4c89 0408 | 0f85 2200
+
+  0x00007f209d02f7a8: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02f7a8: 0000 48b8 | e82a 2537 | 207f 0000 | 4883 8088 | 0100 0001
+
+  0x00007f209d02f7bc: ;   {static_call}
+  0x00007f209d02f7bc: 488b f7e8
+
+  0x00007f209d02f7c0: ; ImmutableOopMap {[168]=Oop [184]=Oop [224]=Oop [232]=Oop }
+                      ;*invokestatic maybeCustomize {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers::checkCustomized@19 (line 627)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@14
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@55 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d02f7c0: bc09 d306
+
+  0x00007f209d02f7c4: ;   {other}
+  0x00007f209d02f7c4: 0f1f 8400 | b41b 0007 | 488b 9c24 | e000 0000 | 488b 9424 | b800 0000
+
+  0x00007f209d02f7dc: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02f7dc: 48b9 7815 | 3037 207f | 0000 488d | 8940 0200 | 0048 85d2 | 750e f641 | 0801 7553 | f048 8349
+  0x00007f209d02f7fc: 0801 eb4b | 8b72 0849 | ba00 0000 | 3b20 7f00 | 0049 03f2 | 4c8b d648 | 3371 0848 | f7c6 fcff
+  0x00007f209d02f81c: ffff 742b | 40f6 c602 | 7525 48f7 | 4108 feff | ffff 7417 | 498b f248 | 3371 0848 | f7c6 fcff
+  0x00007f209d02f83c: ffff 740b | 4883 4908 | 02eb 0448 | 8971 0848 | 85db 750e | f641 1801 | 7553 f048 | 8349 1801
+  0x00007f209d02f85c: eb4b 8b73 | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03f2 4c8b | d648 3371 | 1848 f7c6 | fcff ffff
+  0x00007f209d02f87c: 742b 40f6 | c602 7525 | 48f7 4118 | feff ffff | 7417 498b | f248 3371 | 1848 f7c6 | fcff ffff
+  0x00007f209d02f89c: 740b 4883 | 4918 02eb | 0448 8971 | 1848 8bbc | 24e8 0000
+
+  0x00007f209d02f8b0: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02f8b0: 0048 b978 | 1530 3720 | 7f00 0048 | 8381 0802 | 0000 0148 | 8bcb 488b | b424 e800
+
+  0x00007f209d02f8cc: ;   {optimized virtual_call}
+  0x00007f209d02f8cc: 0000 90e8
+
+  0x00007f209d02f8d0: ; ImmutableOopMap {[168]=Oop }
+                      ;*invokevirtual invokeBasic {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@20
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@55 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d02f8d0: acfe d206
+
+  0x00007f209d02f8d4: ;   {other}
+  0x00007f209d02f8d4: 0f1f 8400 | c41c 0008
+
+  0x00007f209d02f8dc: ;   {metadata(method data for {method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02f8dc: 48be 7815 | 3037 207f | 0000 488d | b660 0200 | 0048 85c0 | 750c f606 | 0175 4df0 | 4883 0e01
+  0x00007f209d02f8fc: eb46 8b78 | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03fa 4c8b | d748 333e | 48f7 c7fc | ffff ff74
+  0x00007f209d02f91c: 2740 f6c7 | 0275 2148 | f706 feff | ffff 7415 | 498b fa48 | 333e 48f7 | c7fc ffff | ff74 0948
+  0x00007f209d02f93c: 830e 02eb | 0348 893e
+
+  0x00007f209d02f944: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02f944: 48be 6034 | d137 207f | 0000 488d | b660 0200 | 0048 85c0 | 750c f606 | 0175 4df0 | 4883 0e01
+  0x00007f209d02f964: eb46 8b78 | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03fa 4c8b | d748 333e | 48f7 c7fc | ffff ff74
+  0x00007f209d02f984: 2740 f6c7 | 0275 2148 | f706 feff | ffff 7415 | 498b fa48 | 333e 48f7 | c7fc ffff | ff74 0948
+  0x00007f209d02f9a4: 830e 02eb | 0348 893e
+
+  0x00007f209d02f9ac: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02f9ac: 48be 6034 | d137 207f | 0000 ff86 | 7002 0000 | 4881 c440 | 0100 005d
+
+  0x00007f209d02f9c4: ;   {poll_return}
+  0x00007f209d02f9c4: 493b a748 | 0400 000f | 87aa 0d00 | 00c3 488b | 9424 b800 | 0000 8b7e | 1848 c1e7 | 0348 89bc
+  0x00007f209d02f9e4: 24f0 0000
+
+  0x00007f209d02f9e8: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02f9e8: 0048 bb60 | 34d1 3720 | 7f00 0048 | 8d9b d001 | 0000 4885 | d275 0ef6 | 4308 0175 | 4ff0 4883
+  0x00007f209d02fa08: 4b08 01eb | 478b 4208 | 49ba 0000 | 003b 207f | 0000 4903 | c24c 8bd0 | 4833 4308 | 48a9 fcff
+  0x00007f209d02fa28: ffff 7428 | a802 7524 | 48f7 4308 | feff ffff | 7416 498b | c248 3343 | 0848 a9fc | ffff ff74
+  0x00007f209d02fa48: 0b48 834b | 0802 eb04 | 4889 4308
+
+  0x00007f209d02fa54: ;   {metadata(method data for {method} {0x00007f203b0b0bb0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02fa54: 48bb 98f8 | 2f37 207f | 0000 488d | 9bc8 0200 | 0048 85ff | 750a f603 | 0175 05f0 | 4883 0b01
+  0x00007f209d02fa74: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02fa74: 48bb 6034 | d137 207f | 0000 4883 | 8398 0100
+
+  0x00007f209d02fa84: ;   {metadata(method data for {method} {0x00007f203b0b0bb0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02fa84: 0001 48bb | 98f8 2f37 | 207f 0000 | 8b83 f400 | 0000 83c0 | 0289 83f4 | 0000 0025 | feff 1f00
+  0x00007f209d02faa4: 85c0 0f84 | e50c 0000
+
+  0x00007f209d02faac: ;   {metadata(method data for {method} {0x00007f203b0b0bb0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02faac: 48bb 98f8 | 2f37 207f | 0000 488d | 9bb8 0100 | 0048 85ff | 750c f643 | 0801 7506 | f048 834b
+  0x00007f209d02facc: ;   {oop(a 'java/lang/invoke/MethodType'{0x000000070d012ed0} = (Ljava/lang/Object;)Ljava/lang/Object;)}
+  0x00007f209d02facc: 0801 48b8 | d02e 010d | 0700 0000 | 4885 c075 | 0cf6 4318 | 0175 06f0 | 4883 4b18
+
+  0x00007f209d02fae8: ;   {metadata(method data for {method} {0x00007f203b0b0bb0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02fae8: 0148 bb98 | f82f 3720 | 7f00 0048 | 8383 a801
+
+  0x00007f209d02faf8: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02faf8: 0000 0148 | bb48 2f25 | 3720 7f00 | 008b 8bf4 | 0000 0083 | c102 898b | f400 0000 | 81e1 feff
+  0x00007f209d02fb18: 1f00 85c9 | 0f84 900c | 0000 483b | 0748 8bdf
+
+  0x00007f209d02fb28: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02fb28: 48b9 482f | 2537 207f | 0000 8b5b | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03da 483b | 9948 0100
+  0x00007f209d02fb48: 0075 0d48 | 8381 5001 | 0000 01e9 | 6000 0000 | 483b 9958 | 0100 0075 | 0d48 8381 | 6001 0000
+  0x00007f209d02fb68: 01e9 4a00 | 0000 4883 | b948 0100 | 0000 7517 | 4889 9948 | 0100 0048 | c781 5001 | 0000 0100
+  0x00007f209d02fb88: 0000 e929 | 0000 0048 | 83b9 5801 | 0000 0075 | 1748 8999 | 5801 0000 | 48c7 8160 | 0100 0001
+  0x00007f209d02fba8: 0000 00e9 | 0800 0000 | 4883 8138 | 0100 0001 | 8b5f 1048 | c1e3 0348
+
+  0x00007f209d02fbc0: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02fbc0: 3bd8 48b8 | 482f 2537 | 207f 0000 | 48c7 c180 | 0100 0075 | 0748 c7c1 | 7001 0000 | 4c8b 0408
+  0x00007f209d02fbe0: 4d8d 4001 | 4c89 0408 | 0f85 cb01
+
+  0x00007f209d02fbec: ;   {metadata(method data for {method} {0x00007f203b0b0bb0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02fbec: 0000 48bb | 98f8 2f37 | 207f 0000 | 4883 83e0 | 0100 0001
+
+  0x00007f209d02fc00: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02fc00: 48bb e82a | 2537 207f | 0000 8b83 | f400 0000 | 83c0 0289 | 83f4 0000 | 0025 feff | 1f00 85c0
+  0x00007f209d02fc20: 0f84 b20b
+
+  0x00007f209d02fc24: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02fc24: 0000 48bb | e82a 2537 | 207f 0000 | 4883 8338 | 0100 0001
+
+  0x00007f209d02fc38: ;   {metadata(method data for {method} {0x00007f203b096bb8} 'isCompileConstant' '(Ljava/lang/Object;)Z' in 'java/lang/invoke/MethodHandleImpl')}
+  0x00007f209d02fc38: 48bb 2832 | 2537 207f | 0000 8b83 | f400 0000 | 83c0 0289 | 83f4 0000 | 0025 feff | 1f00 85c0
+  0x00007f209d02fc58: 0f84 9b0b
+
+  0x00007f209d02fc5c: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02fc5c: 0000 48bb | e82a 2537 | 207f 0000 | ff83 4801 | 0000 8b5f | 1448 c1e3 | 038b 5b1c | 48c1 e303
+  0x00007f209d02fc7c: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02fc7c: 4885 db48 | bbe8 2a25 | 3720 7f00 | 0048 c7c0 | 6801 0000 | 7507 48c7 | c078 0100 | 0048 8b0c
+  0x00007f209d02fc9c: 0348 8d49 | 0148 890c | 030f 8529
+
+  0x00007f209d02fca8: ;   {metadata(method data for {method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02fca8: 0000 0048 | bbe8 2a25 | 3720 7f00 | 0048 8383 | 8801 0000 | 0148 8bf7 | 0f1f 8000
+
+  0x00007f209d02fcc4: ;   {static_call}
+  0x00007f209d02fcc4: 0000 00e8
+
+  0x00007f209d02fcc8: ; ImmutableOopMap {[168]=Oop [184]=Oop [240]=Oop }
+                      ;*invokestatic maybeCustomize {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers::checkCustomized@19 (line 627)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@14
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@41 (line 153)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d02fcc8: f476 c0ff
+
+  0x00007f209d02fccc: ;   {other}
+  0x00007f209d02fccc: 0f1f 8400 | bc20 0009 | 488b bc24 | f000 0000
+
+  0x00007f209d02fcdc: ;   {metadata(method data for {method} {0x00007f203b0b0bb0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02fcdc: 48ba 98f8 | 2f37 207f | 0000 4883 | 8208 0200 | 0001 488b | 9424 b800 | 0000 488b | b424 f000
+  0x00007f209d02fcfc: ;   {optimized virtual_call}
+  0x00007f209d02fcfc: 0000 90e8
+
+  0x00007f209d02fd00: ; ImmutableOopMap {[168]=Oop }
+                      ;*invokevirtual invokeBasic {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@19
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@41 (line 153)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d02fd00: 7c59 4207
+
+  0x00007f209d02fd04: ;   {other}
+  0x00007f209d02fd04: 0f1f 8400 | f420 000a
+
+  0x00007f209d02fd0c: ;   {metadata(method data for {method} {0x00007f203b0b0bb0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d02fd0c: 48be 98f8 | 2f37 207f | 0000 488d | b650 0200 | 0048 85c0 | 750a f606 | 0175 05f0 | 4883 0e01
+  0x00007f209d02fd2c: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02fd2c: 48be 6034 | d137 207f | 0000 488d | b6e0 0100 | 0048 85c0 | 750c f606 | 0175 4cf0 | 4883 0e01
+  0x00007f209d02fd4c: eb45 8b50 | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03d2 4c8b | d248 3316 | 48f7 c2fc | ffff ff74
+  0x00007f209d02fd6c: 26f6 c202 | 7521 48f7 | 06fe ffff | ff74 1549 | 8bd2 4833 | 1648 f7c2 | fcff ffff | 7409 4883
+  0x00007f209d02fd8c: 0e02 eb03
+
+  0x00007f209d02fd90: ;   {metadata(method data for {method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02fd90: 4889 1648 | be60 34d1 | 3720 7f00 | 00ff 86f0 | 0100 0048 | 81c4 4001
+
+  0x00007f209d02fda8: ;   {poll_return}
+  0x00007f209d02fda8: 0000 5d49 | 3ba7 4804 | 0000 0f87 | 670a 0000
+
+  0x00007f209d02fdb8: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02fdb8: c348 be48 | 2f25 3720 | 7f00 0048 | 8386 9001
+
+  0x00007f209d02fdc8: ;   {oop(a 'java/lang/invoke/MethodType'{0x000000070d012ed0} = (Ljava/lang/Object;)Ljava/lang/Object;)}
+  0x00007f209d02fdc8: 0000 0148 | bad0 2e01 | 0d07 0000 | 0048 8bf3 | 0f1f 8000
+
+  0x00007f209d02fddc: ;   {static_call}
+  0x00007f209d02fddc: 0000 00e8
+
+  0x00007f209d02fde0: ; ImmutableOopMap {[168]=Oop [184]=Oop [240]=Oop }
+                      ;*invokestatic newWrongMethodTypeException {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers::checkExactType@12 (line 531)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@41 (line 153)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d02fde0: 9c03 d306
+
+  0x00007f209d02fde4: ;   {other}
+  0x00007f209d02fde4: 0f1f 8400 | d421 000b
+
+  0x00007f209d02fdec: ; implicit exception: dispatches to 0x00007f209d030835
+                      ; ImmutableOopMap {rax=Oop [168]=Oop [184]=Oop [240]=Oop }
+                      ;*athrow {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) java.lang.invoke.Invokers::checkExactType@15 (line 531)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@41 (line 153)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {section_word}
+  0x00007f209d02fdec: 483b 0048 | baef fd02 | 9d20 7f00
+
+  0x00007f209d02fdf8: ;   {runtime_call handle_exception_nofpu Runtime1 stub}
+  0x00007f209d02fdf8: 00e8 82e6
+
+  0x00007f209d02fdfc: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02fdfc: df06 9048 | be48 2f25 | 3720 7f00 | 0048 8386 | 9001 0000
+
+  0x00007f209d02fe10: ;   {oop(a 'java/lang/invoke/MethodType'{0x000000070d013000} = (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;)}
+  0x00007f209d02fe10: 0148 ba00 | 3001 0d07 | 0000 0048
+
+  0x00007f209d02fe1c: ;   {static_call}
+  0x00007f209d02fe1c: 8bf0 90e8
+
+  0x00007f209d02fe20: ; ImmutableOopMap {[168]=Oop [184]=Oop [224]=Oop [232]=Oop }
+                      ;*invokestatic newWrongMethodTypeException {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers::checkExactType@12 (line 531)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@55 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d02fe20: 5c03 d306
+
+  0x00007f209d02fe24: ;   {other}
+  0x00007f209d02fe24: 0f1f 8400 | 1422 000d
+
+  0x00007f209d02fe2c: ; implicit exception: dispatches to 0x00007f209d03083a
+                      ; ImmutableOopMap {rax=Oop [168]=Oop [184]=Oop [224]=Oop [232]=Oop }
+                      ;*athrow {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) java.lang.invoke.Invokers::checkExactType@15 (line 531)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@55 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {section_word}
+  0x00007f209d02fe2c: 483b 0048 | ba2f fe02 | 9d20 7f00
+
+  0x00007f209d02fe38: ;   {runtime_call handle_exception_nofpu Runtime1 stub}
+  0x00007f209d02fe38: 00e8 42e6
+
+  0x00007f209d02fe3c: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02fe3c: df06 9048 | be48 2f25 | 3720 7f00 | 0048 8386 | 9001 0000
+
+  0x00007f209d02fe50: ;   {oop(a 'java/lang/invoke/MethodType'{0x000000070d013218} = (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;)}
+  0x00007f209d02fe50: 0148 ba18 | 3201 0d07 | 0000 0048
+
+  0x00007f209d02fe5c: ;   {static_call}
+  0x00007f209d02fe5c: 8bf1 90e8
+
+  0x00007f209d02fe60: ; ImmutableOopMap {[168]=Oop [184]=Oop [200]=Oop [208]=Oop [216]=Oop }
+                      ;*invokestatic newWrongMethodTypeException {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers::checkExactType@12 (line 531)
+                      ; - java.lang.invoke.LambdaForm$MH/0x00007f203c003000::invokeExact_MT@11
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@72 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d02fe60: 1c03 d306
+
+  0x00007f209d02fe64: ;   {other}
+  0x00007f209d02fe64: 0f1f 8400 | 5422 000f
+
+  0x00007f209d02fe6c: ; implicit exception: dispatches to 0x00007f209d03083f
+                      ; ImmutableOopMap {rax=Oop [168]=Oop [184]=Oop [200]=Oop [208]=Oop [216]=Oop }
+                      ;*athrow {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) java.lang.invoke.Invokers::checkExactType@15 (line 531)
+                      ; - java.lang.invoke.LambdaForm$MH/0x00007f203c003000::invokeExact_MT@11
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@72 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {section_word}
+  0x00007f209d02fe6c: 483b 0048 | ba6f fe02 | 9d20 7f00
+
+  0x00007f209d02fe78: ;   {runtime_call handle_exception_nofpu Runtime1 stub}
+  0x00007f209d02fe78: 00e8 02e6
+
+  0x00007f209d02fe7c: ;   {metadata(method data for {method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d02fe7c: df06 9048 | be48 2f25 | 3720 7f00 | 0048 8386 | 9001 0000
+
+  0x00007f209d02fe90: ;   {oop(a 'java/lang/invoke/MethodType'{0x000000070d16cf38} = (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;)}
+  0x00007f209d02fe90: 0148 ba38 | cf16 0d07 | 0000 0048
+
+  0x00007f209d02fe9c: ;   {static_call}
+  0x00007f209d02fe9c: 8bf3 90e8
+
+  0x00007f209d02fea0: ; ImmutableOopMap {[168]=Oop [176]=Oop [184]=Oop [192]=Oop }
+                      ;*invokestatic newWrongMethodTypeException {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers::checkExactType@12 (line 531)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@104 (line 157)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d02fea0: dc02 d306
+
+  0x00007f209d02fea4: ;   {other}
+  0x00007f209d02fea4: 0f1f 8400 | 9422 0011
+
+  0x00007f209d02feac: ; implicit exception: dispatches to 0x00007f209d030844
+                      ; ImmutableOopMap {rax=Oop [168]=Oop [176]=Oop [184]=Oop [192]=Oop }
+                      ;*athrow {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) java.lang.invoke.Invokers::checkExactType@15 (line 531)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@104 (line 157)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {section_word}
+  0x00007f209d02feac: 483b 0048 | baaf fe02 | 9d20 7f00
+
+  0x00007f209d02feb8: ;   {runtime_call handle_exception_nofpu Runtime1 stub}
+  0x00007f209d02feb8: 00e8 c2e5 | df06 9049 | 8b87 f804 | 0000 4d33 | d24d 8997 | f804 0000 | 4d33 d24d | 8997 0005
+  0x00007f209d02fed8: 0000 488b | b424 a800
+
+  0x00007f209d02fee0: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02fee0: 0000 48ba | e02e d137 | 207f 0000 | 4883 8288 | 0200 0001
+
+  0x00007f209d02fef4: ;   {metadata(method data for {method} {0x00007f203b3c5070} 'isIllegalArgument' '(Ljava/lang/RuntimeException;)Z' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02fef4: 48be a038 | d137 207f | 0000 8b96 | f400 0000 | 83c2 0289 | 96f4 0000 | 0081 e2fe | ff1f 0085
+  0x00007f209d02ff14: d20f 842e
+
+  0x00007f209d02ff18: ;   {oop(a 'java/lang/Class'{0x00000007ffebb430} = 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02ff18: 0900 0048 | be30 b4eb | ff07 0000 | 0048 8bd0 | 4889 8424 | f800 0000 | 0f1f 8000
+
+  0x00007f209d02ff34: ;   {static_call}
+  0x00007f209d02ff34: 0000 00e8
+
+  0x00007f209d02ff38: ; ImmutableOopMap {[248]=Oop }
+                      ;*invokestatic isIllegalArgument {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::isIllegalArgument@3 (line 191)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@58 (line 112)
+  0x00007f209d02ff38: 4402 d306
+
+  0x00007f209d02ff3c: ;   {other}
+  0x00007f209d02ff3c: 0f1f 8400 | 2c23 0013 | 83e0 0185
+
+  0x00007f209d02ff48: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02ff48: c048 b8e0 | 2ed1 3720 | 7f00 0048 | c7c6 c002 | 0000 7407 | 48c7 c6d0 | 0200 0048 | 8b14 3048
+  0x00007f209d02ff68: 8d52 0148 | 8914 300f | 84bc 0200 | 00e9 0f02 | 0000 498b | 87f8 0400 | 004d 33d2 | 4d89 97f8
+  0x00007f209d02ff88: 0400 004d | 33d2 4d89 | 9700 0500 | 0048 8bb4 | 24a8 0000
+
+  0x00007f209d02ff9c: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02ff9c: 0048 bae0 | 2ed1 3720 | 7f00 0048 | 8382 1002
+
+  0x00007f209d02ffac: ;   {metadata(method data for {method} {0x00007f203b3c5070} 'isIllegalArgument' '(Ljava/lang/RuntimeException;)Z' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02ffac: 0000 0148 | bea0 38d1 | 3720 7f00 | 008b 96f4 | 0000 0083 | c202 8996 | f400 0000 | 81e2 feff
+  0x00007f209d02ffcc: 1f00 85d2 | 0f84 9408
+
+  0x00007f209d02ffd4: ;   {oop(a 'java/lang/Class'{0x00000007ffebb430} = 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d02ffd4: 0000 48be | 30b4 ebff | 0700 0000 | 488b d048 | 8984 2400 | 0100 000f
+
+  0x00007f209d02ffec: ;   {static_call}
+  0x00007f209d02ffec: 1f40 00e8
+
+  0x00007f209d02fff0: ; ImmutableOopMap {[256]=Oop }
+                      ;*invokestatic isIllegalArgument {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::isIllegalArgument@3 (line 191)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@30 (line 105)
+  0x00007f209d02fff0: d909 0000
+
+  0x00007f209d02fff4: ;   {other}
+  0x00007f209d02fff4: 0f1f 8400 | e423 0014 | 83e0 0185
+
+  0x00007f209d030000: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d030000: c048 bae0 | 2ed1 3720 | 7f00 0048 | c7c6 4802 | 0000 7407 | 48c7 c658 | 0200 0048 | 8b3c 3248
+  0x00007f209d030020: 8d7f 0148 | 893c 320f | 84a4 0000 | 0066 6690
+
+  0x00007f209d030030: ;   {no_reloc}
+  0x00007f209d030030: e965 0800 | 0000 0000 | 0000 498b | 87b8 0100 | 0048 8d78 | 2849 3bbf | c801 0000 | 0f87 5208
+  0x00007f209d030050: 0000 4989 | bfb8 0100 | 0048 c700 | 0100 0000 | 488b ca49 | ba00 0000 | 3b20 7f00 | 0049 2bca
+  0x00007f209d030070: 8948 0848 | 33c9 8948 | 0c48 33c9 | 4889 4810 | 4889 4818 | 4889 4820
+
+  0x00007f209d030088: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d030088: 488b d048 | bee0 2ed1 | 3720 7f00 | 0048 8386 | 6802 0000
+
+  0x00007f209d03009c: ;   {oop("argument type mismatch"{0x00000007ffe087e0})}
+  0x00007f209d03009c: 0148 bae0 | 87e0 ff07 | 0000 0048 | 8bf0 4889 | 8424 0801 | 0000 0f1f
+
+  0x00007f209d0300b4: ;   {optimized virtual_call}
+  0x00007f209d0300b4: 4400 00e8
+
+  0x00007f209d0300b8: ; ImmutableOopMap {[264]=Oop }
+                      ;*invokespecial <init> {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@42 (line 107)
+  0x00007f209d0300b8: c4f6 d206
+
+  0x00007f209d0300bc: ;   {other}
+  0x00007f209d0300bc: 0f1f 8400 | ac24 0015 | 488b 8424 | 0801 0000 | e9ca 0800 | 0048 8b9c | 2400 0100 | 000f 1f80
+  0x00007f209d0300dc: 0000 0000
+
+  0x00007f209d0300e0: ;   {metadata('java/lang/reflect/InvocationTargetException')}
+  0x00007f209d0300e0: 48ba 68fa | 063c 207f | 0000 80ba | 2101 0000 | 040f 85d8 | 0700 0049 | 8b87 b801 | 0000 488d
+  0x00007f209d030100: 7828 493b | bfc8 0100 | 000f 87c0 | 0700 0049 | 89bf b801 | 0000 48c7 | 0001 0000 | 0048 8bca
+  0x00007f209d030120: 49ba 0000 | 003b 207f | 0000 492b | ca89 4808 | 4833 c989 | 480c 4833 | c948 8948 | 1048 8948
+  0x00007f209d030140: 1848 8948 | 2048 8bd0
+
+  0x00007f209d030148: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d030148: 48be e02e | d137 207f | 0000 4883 | 8678 0200 | 0001 488b | d348 8bf0 | 4889 8424 | 1001 0000
+  0x00007f209d030168: 0f1f 8000
+
+  0x00007f209d03016c: ;   {optimized virtual_call}
+  0x00007f209d03016c: 0000 00e8
+
+  0x00007f209d030170: ; ImmutableOopMap {[272]=Oop }
+                      ;*invokespecial <init> {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@51 (line 109)
+  0x00007f209d030170: 6908 0000
+
+  0x00007f209d030174: ;   {other}
+  0x00007f209d030174: 0f1f 8400 | 6425 0016 | 488b 8424 | 1001 0000 | e912 0800 | 000f 1f80 | 0000 0000
+
+  0x00007f209d030190: ;   {no_reloc}
+  0x00007f209d030190: e956 0700 | 0000 0000 | 0000 498b | 87b8 0100 | 0048 8d78 | 2849 3bbf | c801 0000 | 0f87 4307
+  0x00007f209d0301b0: 0000 4989 | bfb8 0100 | 0048 c700 | 0100 0000 | 488b ca49 | ba00 0000 | 3b20 7f00 | 0049 2bca
+  0x00007f209d0301d0: 8948 0848 | 33c9 8948 | 0c48 33c9 | 4889 4810 | 4889 4818 | 4889 4820
+
+  0x00007f209d0301e8: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d0301e8: 488b d048 | bee0 2ed1 | 3720 7f00 | 0048 8386 | e002 0000 | 0148 8b94 | 24f8 0000 | 0048 8bf0
+  0x00007f209d030208: 4889 8424 | 1801 0000 | 0f1f 8000
+
+  0x00007f209d030214: ;   {optimized virtual_call}
+  0x00007f209d030214: 0000 00e8
+
+  0x00007f209d030218: ; ImmutableOopMap {[280]=Oop }
+                      ;*invokespecial <init> {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@69 (line 113)
+  0x00007f209d030218: 64f5 d206
+
+  0x00007f209d03021c: ;   {other}
+  0x00007f209d03021c: 0f1f 8400 | 0c26 0017 | 488b 8424 | 1801 0000 | e96a 0700 | 0048 8b9c | 24f8 0000 | 000f 1f80
+  0x00007f209d03023c: 0000 0000
+
+  0x00007f209d030240: ;   {no_reloc}
+  0x00007f209d030240: e9cc 0600 | 0000 0000 | 0000 80ba | 2101 0000 | 040f 85c9 | 0600 0049 | 8b87 b801 | 0000 488d
+  0x00007f209d030260: 7828 493b | bfc8 0100 | 000f 87b1 | 0600 0049 | 89bf b801 | 0000 48c7 | 0001 0000 | 0048 8bca
+  0x00007f209d030280: 49ba 0000 | 003b 207f | 0000 492b | ca89 4808 | 4833 c989 | 480c 4833 | c948 8948 | 1048 8948
+  0x00007f209d0302a0: 1848 8948 | 2048 8bd0
+
+  0x00007f209d0302a8: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d0302a8: 48be e02e | d137 207f | 0000 4883 | 86f0 0200 | 0001 488b | d348 8bf0 | 4889 8424 | 2001 0000
+  0x00007f209d0302c8: 0f1f 8000
+
+  0x00007f209d0302cc: ;   {optimized virtual_call}
+  0x00007f209d0302cc: 0000 00e8
+
+  0x00007f209d0302d0: ; ImmutableOopMap {[288]=Oop }
+                      ;*invokespecial <init> {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@78 (line 115)
+  0x00007f209d0302d0: acf4 d206
+
+  0x00007f209d0302d4: ;   {other}
+  0x00007f209d0302d4: 0f1f 8400 | c426 0018 | 488b 8424 | 2001 0000 | e9b2 0600 | 000f 1f80 | 0000 0000
+
+  0x00007f209d0302f0: ;   {no_reloc}
+  0x00007f209d0302f0: e947 0600 | 0000 0000 | 0000 498b | 87b8 0100 | 0048 8d78 | 2849 3bbf | c801 0000 | 0f87 3406
+  0x00007f209d030310: 0000 4989 | bfb8 0100 | 0048 c700 | 0100 0000 | 488b ca49 | ba00 0000 | 3b20 7f00 | 0049 2bca
+  0x00007f209d030330: 8948 0848 | 33c9 8948 | 0c48 33c9 | 4889 4810 | 4889 4818 | 4889 4820
+
+  0x00007f209d030348: ;   {metadata(method data for {method} {0x00007f203b3c5178} 'checkReceiver' '(Ljava/lang/Object;)V' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d030348: 488b d048 | be40 32d1 | 3720 7f00 | 0048 8386 | c801 0000
+
+  0x00007f209d03035c: ;   {oop("object is not an instance of declaring class"{0x00000007ffe46960})}
+  0x00007f209d03035c: 0148 ba60 | 69e4 ff07 | 0000 0048 | 8bf0 4889 | 8424 2801 | 0000 0f1f
+
+  0x00007f209d030374: ;   {optimized virtual_call}
+  0x00007f209d030374: 4400 00e8
+
+  0x00007f209d030378: ; ImmutableOopMap {[168]=Oop [176]=Oop [184]=Oop [296]=Oop }
+                      ;*invokespecial <init> {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::checkReceiver@20 (line 197)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@9 (line 99)
+  0x00007f209d030378: 04f4 d206
+
+  0x00007f209d03037c: ;   {other}
+  0x00007f209d03037c: 0f1f 8400 | 6c27 0019 | 488b 8424 | 2801 0000 | e90a 0600 | 0049 8b87 | f804 0000 | 4d33 d24d
+  0x00007f209d03039c: 8997 f804 | 0000 4d33 | d24d 8997 | 0005 0000 | 488b d890
+
+  0x00007f209d0303b0: ;   {metadata('java/lang/reflect/InvocationTargetException')}
+  0x00007f209d0303b0: 48ba 68fa | 063c 207f | 0000 80ba | 2101 0000 | 040f 85aa | 0500 0049 | 8b87 b801 | 0000 488d
+  0x00007f209d0303d0: 7828 493b | bfc8 0100 | 000f 8792 | 0500 0049 | 89bf b801 | 0000 48c7 | 0001 0000 | 0048 8bca
+  0x00007f209d0303f0: 49ba 0000 | 003b 207f | 0000 492b | ca89 4808 | 4833 c989 | 480c 4833 | c948 8948 | 1048 8948
+  0x00007f209d030410: 1848 8948 | 2048 8bd0
+
+  0x00007f209d030418: ;   {metadata(method data for {method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d030418: 48be e02e | d137 207f | 0000 4883 | 8600 0300 | 0001 488b | d348 8bf0 | 4889 8424 | 3001 0000
+  0x00007f209d030438: 0f1f 8000
+
+  0x00007f209d03043c: ;   {optimized virtual_call}
+  0x00007f209d03043c: 0000 00e8
+
+  0x00007f209d030440: ; ImmutableOopMap {[304]=Oop }
+                      ;*invokespecial <init> {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@88 (line 118)
+  0x00007f209d030440: b905 0000
+
+  0x00007f209d030444: ;   {other}
+  0x00007f209d030444: 0f1f 8400 | 3428 001a | 488b 8424 | 3001 0000 | e942 0500
+
+  0x00007f209d030458: ;   {metadata({method} {0x00007f203b19d2c0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d030458: 0049 bac0 | d219 3b20 | 7f00 004c | 8954 2408 | 48c7 0424 | ffff ffff
+
+  0x00007f209d030470: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d030470: e80b 41e0
+
+  0x00007f209d030474: ; ImmutableOopMap {rsi=Oop rdx=Oop rcx=Oop [168]=Oop [176]=Oop [184]=Oop }
+                      ;*synchronization entry
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@-1 (line 98)
+  0x00007f209d030474: 06e9 e4dc
+
+  0x00007f209d030478: ;   {metadata({method} {0x00007f203b3c5228} 'isStatic' '()Z' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d030478: ffff 49ba | 2852 3c3b | 207f 0000 | 4c89 5424 | 0848 c704 | 24ff ffff
+
+  0x00007f209d030490: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d030490: ffe8 ea40
+
+  0x00007f209d030494: ; ImmutableOopMap {rsi=Oop rdx=Oop rcx=Oop [168]=Oop [176]=Oop [184]=Oop }
+                      ;*synchronization entry
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::isStatic@-1 (line 183)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@1 (line 98)
+  0x00007f209d030494: e006 e9ff
+
+  0x00007f209d030498: ;   {metadata({method} {0x00007f203b3c5178} 'checkReceiver' '(Ljava/lang/Object;)V' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d030498: dcff ff49 | ba78 513c | 3b20 7f00 | 004c 8954 | 2408 48c7 | 0424 ffff
+
+  0x00007f209d0304b0: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d0304b0: ffff e8c9
+
+  0x00007f209d0304b4: ; ImmutableOopMap {rsi=Oop rdx=Oop [168]=Oop [176]=Oop [184]=Oop }
+                      ;*synchronization entry
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::checkReceiver@-1 (line 196)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@9 (line 99)
+  0x00007f209d0304b4: 40e0 06e9 | a5dd ffff
+
+  0x00007f209d0304bc: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d0304bc: e85f b9df
+
+  0x00007f209d0304c0: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop [168]=Oop [176]=Oop [184]=Oop }
+                      ;*invokevirtual getClass {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::checkReceiver@5 (line 196)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@9 (line 99)
+                      ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d0304c0: 06e8 5ab9
+
+  0x00007f209d0304c4: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rbx=Oop [168]=Oop [176]=Oop [184]=Oop }
+                      ;*invokevirtual isAssignableFrom {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::checkReceiver@8 (line 196)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@9 (line 99)
+                      ;   {metadata({method} {0x00007f203b3c50c8} 'invokeImpl' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d0304c4: df06 49ba | c850 3c3b | 207f 0000 | 4c89 5424 | 0848 c704 | 24ff ffff
+
+  0x00007f209d0304dc: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d0304dc: ffe8 9e40
+
+  0x00007f209d0304e0: ; ImmutableOopMap {rsi=Oop [168]=Oop [176]=Oop [184]=Oop }
+                      ;*synchronization entry
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@-1 (line 152)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d0304e0: e006 e989
+
+  0x00007f209d0304e4: ;   {metadata({method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d0304e4: deff ff49 | ba00 0b0b | 3b20 7f00 | 004c 8954 | 2408 48c7 | 0424 ffff
+
+  0x00007f209d0304fc: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d0304fc: ffff e87d
+
+  0x00007f209d030500: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop [168]=Oop [176]=Oop [184]=Oop [192]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@-1
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@104 (line 157)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030500: 40e0 06e9 | 6ce0 ffff
+
+  0x00007f209d030508: ;   {metadata({method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d030508: 49ba 089b | 3d3b 207f | 0000 4c89 | 5424 0848 | c704 24ff
+
+  0x00007f209d03051c: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d03051c: ffff ffe8
+
+  0x00007f209d030520: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rax=Oop [168]=Oop [176]=Oop [184]=Oop [192]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.Invokers::checkExactType@-1 (line 529)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@104 (line 157)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030520: 5c40 e006 | e90a e1ff
+
+  0x00007f209d030528: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d030528: ffe8 f2b8
+
+  0x00007f209d03052c: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rax=Oop [168]=Oop [176]=Oop [184]=Oop [192]=Oop }
+                      ;*invokevirtual type {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers::checkExactType@1 (line 529)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@104 (line 157)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {metadata({method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d03052c: df06 49ba | 009a 3d3b | 207f 0000 | 4c89 5424 | 0848 c704 | 24ff ffff
+
+  0x00007f209d030544: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d030544: ffe8 3640
+
+  0x00007f209d030548: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop [168]=Oop [176]=Oop [184]=Oop [192]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.Invokers::checkCustomized@-1 (line 623)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@14
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@104 (line 157)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030548: e006 e940
+
+  0x00007f209d03054c: ;   {metadata({method} {0x00007f203b096bb8} 'isCompileConstant' '(Ljava/lang/Object;)Z' in 'java/lang/invoke/MethodHandleImpl')}
+  0x00007f209d03054c: e2ff ff49 | bab8 6b09 | 3b20 7f00 | 004c 8954 | 2408 48c7 | 0424 ffff
+
+  0x00007f209d030564: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d030564: ffff e815
+
+  0x00007f209d030568: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop [168]=Oop [176]=Oop [184]=Oop [192]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.MethodHandleImpl::isCompileConstant@-1 (line 618)
+                      ; - java.lang.invoke.Invokers::checkCustomized@1 (line 623)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@14
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@104 (line 157)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030568: 40e0 06e9 | 57e2 ffff
+
+  0x00007f209d030570: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d030570: e8ab b8df
+
+  0x00007f209d030574: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop [168]=Oop [176]=Oop [184]=Oop [192]=Oop }
+                      ;*getfield customized {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) java.lang.invoke.Invokers::checkCustomized@12 (line 626)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@14
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@104 (line 157)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {internal_word}
+  0x00007f209d030574: 0649 ba22 | ea02 9d20 | 7f00 004d | 8997 6004
+
+  0x00007f209d030584: ;   {runtime_call SafepointBlob}
+  0x00007f209d030584: 0000 e975
+
+  0x00007f209d030588: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d030588: 6ed3 06e8
+
+  0x00007f209d03058c: ; ImmutableOopMap {rsi=Oop rdx=Oop rcx=Oop rbx=Oop [168]=Oop [176]=Oop [184]=Oop }
+                      ;*aaload {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@85 (line 156)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d03058c: 90b8 df06
+
+  0x00007f209d030590: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d030590: e88b b8df
+
+  0x00007f209d030594: ; ImmutableOopMap {rsi=Oop rdx=Oop rcx=Oop rbx=Oop [168]=Oop [176]=Oop [184]=Oop }
+                      ;*aaload {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@85 (line 156)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030594: 0648 c704 | 2400 0000 | 0048 894c
+
+  0x00007f209d0305a0: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d0305a0: 2408 e8f9
+
+  0x00007f209d0305a4: ; ImmutableOopMap {rsi=Oop rdx=Oop rcx=Oop rbx=Oop [168]=Oop [176]=Oop [184]=Oop }
+                      ;*aaload {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@85 (line 156)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d0305a4: a9df 0648 | c704 2401 | 0000 0048 | 894c 2408
+
+  0x00007f209d0305b4: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d0305b4: e8e7 a9df
+
+  0x00007f209d0305b8: ; ImmutableOopMap {rsi=Oop rdx=Oop rcx=Oop rbx=Oop r8=Oop [168]=Oop [176]=Oop [184]=Oop }
+                      ;*aaload {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@88 (line 156)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d0305b8: 0648 c704 | 2402 0000 | 0048 894c
+
+  0x00007f209d0305c4: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d0305c4: 2408 e8d5
+
+  0x00007f209d0305c8: ; ImmutableOopMap {rsi=Oop rdx=Oop rcx=Oop rbx=Oop r8=Oop r9=Oop [168]=Oop [176]=Oop [184]=Oop }
+                      ;*aaload {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@91 (line 156)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d0305c8: a9df 0648 | b8d0 84ca | 1207 0000 | 00b8 000f
+
+  0x00007f209d0305d8: ;   {runtime_call load_appendix_patching Runtime1 stub}
+  0x00007f209d0305d8: 050a e8a1
+
+  0x00007f209d0305dc: ; ImmutableOopMap {rsi=Oop rdx=Oop rbx=Oop r8=Oop r9=Oop rdi=Oop [168]=Oop [184]=Oop }
+                      ;*invokevirtual invokeExact {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@92 (line 156)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d0305dc: 39e0 06e9 | 9ce4 ffff
+
+  0x00007f209d0305e4: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d0305e4: e837 b8df
+
+  0x00007f209d0305e8: ; ImmutableOopMap {rsi=Oop rdx=Oop rbx=Oop r8=Oop r9=Oop rdi=Oop rax=Oop [168]=Oop [184]=Oop }
+                      ;*invokevirtual invokeExact {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@92 (line 156)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {internal_word}
+  0x00007f209d0305e8: 0649 ba8c | ec02 9d20 | 7f00 004d | 8997 6004
+
+  0x00007f209d0305f8: ;   {runtime_call SafepointBlob}
+  0x00007f209d0305f8: 0000 e901
+
+  0x00007f209d0305fc: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d0305fc: 6ed3 06e8
+
+  0x00007f209d030600: ; ImmutableOopMap {rsi=Oop rcx=Oop rdx=Oop rdi=Oop [168]=Oop [176]=Oop [184]=Oop [208]=Oop }
+                      ;*aaload {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@68 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030600: 1cb8 df06
+
+  0x00007f209d030604: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d030604: e817 b8df
+
+  0x00007f209d030608: ; ImmutableOopMap {rsi=Oop rcx=Oop rdx=Oop rdi=Oop [168]=Oop [176]=Oop [184]=Oop [208]=Oop }
+                      ;*aaload {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@68 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030608: 0648 c704 | 2400 0000 | 0048 894c
+
+  0x00007f209d030614: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d030614: 2408 e885
+
+  0x00007f209d030618: ; ImmutableOopMap {rsi=Oop rcx=Oop rdx=Oop rdi=Oop [168]=Oop [176]=Oop [184]=Oop [208]=Oop }
+                      ;*aaload {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@68 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030618: a9df 0648 | c704 2401 | 0000 0048 | 894c 2408
+
+  0x00007f209d030628: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d030628: e873 a9df
+
+  0x00007f209d03062c: ; ImmutableOopMap {rsi=Oop rcx=Oop rdx=Oop rdi=Oop rbx=Oop [168]=Oop [176]=Oop [184]=Oop [200]=Oop [208]=Oop }
+                      ;*aaload {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@71 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {metadata({method} {0x00007f20374052b0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/LambdaForm$MH+0x00007f203c003000')}
+  0x00007f209d03062c: 0649 bab0 | 5240 3720 | 7f00 004c | 8954 2408 | 48c7 0424 | ffff ffff
+
+  0x00007f209d030644: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d030644: e837 3fe0
+
+  0x00007f209d030648: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rbx=Oop rax=Oop [168]=Oop [184]=Oop [200]=Oop [208]=Oop [216]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.LambdaForm$MH/0x00007f203c003000::invokeExact_MT@-1
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@72 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030648: 06e9 13e8
+
+  0x00007f209d03064c: ;   {metadata({method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d03064c: ffff 49ba | 089b 3d3b | 207f 0000 | 4c89 5424 | 0848 c704 | 24ff ffff
+
+  0x00007f209d030664: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d030664: ffe8 163f
+
+  0x00007f209d030668: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rbx=Oop rax=Oop r8=Oop [168]=Oop [184]=Oop [200]=Oop [208]=Oop [216]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.Invokers::checkExactType@-1 (line 529)
+                      ; - java.lang.invoke.LambdaForm$MH/0x00007f203c003000::invokeExact_MT@11
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@72 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030668: e006 e9bb
+
+  0x00007f209d03066c: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d03066c: e8ff ffe8
+
+  0x00007f209d030670: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rbx=Oop rax=Oop r8=Oop [168]=Oop [184]=Oop [200]=Oop [208]=Oop [216]=Oop }
+                      ;*invokevirtual type {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers::checkExactType@1 (line 529)
+                      ; - java.lang.invoke.LambdaForm$MH/0x00007f203c003000::invokeExact_MT@11
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@72 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030670: acb7 df06
+
+  0x00007f209d030674: ;   {metadata({method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d030674: 49ba 009a | 3d3b 207f | 0000 4c89 | 5424 0848 | c704 24ff
+
+  0x00007f209d030688: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d030688: ffff ffe8
+
+  0x00007f209d03068c: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rbx=Oop rax=Oop [168]=Oop [184]=Oop [200]=Oop [208]=Oop [216]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.Invokers::checkCustomized@-1 (line 623)
+                      ; - java.lang.invoke.LambdaForm$MH/0x00007f203c003000::invokeExact_MT@15
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@72 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d03068c: f03e e006 | e9fc e9ff
+
+  0x00007f209d030694: ;   {metadata({method} {0x00007f203b096bb8} 'isCompileConstant' '(Ljava/lang/Object;)Z' in 'java/lang/invoke/MethodHandleImpl')}
+  0x00007f209d030694: ff49 bab8 | 6b09 3b20 | 7f00 004c | 8954 2408 | 48c7 0424 | ffff ffff
+
+  0x00007f209d0306ac: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d0306ac: e8cf 3ee0
+
+  0x00007f209d0306b0: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rbx=Oop rax=Oop [168]=Oop [184]=Oop [200]=Oop [208]=Oop [216]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.MethodHandleImpl::isCompileConstant@-1 (line 618)
+                      ; - java.lang.invoke.Invokers::checkCustomized@1 (line 623)
+                      ; - java.lang.invoke.LambdaForm$MH/0x00007f203c003000::invokeExact_MT@15
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@72 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d0306b0: 06e9 19ea
+
+  0x00007f209d0306b4: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d0306b4: ffff e865
+
+  0x00007f209d0306b8: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rbx=Oop rax=Oop [168]=Oop [184]=Oop [200]=Oop [208]=Oop [216]=Oop }
+                      ;*getfield customized {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) java.lang.invoke.Invokers::checkCustomized@12 (line 626)
+                      ; - java.lang.invoke.LambdaForm$MH/0x00007f203c003000::invokeExact_MT@15
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@72 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {internal_word}
+  0x00007f209d0306b8: b7df 0649 | ba4c f302 | 9d20 7f00 | 004d 8997 | 6004 0000
+
+  0x00007f209d0306cc: ;   {runtime_call SafepointBlob}
+  0x00007f209d0306cc: e92f 6dd3
+
+  0x00007f209d0306d0: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d0306d0: 06e8 4ab7
+
+  0x00007f209d0306d4: ; ImmutableOopMap {rsi=Oop rcx=Oop rdx=Oop rdi=Oop [168]=Oop [176]=Oop [184]=Oop [232]=Oop }
+                      ;*aaload {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@54 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d0306d4: df06 e845
+
+  0x00007f209d0306d8: ; ImmutableOopMap {rsi=Oop rcx=Oop rdx=Oop rdi=Oop [168]=Oop [176]=Oop [184]=Oop [232]=Oop }
+                      ;*aaload {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@54 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d0306d8: b7df 0648 | c704 2400 | 0000 0048 | 894c 2408
+
+  0x00007f209d0306e8: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d0306e8: e8b3 a8df
+
+  0x00007f209d0306ec: ; ImmutableOopMap {rsi=Oop rcx=Oop rdx=Oop rdi=Oop [168]=Oop [176]=Oop [184]=Oop [232]=Oop }
+                      ;*aaload {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@54 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {metadata({method} {0x00007f203b0b0b00} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d0306ec: 0649 ba00 | 0b0b 3b20 | 7f00 004c | 8954 2408 | 48c7 0424 | ffff ffff
+
+  0x00007f209d030704: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d030704: e877 3ee0
+
+  0x00007f209d030708: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rbx=Oop [168]=Oop [184]=Oop [224]=Oop [232]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@-1
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@55 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030708: 06e9 efed
+
+  0x00007f209d03070c: ;   {metadata({method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d03070c: ffff 49ba | 089b 3d3b | 207f 0000 | 4c89 5424 | 0848 c704 | 24ff ffff
+
+  0x00007f209d030724: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d030724: ffe8 563e
+
+  0x00007f209d030728: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rbx=Oop rcx=Oop [168]=Oop [184]=Oop [224]=Oop [232]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.Invokers::checkExactType@-1 (line 529)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@55 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030728: e006 e995
+
+  0x00007f209d03072c: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d03072c: eeff ffe8
+
+  0x00007f209d030730: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rbx=Oop rcx=Oop [168]=Oop [184]=Oop [224]=Oop [232]=Oop }
+                      ;*invokevirtual type {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers::checkExactType@1 (line 529)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@55 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030730: ecb6 df06
+
+  0x00007f209d030734: ;   {metadata({method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d030734: 49ba 009a | 3d3b 207f | 0000 4c89 | 5424 0848 | c704 24ff
+
+  0x00007f209d030748: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d030748: ffff ffe8
+
+  0x00007f209d03074c: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rbx=Oop [168]=Oop [184]=Oop [224]=Oop [232]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.Invokers::checkCustomized@-1 (line 623)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@14
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@55 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d03074c: 303e e006 | e9cf efff
+
+  0x00007f209d030754: ;   {metadata({method} {0x00007f203b096bb8} 'isCompileConstant' '(Ljava/lang/Object;)Z' in 'java/lang/invoke/MethodHandleImpl')}
+  0x00007f209d030754: ff49 bab8 | 6b09 3b20 | 7f00 004c | 8954 2408 | 48c7 0424 | ffff ffff
+
+  0x00007f209d03076c: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d03076c: e80f 3ee0
+
+  0x00007f209d030770: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rbx=Oop [168]=Oop [184]=Oop [224]=Oop [232]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.MethodHandleImpl::isCompileConstant@-1 (line 618)
+                      ; - java.lang.invoke.Invokers::checkCustomized@1 (line 623)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@14
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@55 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030770: 06e9 e7ef
+
+  0x00007f209d030774: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d030774: ffff e8a5
+
+  0x00007f209d030778: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rbx=Oop [168]=Oop [184]=Oop [224]=Oop [232]=Oop }
+                      ;*getfield customized {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) java.lang.invoke.Invokers::checkCustomized@12 (line 626)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@14
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@55 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {internal_word}
+  0x00007f209d030778: b6df 0649 | bac4 f902 | 9d20 7f00 | 004d 8997 | 6004 0000
+
+  0x00007f209d03078c: ;   {runtime_call SafepointBlob}
+  0x00007f209d03078c: e96f 6cd3
+
+  0x00007f209d030790: ;   {metadata({method} {0x00007f203b0b0bb0} 'invokeExact_MT' '(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d030790: 0649 bab0 | 0b0b 3b20 | 7f00 004c | 8954 2408 | 48c7 0424 | ffff ffff
+
+  0x00007f209d0307a8: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d0307a8: e8d3 3de0
+
+  0x00007f209d0307ac: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop [168]=Oop [184]=Oop [240]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@-1
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@41 (line 153)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d0307ac: 06e9 faf2
+
+  0x00007f209d0307b0: ;   {metadata({method} {0x00007f203b3d9b08} 'checkExactType' '(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d0307b0: ffff 49ba | 089b 3d3b | 207f 0000 | 4c89 5424 | 0848 c704 | 24ff ffff
+
+  0x00007f209d0307c8: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d0307c8: ffe8 b23d
+
+  0x00007f209d0307cc: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rax=Oop [168]=Oop [184]=Oop [240]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.Invokers::checkExactType@-1 (line 529)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@41 (line 153)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d0307cc: e006 e94f
+
+  0x00007f209d0307d0: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d0307d0: f3ff ffe8
+
+  0x00007f209d0307d4: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop rax=Oop [168]=Oop [184]=Oop [240]=Oop }
+                      ;*invokevirtual type {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.Invokers::checkExactType@1 (line 529)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@41 (line 153)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d0307d4: 48b6 df06
+
+  0x00007f209d0307d8: ;   {metadata({method} {0x00007f203b3d9a00} 'checkCustomized' '(Ljava/lang/invoke/MethodHandle;)V' in 'java/lang/invoke/Invokers')}
+  0x00007f209d0307d8: 49ba 009a | 3d3b 207f | 0000 4c89 | 5424 0848 | c704 24ff
+
+  0x00007f209d0307ec: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d0307ec: ffff ffe8
+
+  0x00007f209d0307f0: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop [168]=Oop [184]=Oop [240]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.Invokers::checkCustomized@-1 (line 623)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@14
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@41 (line 153)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d0307f0: 8c3d e006 | e92d f4ff
+
+  0x00007f209d0307f8: ;   {metadata({method} {0x00007f203b096bb8} 'isCompileConstant' '(Ljava/lang/Object;)Z' in 'java/lang/invoke/MethodHandleImpl')}
+  0x00007f209d0307f8: ff49 bab8 | 6b09 3b20 | 7f00 004c | 8954 2408 | 48c7 0424 | ffff ffff
+
+  0x00007f209d030810: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d030810: e86b 3de0
+
+  0x00007f209d030814: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop [168]=Oop [184]=Oop [240]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.MethodHandleImpl::isCompileConstant@-1 (line 618)
+                      ; - java.lang.invoke.Invokers::checkCustomized@1 (line 623)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@14
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@41 (line 153)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030814: 06e9 44f4
+
+  0x00007f209d030818: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d030818: ffff e801
+
+  0x00007f209d03081c: ; ImmutableOopMap {rsi=Oop rdx=Oop rdi=Oop [168]=Oop [184]=Oop [240]=Oop }
+                      ;*getfield customized {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) java.lang.invoke.Invokers::checkCustomized@12 (line 626)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@14
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@41 (line 153)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {internal_word}
+  0x00007f209d03081c: b6df 0649 | baab fd02 | 9d20 7f00 | 004d 8997 | 6004 0000
+
+  0x00007f209d030830: ;   {runtime_call SafepointBlob}
+  0x00007f209d030830: e9cb 6bd3
+
+  0x00007f209d030834: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d030834: 06e8 e6b5
+
+  0x00007f209d030838: ; ImmutableOopMap {rax=Oop [168]=Oop [184]=Oop [240]=Oop }
+                      ;*athrow {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) java.lang.invoke.Invokers::checkExactType@15 (line 531)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@41 (line 153)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d030838: df06 e8e1
+
+  0x00007f209d03083c: ; ImmutableOopMap {rax=Oop [168]=Oop [184]=Oop [224]=Oop [232]=Oop }
+                      ;*athrow {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) java.lang.invoke.Invokers::checkExactType@15 (line 531)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@55 (line 154)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d03083c: b5df 06e8
+
+  0x00007f209d030840: ; ImmutableOopMap {rax=Oop [168]=Oop [184]=Oop [200]=Oop [208]=Oop [216]=Oop }
+                      ;*athrow {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) java.lang.invoke.Invokers::checkExactType@15 (line 531)
+                      ; - java.lang.invoke.LambdaForm$MH/0x00007f203c003000::invokeExact_MT@11
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@72 (line 155)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+  0x00007f209d030840: dcb5 df06
+
+  0x00007f209d030844: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d030844: e8d7 b5df
+
+  0x00007f209d030848: ; ImmutableOopMap {rax=Oop [168]=Oop [176]=Oop [184]=Oop [192]=Oop }
+                      ;*athrow {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) java.lang.invoke.Invokers::checkExactType@15 (line 531)
+                      ; - java.lang.invoke.Invokers$Holder::invokeExact_MT@10
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invokeImpl@104 (line 157)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@23 (line 103)
+                      ;   {metadata({method} {0x00007f203b3c5070} 'isIllegalArgument' '(Ljava/lang/RuntimeException;)Z' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d030848: 0649 ba70 | 503c 3b20 | 7f00 004c | 8954 2408 | 48c7 0424 | ffff ffff
+
+  0x00007f209d030860: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d030860: e81b 3de0
+
+  0x00007f209d030864: ; ImmutableOopMap {rax=Oop }
+                      ;*synchronization entry
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::isIllegalArgument@-1 (line 191)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@58 (line 112)
+  0x00007f209d030864: 06e9 b1f6
+
+  0x00007f209d030868: ;   {metadata({method} {0x00007f203b3c5070} 'isIllegalArgument' '(Ljava/lang/RuntimeException;)Z' in 'jdk/internal/reflect/DirectMethodHandleAccessor')}
+  0x00007f209d030868: ffff 49ba | 7050 3c3b | 207f 0000 | 4c89 5424 | 0848 c704 | 24ff ffff
+
+  0x00007f209d030880: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d030880: ffe8 fa3c
+
+  0x00007f209d030884: ; ImmutableOopMap {rax=Oop }
+                      ;*synchronization entry
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::isIllegalArgument@-1 (line 191)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@30 (line 105)
+  0x00007f209d030884: e006 e94b
+
+  0x00007f209d030888: ;   {metadata(nullptr)}
+  0x00007f209d030888: f7ff ff48 | ba00 0000 | 0000 0000 | 00b8 000f
+
+  0x00007f209d030898: ;   {runtime_call load_klass_patching Runtime1 stub}
+  0x00007f209d030898: 050a e8e1
+
+  0x00007f209d03089c: ; ImmutableOopMap {}
+                      ;*new {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) jdk.internal.reflect.DirectMethodHandleAccessor::invoke@36 (line 107)
+  0x00007f209d03089c: 1ee0 06e9 | 8cf7 ffff
+
+  0x00007f209d0308a4: ;   {runtime_call fast_new_instance Runtime1 stub}
+  0x00007f209d0308a4: 488b d2e8
+
+  0x00007f209d0308a8: ; ImmutableOopMap {}
+                      ;*new {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@36 (line 107)
+  0x00007f209d0308a8: d4c4 df06 | e9d7 f7ff
+
+  0x00007f209d0308b0: ;   {metadata('java/lang/reflect/InvocationTargetException')}
+  0x00007f209d0308b0: ff48 ba68 | fa06 3c20 | 7f00 00b8 | 000f 050a
+
+  0x00007f209d0308c0: ;   {runtime_call load_klass_patching Runtime1 stub}
+  0x00007f209d0308c0: e8bb 1ee0
+
+  0x00007f209d0308c4: ; ImmutableOopMap {rbx=Oop }
+                      ;*new {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) jdk.internal.reflect.DirectMethodHandleAccessor::invoke@46 (line 109)
+  0x00007f209d0308c4: 06e9 16f8
+
+  0x00007f209d0308c8: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d0308c8: ffff e851
+
+  0x00007f209d0308cc: ; ImmutableOopMap {rbx=Oop }
+                      ;*new {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@46 (line 109)
+  0x00007f209d0308cc: b5df 0648
+
+  0x00007f209d0308d0: ;   {runtime_call fast_new_instance_init_check Runtime1 stub}
+  0x00007f209d0308d0: 8bd2 e8a9
+
+  0x00007f209d0308d4: ; ImmutableOopMap {rbx=Oop }
+                      ;*new {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@46 (line 109)
+  0x00007f209d0308d4: cddf 06e9 | 69f8 ffff
+
+  0x00007f209d0308dc: ;   {metadata(nullptr)}
+  0x00007f209d0308dc: 48ba 0000 | 0000 0000 | 0000 b800
+
+  0x00007f209d0308e8: ;   {runtime_call load_klass_patching Runtime1 stub}
+  0x00007f209d0308e8: 0f05 0ae8
+
+  0x00007f209d0308ec: ; ImmutableOopMap {[248]=Oop }
+                      ;*new {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) jdk.internal.reflect.DirectMethodHandleAccessor::invoke@64 (line 113)
+  0x00007f209d0308ec: 901e e006 | e99b f8ff | ff48 8bd2
+
+  0x00007f209d0308f8: ;   {runtime_call fast_new_instance Runtime1 stub}
+  0x00007f209d0308f8: e883 c4df
+
+  0x00007f209d0308fc: ; ImmutableOopMap {[248]=Oop }
+                      ;*new {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@64 (line 113)
+  0x00007f209d0308fc: 06e9 e6f8
+
+  0x00007f209d030900: ;   {metadata(nullptr)}
+  0x00007f209d030900: ffff 48ba | 0000 0000 | 0000 0000 | b800 0f05
+
+  0x00007f209d030910: ;   {runtime_call load_klass_patching Runtime1 stub}
+  0x00007f209d030910: 0ae8 6a1e
+
+  0x00007f209d030914: ; ImmutableOopMap {rbx=Oop }
+                      ;*new {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) jdk.internal.reflect.DirectMethodHandleAccessor::invoke@73 (line 115)
+  0x00007f209d030914: e006 e925
+
+  0x00007f209d030918: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d030918: f9ff ffe8
+
+  0x00007f209d03091c: ; ImmutableOopMap {rbx=Oop }
+                      ;*new {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@73 (line 115)
+  0x00007f209d03091c: 00b5 df06
+
+  0x00007f209d030920: ;   {runtime_call fast_new_instance_init_check Runtime1 stub}
+  0x00007f209d030920: 488b d2e8
+
+  0x00007f209d030924: ; ImmutableOopMap {rbx=Oop }
+                      ;*new {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@73 (line 115)
+  0x00007f209d030924: 58cd df06 | e978 f9ff
+
+  0x00007f209d03092c: ;   {metadata(nullptr)}
+  0x00007f209d03092c: ff48 ba00 | 0000 0000 | 0000 00b8 | 000f 050a
+
+  0x00007f209d03093c: ;   {runtime_call load_klass_patching Runtime1 stub}
+  0x00007f209d03093c: e83f 1ee0
+
+  0x00007f209d030940: ; ImmutableOopMap {[168]=Oop [176]=Oop [184]=Oop }
+                      ;*new {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) jdk.internal.reflect.DirectMethodHandleAccessor::checkReceiver@14 (line 197)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@9 (line 99)
+  0x00007f209d030940: 06e9 aaf9 | ffff 488b
+
+  0x00007f209d030948: ;   {runtime_call fast_new_instance Runtime1 stub}
+  0x00007f209d030948: d2e8 32c4
+
+  0x00007f209d03094c: ; ImmutableOopMap {[168]=Oop [176]=Oop [184]=Oop }
+                      ;*new {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::checkReceiver@14 (line 197)
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@9 (line 99)
+  0x00007f209d03094c: df06 e9f5
+
+  0x00007f209d030950: ;   {metadata('java/lang/reflect/InvocationTargetException')}
+  0x00007f209d030950: f9ff ff48 | ba68 fa06 | 3c20 7f00 | 00b8 000f
+
+  0x00007f209d030960: ;   {runtime_call load_klass_patching Runtime1 stub}
+  0x00007f209d030960: 050a e819
+
+  0x00007f209d030964: ; ImmutableOopMap {rbx=Oop }
+                      ;*new {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) jdk.internal.reflect.DirectMethodHandleAccessor::invoke@83 (line 118)
+  0x00007f209d030964: 1ee0 06e9 | 44fa ffff
+
+  0x00007f209d03096c: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d03096c: e8af b4df
+
+  0x00007f209d030970: ; ImmutableOopMap {rbx=Oop }
+                      ;*new {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@83 (line 118)
+  0x00007f209d030970: 0648 8bd2
+
+  0x00007f209d030974: ;   {runtime_call fast_new_instance_init_check Runtime1 stub}
+  0x00007f209d030974: e807 cddf
+
+  0x00007f209d030978: ; ImmutableOopMap {rbx=Oop }
+                      ;*new {reexecute=0 rethrow=0 return_oop=0}
+                      ; - jdk.internal.reflect.DirectMethodHandleAccessor::invoke@83 (line 118)
+  0x00007f209d030978: 06e9 97fa | ffff 498b | 87f8 0400 | 0049 c787 | f804 0000 | 0000 0000 | 49c7 8700 | 0500 0000
+  0x00007f209d030998: 0000 0048 | 81c4 4001
+
+  0x00007f209d0309a0: ;   {runtime_call unwind_exception Runtime1 stub}
+  0x00007f209d0309a0: 0000 5de9 | d89f df06
+[Stub Code]
+  0x00007f209d0309a8: ;   {no_reloc}
+  0x00007f209d0309a8: 0f1f 4400
+
+  0x00007f209d0309ac: ;   {static_stub}
+  0x00007f209d0309ac: 0048 bbb0 | 0a89 3720
+
+  0x00007f209d0309b4: ;   {runtime_call I2C/C2I adapters}
+  0x00007f209d0309b4: 7f00 00e9 | db6f d306
+
+  0x00007f209d0309bc: ;   {static_stub}
+  0x00007f209d0309bc: 9048 bb00 | 0000 0000
+
+  0x00007f209d0309c4: ;   {runtime_call nmethod}
+  0x00007f209d0309c4: 0000 00e9 | fbff ffff
+
+  0x00007f209d0309cc: ;   {static_stub}
+  0x00007f209d0309cc: 9048 bb30 | 1610 3820
+
+  0x00007f209d0309d4: ;   {runtime_call I2C/C2I adapters}
+  0x00007f209d0309d4: 7f00 00e9 | 2b4e d306
+
+  0x00007f209d0309dc: ;   {static_stub}
+  0x00007f209d0309dc: 9048 bbf0 | fc20 3720
+
+  0x00007f209d0309e4: ;   {runtime_call I2C/C2I adapters}
+  0x00007f209d0309e4: 7f00 00e9 | 1b4e d306
+
+  0x00007f209d0309ec: ;   {static_stub}
+  0x00007f209d0309ec: 9048 bb00 | 0000 0000
+
+  0x00007f209d0309f4: ;   {runtime_call nmethod}
+  0x00007f209d0309f4: 0000 00e9 | fbff ffff
+
+  0x00007f209d0309fc: ;   {static_stub}
+  0x00007f209d0309fc: 9048 bbf0 | fc20 3720
+
+  0x00007f209d030a04: ;   {runtime_call I2C/C2I adapters}
+  0x00007f209d030a04: 7f00 00e9 | fb4d d306
+
+  0x00007f209d030a0c: ;   {static_stub}
+  0x00007f209d030a0c: 48bb 0000 | 0000 0000
+
+  0x00007f209d030a14: ;   {runtime_call nmethod}
+  0x00007f209d030a14: 0000 e9fb
+
+  0x00007f209d030a18: ;   {static_stub}
+  0x00007f209d030a18: ffff ff48 | bb00 0000 | 0000 0000
+
+  0x00007f209d030a24: ;   {runtime_call nmethod}
+  0x00007f209d030a24: 00e9 fbff
+
+  0x00007f209d030a28: ;   {static_stub}
+  0x00007f209d030a28: ffff 48bb | 0000 0000 | 0000 0000
+
+  0x00007f209d030a34: ;   {runtime_call nmethod}
+  0x00007f209d030a34: e9fb ffff
+
+  0x00007f209d030a38: ;   {static_stub}
+  0x00007f209d030a38: ff48 bb00 | 0000 0000
+
+  0x00007f209d030a40: ;   {runtime_call nmethod}
+  0x00007f209d030a40: 0000 00e9 | fbff ffff
+
+  0x00007f209d030a48: ;   {static_stub}
+  0x00007f209d030a48: 48bb 0000 | 0000 0000
+
+  0x00007f209d030a50: ;   {runtime_call nmethod}
+  0x00007f209d030a50: 0000 e9fb
+
+  0x00007f209d030a54: ;   {static_stub}
+  0x00007f209d030a54: ffff ff48 | bb00 0000 | 0000 0000
+
+  0x00007f209d030a60: ;   {runtime_call nmethod}
+  0x00007f209d030a60: 00e9 fbff
+
+  0x00007f209d030a64: ;   {static_stub}
+  0x00007f209d030a64: ffff 48bb | 0000 0000 | 0000 0000
+
+  0x00007f209d030a70: ;   {runtime_call nmethod}
+  0x00007f209d030a70: e9fb ffff
+
+  0x00007f209d030a74: ;   {static_stub}
+  0x00007f209d030a74: ff48 bb00 | 0000 0000
+
+  0x00007f209d030a7c: ;   {runtime_call nmethod}
+  0x00007f209d030a7c: 0000 00e9 | fbff ffff
+
+  0x00007f209d030a84: ;   {static_stub}
+  0x00007f209d030a84: 48bb 0000 | 0000 0000
+
+  0x00007f209d030a8c: ;   {runtime_call nmethod}
+  0x00007f209d030a8c: 0000 e9fb
+
+  0x00007f209d030a90: ;   {runtime_call handle_exception_from_callee Runtime1 stub}
+  0x00007f209d030a90: ffff ffe8 | e8e5 df06
+
+  0x00007f209d030a98: ;   {external_word}
+  0x00007f209d030a98: 48bf 390f | 15bb 207f | 0000 4883
+
+  0x00007f209d030aa4: ;   {runtime_call MacroAssembler::debug64(char*, long, long*)}
+  0x00007f209d030aa4: e4f0 e895 | 95ba 1df4
+[Deopt Handler Code]
+  0x00007f209d030aac: ;   {section_word}
+  0x00007f209d030aac: 49ba ac0a | 039d 207f | 0000 4152
+
+  0x00007f209d030ab8: ;   {runtime_call DeoptimizationBlob}
+  0x00007f209d030ab8: e9e3 7dd3
+
+  0x00007f209d030abc: ;   {section_word}
+  0x00007f209d030abc: 0649 babd | 0a03 9d20 | 7f00 0041
+
+  0x00007f209d030ac8: ;   {runtime_call DeoptimizationBlob}
+  0x00007f209d030ac8: 52e9 d27d | d306 f4f4
+[/MachCode]
+
+
+Compiled method (c1) 8155 5273   !   3       org.junit.platform.commons.util.ReflectionUtils::invokeMethod (128 bytes)
+ total in heap  [0x00007f209d369710,0x00007f209d36b148] = 6712
+ relocation     [0x00007f209d369868,0x00007f209d369a28] = 448
+ main code      [0x00007f209d369a40,0x00007f209d36a920] = 3808
+ stub code      [0x00007f209d36a920,0x00007f209d36aa28] = 264
+ oops           [0x00007f209d36aa28,0x00007f209d36aa38] = 16
+ metadata       [0x00007f209d36aa38,0x00007f209d36aa80] = 72
+ scopes data    [0x00007f209d36aa80,0x00007f209d36ad10] = 656
+ scopes pcs     [0x00007f209d36ad10,0x00007f209d36afc0] = 688
+ dependencies   [0x00007f209d36afc0,0x00007f209d36afc8] = 8
+ handler table  [0x00007f209d36afc8,0x00007f209d36b100] = 312
+ nul chk table  [0x00007f209d36b100,0x00007f209d36b148] = 72
+
+[Constant Pool (empty)]
+
+[MachCode]
+[Verified Entry Point]
+  # {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils'
+  # parm0:    rsi:rsi   = 'java/lang/reflect/Method'
+  # parm1:    rdx:rdx   = 'java/lang/Object'
+  # parm2:    rcx:rcx   = '[Ljava/lang/Object;'
+  #           [sp+0xf0]  (sp of caller)
+  0x00007f209d369a40: 8984 2400 | c0fe ff55 | 4881 ece0 | 0000 0090 | 4181 7f20 | 0100 0000
+
+  0x00007f209d369a58: ;   {runtime_call StubRoutines (final stubs)}
+  0x00007f209d369a58: 7405 e8c1 | d79d 0648 | 89b4 2490 | 0000 0048 | 8994 2498
+
+  0x00007f209d369a6c: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d369a6c: 0000 0048 | bff8 8f74 | 3720 7f00 | 008b 9ff4 | 0000 0083 | c302 899f | f400 0000 | 81e3 fe07
+  0x00007f209d369a8c: 0000 85db | 0f84 120c | 0000 4889 | 8c24 a000
+
+  0x00007f209d369a9c: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d369a9c: 0000 48bf | f88f 7437 | 207f 0000 | 4883 8738 | 0100 0001 | 0f1f 8000
+
+  0x00007f209d369ab4: ;   {static_call}
+  0x00007f209d369ab4: 0000 00e8
+
+  0x00007f209d369ab8: ; ImmutableOopMap {[144]=Oop [152]=Oop [160]=Oop }
+                      ;*invokestatic $jacocoInit {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@0
+  0x00007f209d369ab8: 444e 1f07
+
+  0x00007f209d369abc: ;   {other}
+  0x00007f209d369abc: 0f1f 8400 | ac03 0000 | 4889 8424 | a800 0000
+
+  0x00007f209d369acc: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d369acc: 48be f88f | 7437 207f | 0000 4883 | 8648 0100 | 0001 488b | b424 9000
+
+  0x00007f209d369ae4: ;   {oop("Method must not be null"{0x000000070d607a80})}
+  0x00007f209d369ae4: 0000 48ba | 807a 600d | 0700 0000 | 0f1f 8000
+
+  0x00007f209d369af4: ;   {static_call}
+  0x00007f209d369af4: 0000 00e8
+
+  0x00007f209d369af8: ; ImmutableOopMap {[144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*invokestatic notNull {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@9 (line 723)
+  0x00007f209d369af8: 242a 2007
+
+  0x00007f209d369afc: ;   {other}
+  0x00007f209d369afc: 0f1f 8400 | ec03 0001 | 488b 8424 | a800 0000
+
+  0x00007f209d369b0c: ; implicit exception: dispatches to 0x00007f209d36a6c9
+  0x00007f209d369b0c: 8178 0c9d | 0000 000f | 86ba 0b00 | 00c6 80ad | 0000 0001 | 488b 9424 | 9800 0000
+
+  0x00007f209d369b28: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d369b28: 4885 d248 | bef8 8f74 | 3720 7f00 | 0048 c7c7 | 5801 0000 | 7407 48c7 | c768 0100 | 0048 8b1c
+  0x00007f209d369b48: 3e48 8d5b | 0148 891c | 3e0f 8429 | 0000 0081 | 780c 9e00 | 0000 0f86 | 810b 0000 | c680 ae00
+  0x00007f209d369b68: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d369b68: 0000 0148 | bef8 8f74 | 3720 7f00 | 00ff 8678 | 0100 00e9 | 7600 0000
+
+  0x00007f209d369b80: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d369b80: 48be f88f | 7437 207f | 0000 4883 | 8690 0100 | 0001 488b | b424 9000 | 0000 0f1f
+
+  0x00007f209d369b9c: ;   {static_call}
+  0x00007f209d369b9c: 4400 00e8
+
+  0x00007f209d369ba0: ; ImmutableOopMap {[144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*invokestatic isStatic {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@35 (line 724)
+  0x00007f209d369ba0: 7c69 3f07
+
+  0x00007f209d369ba4: ;   {other}
+  0x00007f209d369ba4: 0f1f 8400 | 9404 0002
+
+  0x00007f209d369bac: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d369bac: 85c0 48ba | f88f 7437 | 207f 0000 | 48c7 c6a0 | 0100 0074 | 0748 c7c6 | b001 0000 | 488b 3c32
+  0x00007f209d369bcc: 488d 7f01 | 4889 3c32 | 488b 8424 | a800 0000 | 0f84 4200 | 0000 8178 | 0c9f 0000 | 000f 8608
+  0x00007f209d369bec: 0b00 00c6 | 80af 0000 | 0001 8178 | 0ca0 0000 | 000f 8606 | 0b00 00c6 | 80b0 0000
+
+  0x00007f209d369c08: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d369c08: 0001 48ba | f88f 7437 | 207f 0000 | ff82 c001 | 0000 bf01 | 0000 00e9 | 1900 0000 | 8178 0ca1
+  0x00007f209d369c28: 0000 000f | 86ea 0a00 | 00c6 80b1 | 0000 0001 | bf00 0000 | 0089 bc24 | b800 0000 | 488b b424
+  0x00007f209d369c48: 9000 0000
+
+  0x00007f209d369c4c: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d369c4c: 48ba f88f | 7437 207f | 0000 488d | 92e8 0100 | 0048 85f6 | 750c f642 | 0801 7506 | f048 834a
+  0x00007f209d369c6c: ;   {metadata(method data for {method} {0x00007f203b0b03c8} 'linkToTargetMethod' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d369c6c: 0801 48ba | c8b1 2637 | 207f 0000 | 488d 9228
+
+  0x00007f209d369c7c: ;   {oop(a 'java/lang/invoke/DirectMethodHandle$Constructor'{0x000000070d620ca8})}
+  0x00007f209d369c7c: 0200 0048 | bba8 0c62 | 0d07 0000 | 0048 85db | 750c f642 | 1001 7506 | f048 834a
+
+  0x00007f209d369c98: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d369c98: 1001 48ba | f88f 7437 | 207f 0000 | 4883 82d8 | 0100 0001
+
+  0x00007f209d369cac: ;   {metadata(method data for {method} {0x00007f203b0b03c8} 'linkToTargetMethod' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d369cac: 48ba c8b1 | 2637 207f | 0000 8b8a | f400 0000 | 83c1 0289 | 8af4 0000 | 0081 e1fe | ff1f 0085
+  0x00007f209d369ccc: c90f 845a
+
+  0x00007f209d369cd0: ;   {metadata(method data for {method} {0x00007f203b0b65d8} 'newInvokeSpecial' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle$Holder')}
+  0x00007f209d369cd0: 0a00 0048 | ba90 6328 | 3720 7f00 | 0048 8d92 | 6802 0000 | 4885 db75 | 0af6 0201 | 7505 f048
+  0x00007f209d369cf0: ;   {metadata(method data for {method} {0x00007f203b0b03c8} 'linkToTargetMethod' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d369cf0: 830a 0148 | bac8 b126 | 3720 7f00 | 0048 8382 | 7001 0000
+
+  0x00007f209d369d04: ;   {metadata(method data for {method} {0x00007f203b0b65d8} 'newInvokeSpecial' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle$Holder')}
+  0x00007f209d369d04: 0148 ba90 | 6328 3720 | 7f00 008b | 8af4 0000 | 0083 c102 | 898a f400 | 0000 81e1 | feff 1f00
+  0x00007f209d369d24: 85c9 0f84 | 220a 0000
+
+  0x00007f209d369d2c: ;   {metadata(method data for {method} {0x00007f203b0b65d8} 'newInvokeSpecial' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle$Holder')}
+  0x00007f209d369d2c: 48ba 9063 | 2837 207f | 0000 488d | 9248 0100 | 0048 85db | 750c f642 | 0801 7506 | f048 834a
+  0x00007f209d369d4c: ;   {metadata(method data for {method} {0x00007f203b0b65d8} 'newInvokeSpecial' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle$Holder')}
+  0x00007f209d369d4c: 0801 48ba | 9063 2837 | 207f 0000 | 4883 8238 | 0100 0001
+
+  0x00007f209d369d60: ;   {metadata(method data for {method} {0x00007f203b0a2f58} 'allocateInstance' '(Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle')}
+  0x00007f209d369d60: 48ba 302a | 2637 207f | 0000 8b8a | f400 0000 | 83c1 0289 | 8af4 0000 | 0081 e1fe | ff1f 0085
+  0x00007f209d369d80: c90f 84e8
+
+  0x00007f209d369d84: ;   {oop(a 'jdk/internal/misc/Unsafe'{0x000000070d001158})}
+  0x00007f209d369d84: 0900 0048 | b958 1100 | 0d07 0000 | 0048 8bd1
+
+  0x00007f209d369d94: ;   {metadata(method data for {method} {0x00007f203b0a2f58} 'allocateInstance' '(Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle')}
+  0x00007f209d369d94: 49b8 302a | 2637 207f | 0000 4983 | 8070 0100
+
+  0x00007f209d369da4: ;   {oop(a 'java/lang/Class'{0x000000070d5c3e70} = 'org/junit/platform/commons/util/ReflectionUtils$$Lambda+0x00007f203c137b00')}
+  0x00007f209d369da4: 0001 48ba | 703e 5c0d | 0700 0000 | 488b f148 | 899c 24b0 | 0000 000f
+
+  0x00007f209d369dbc: ;   {optimized virtual_call}
+  0x00007f209d369dbc: 1f40 00e8
+
+  0x00007f209d369dc0: ; ImmutableOopMap {[144]=Oop [152]=Oop [160]=Oop [168]=Oop [176]=Oop }
+                      ;*invokevirtual allocateInstance {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.DirectMethodHandle::allocateInstance@12 (line 501)
+                      ; - java.lang.invoke.DirectMethodHandle$Holder::newInvokeSpecial@1
+                      ; - java.lang.invoke.Invokers$Holder::linkToTargetMethod@5
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@68 (line 724)
+  0x00007f209d369dc0: fcef 1907
+
+  0x00007f209d369dc4: ;   {other}
+  0x00007f209d369dc4: 0f1f 8400 | b406 0003
+
+  0x00007f209d369dcc: ;   {metadata(method data for {method} {0x00007f203b0b65d8} 'newInvokeSpecial' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle$Holder')}
+  0x00007f209d369dcc: 48be 9063 | 2837 207f | 0000 488d | b658 0100 | 0048 85c0 | 750a f606 | 0175 05f0 | 4883 0e01
+  0x00007f209d369dec: ;   {metadata(method data for {method} {0x00007f203b0b65d8} 'newInvokeSpecial' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle$Holder')}
+  0x00007f209d369dec: 48be 9063 | 2837 207f | 0000 488d | b678 0100 | 0048 8b9c | 24b0 0000 | 0048 85db | 750c f646
+  0x00007f209d369e0c: 0801 7506 | f048 834e
+
+  0x00007f209d369e14: ;   {metadata(method data for {method} {0x00007f203b0b65d8} 'newInvokeSpecial' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle$Holder')}
+  0x00007f209d369e14: 0801 48be | 9063 2837 | 207f 0000 | 4883 8668 | 0100 0001
+
+  0x00007f209d369e28: ;   {metadata(method data for {method} {0x00007f203b0a3a00} 'constructorMethod' '(Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle')}
+  0x00007f209d369e28: 48be 5834 | 2637 207f | 0000 8b96 | f400 0000 | 83c2 0289 | 96f4 0000 | 0081 e2fe | ff1f 0085
+  0x00007f209d369e48: d20f 8441
+
+  0x00007f209d369e4c: ;   {metadata(method data for {method} {0x00007f203b0b65d8} 'newInvokeSpecial' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle$Holder')}
+  0x00007f209d369e4c: 0900 0048 | be90 6328 | 3720 7f00 | 0048 8db6 | 8801 0000
+
+  0x00007f209d369e60: ;   {oop(a 'java/lang/invoke/MemberName'{0x000000070d620d20} = {method} {0x00007f2037915d38} '<init>' '(Ljava/lang/reflect/Method;)V' in 'org/junit/platform/commons/util/ReflectionUtils$$Lambda+0x00007f203c137b00')}
+  0x00007f209d369e60: 48ba 200d | 620d 0700 | 0000 4885 | d275 0af6 | 0601 7505 | f048 830e | 0148 3b00
+
+  0x00007f209d369e7c: ;   {metadata(method data for {method} {0x00007f203b0b65d8} 'newInvokeSpecial' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle$Holder')}
+  0x00007f209d369e7c: 488b f048 | ba90 6328 | 3720 7f00 | 0048 8382 | d001 0000
+
+  0x00007f209d369e90: ;   {metadata(method data for {method} {0x00007f2037915d38} '<init>' '(Ljava/lang/reflect/Method;)V' in 'org/junit/platform/commons/util/ReflectionUtils$$Lambda+0x00007f203c137b00')}
+  0x00007f209d369e90: 0148 be58 | 2307 3820 | 7f00 008b | 96f4 0000 | 0083 c202 | 8996 f400 | 0000 81e2 | feff 1f00
+  0x00007f209d369eb0: 85d2 0f84 | fe08 0000
+
+  0x00007f209d369eb8: ;   {metadata(method data for {method} {0x00007f2037915d38} '<init>' '(Ljava/lang/reflect/Method;)V' in 'org/junit/platform/commons/util/ReflectionUtils$$Lambda+0x00007f203c137b00')}
+  0x00007f209d369eb8: 488b f048 | ba58 2307 | 3820 7f00 | 0048 8382 | 3801 0000
+
+  0x00007f209d369ecc: ;   {metadata(method data for {method} {0x00007f203b470b68} '<init>' '()V' in 'java/lang/Object')}
+  0x00007f209d369ecc: 0148 be90 | 7000 3720 | 7f00 008b | 96f4 0000 | 0083 c202 | 8996 f400 | 0000 81e2 | feff 1f00
+  0x00007f209d369eec: 85d2 0f84 | e308 0000 | 410f be77 | 4085 f60f | 85f7 0800 | 0048 8bb4 | 2490 0000 | 004c 8bd6
+  0x00007f209d369f0c: 49c1 ea03 | 4489 500c | 488b d048 | 33d6 48c1 | ea15 4883 | fa00 0f85 | ef08 0000
+
+  0x00007f209d369f28: ;   {metadata(method data for {method} {0x00007f203b0b03c8} 'linkToTargetMethod' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d369f28: 48ba c8b1 | 2637 207f | 0000 488d | 92b8 0100 | 0048 85c0 | 750a f602 | 0175 05f0 | 4883 0a01
+  0x00007f209d369f48: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d369f48: 48ba f88f | 7437 207f | 0000 488d | 92f8 0100 | 0048 85c0 | 750c f602 | 0175 30f0 | 4883 0a01
+  0x00007f209d369f68: eb29 8b78 | 0849 ba00 | 0000 3b20 | 7f00 0049 | 03fa 4c8b | d748 333a | 48f7 c7fc | ffff ff74
+  0x00007f209d369f88: 0a40 f6c7 | 0275 0448
+
+  0x00007f209d369f90: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d369f90: 830a 0248 | baf8 8f74 | 3720 7f00 | 0048 8382 | 0802 0000 | 018b b424 | b800 0000
+
+  0x00007f209d369fac: ;   {static_call}
+  0x00007f209d369fac: 488b d0e8
+
+  0x00007f209d369fb0: ; ImmutableOopMap {[144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*invokestatic condition {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@73 (line 724)
+  0x00007f209d369fb0: 6c26 4707
+
+  0x00007f209d369fb4: ;   {other}
+  0x00007f209d369fb4: 0f1f 8400 | a408 0004 | 488b 8424 | a800 0000 | 488b b424 | 9000 0000 | 8178 0ca2 | 0000 000f
+  0x00007f209d369fd4: 8656 0800 | 00c6 80b2 | 0000 0001
+
+  0x00007f209d369fe0: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d369fe0: 48bf f88f | 7437 207f | 0000 4883 | 8718 0200 | 0001 0f1f
+
+  0x00007f209d369ff4: ;   {static_call}
+  0x00007f209d369ff4: 4400 00e8
+
+  0x00007f209d369ff8: ; ImmutableOopMap {[152]=Oop [160]=Oop [168]=Oop }
+                      ;*invokestatic makeAccessible {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@84 (line 728)
+  0x00007f209d369ff8: 6402 f1ff
+
+  0x00007f209d369ffc: ;   {other}
+  0x00007f209d369ffc: 0f1f 8400 | ec08 0005 | 4885 c075
+
+  0x00007f209d36a008: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d36a008: 1648 bbf8 | 8f74 3720 | 7f00 0080 | 8b21 0200 | 0001 e9cc
+
+  0x00007f209d36a01c: ;   {metadata('java/lang/reflect/Method')}
+  0x00007f209d36a01c: 0000 0048 | bf78 1104 | 3b20 7f00 | 008b 7008 | 49ba 0000 | 003b 207f | 0000 4903 | f248 3bfe
+  0x00007f209d36a03c: 0f85 8d00
+
+  0x00007f209d36a040: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d36a040: 0000 48bb | f88f 7437 | 207f 0000 | 8b78 0849 | ba00 0000 | 3b20 7f00 | 0049 03fa | 483b bb38
+  0x00007f209d36a060: 0200 0075 | 0d48 8383 | 4002 0000 | 01e9 7900 | 0000 483b | bb48 0200 | 0075 0d48 | 8383 5002
+  0x00007f209d36a080: 0000 01e9 | 6300 0000 | 4883 bb38 | 0200 0000 | 7517 4889 | bb38 0200 | 0048 c783 | 4002 0000
+  0x00007f209d36a0a0: 0100 0000 | e942 0000 | 0048 83bb | 4802 0000 | 0075 1748 | 89bb 4802 | 0000 48c7 | 8350 0200
+  0x00007f209d36a0c0: 0001 0000 | 00e9 2100 | 0000 e91c
+
+  0x00007f209d36a0cc: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d36a0cc: 0000 0048 | bbf8 8f74 | 3720 7f00 | 0048 83ab | 2802 0000 | 01e9 5b07 | 0000 e900 | 0000 0048
+  0x00007f209d36a0ec: 8bf8 4889 | bc24 c000 | 0000 483b | 0748 8bf7
+
+  0x00007f209d36a0fc: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d36a0fc: 48bb f88f | 7437 207f | 0000 4883 | 8360 0200
+
+  0x00007f209d36a10c: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a10c: 0001 48be | 58f8 2737 | 207f 0000 | 8b9e f400 | 0000 83c3 | 0289 9ef4 | 0000 0081 | e3fe ff1f
+  0x00007f209d36a12c: 0085 db0f | 841a 0700 | 0048 8bf7
+
+  0x00007f209d36a138: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a138: 48bb 58f8 | 2737 207f | 0000 4883 | 8338 0100 | 0001 488b
+
+  0x00007f209d36a14c: ;   {optimized virtual_call}
+  0x00007f209d36a14c: f766 90e8
+
+  0x00007f209d36a150: ; ImmutableOopMap {[152]=Oop [160]=Oop [168]=Oop [192]=Oop }
+                      ;*invokevirtual isCallerSensitive {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.reflect.Method::invoke@1 (line 561)
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@92 (line 728)
+  0x00007f209d36a150: 8c84 ccff
+
+  0x00007f209d36a154: ;   {other}
+  0x00007f209d36a154: 0f1f 8400 | 440a 0006 | 488b bc24 | c000 0000 | 0fbe 770c
+
+  0x00007f209d36a168: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a168: 85f6 48be | 58f8 2737 | 207f 0000 | 48c7 c370 | 0100 0074 | 0748 c7c3 | 8001 0000 | 488b 141e
+  0x00007f209d36a188: 488d 5201 | 4889 141e | 0f84 4400 | 0000 85c0
+
+  0x00007f209d36a198: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a198: 48be 58f8 | 2737 207f | 0000 48c7 | c3a0 0100 | 0075 0748 | c7c3 9001 | 0000 488b | 141e 488d
+  0x00007f209d36a1b8: 5201 4889 | 141e 0f85 | 1600 0000
+
+  0x00007f209d36a1c4: ;   {oop(nullptr)}
+  0x00007f209d36a1c4: 48bb 0000 | 0000 0000 | 0000 8984 | 24bc 0000 | 00e9 3500 | 0000 8984 | 24bc 0000
+
+  0x00007f209d36a1e0: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a1e0: 0048 be58 | f827 3720 | 7f00 0048 | 8386 b001 | 0000 010f
+
+  0x00007f209d36a1f4: ;   {static_call}
+  0x00007f209d36a1f4: 1f40 00e8
+
+  0x00007f209d36a1f8: ; ImmutableOopMap {[152]=Oop [160]=Oop [168]=Oop [192]=Oop }
+                      ;*invokestatic getCallerClass {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.reflect.Method::invoke@19 (line 564)
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@92 (line 728)
+  0x00007f209d36a1f8: 845f 9f06
+
+  0x00007f209d36a1fc: ;   {other}
+  0x00007f209d36a1fc: 0f1f 8400 | ec0a 0007 | 488b d848 | 8bbc 24c0 | 0000 000f | be57 0c85
+
+  0x00007f209d36a214: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a214: d248 ba58 | f827 3720 | 7f00 0048 | c7c1 d001 | 0000 7407 | 48c7 c1c0 | 0100 004c | 8b04 0a4d
+  0x00007f209d36a234: 8d40 014c | 8904 0a0f | 840d 0000 | 0048 899c | 24c8 0000 | 00e9 5e01 | 0000 8b4f | 2448 c1e1
+  0x00007f209d36a254: 0344 8b4f
+
+  0x00007f209d36a258: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a258: 2048 ba58 | f827 3720 | 7f00 0048 | 8382 e001
+
+  0x00007f209d36a268: ;   {metadata(method data for {method} {0x00007f203b0ecff0} 'isStatic' '(I)Z' in 'java/lang/reflect/Modifier')}
+  0x00007f209d36a268: 0000 0148 | ba20 1c0b | 3720 7f00 | 0044 8b82 | f400 0000 | 4183 c002 | 4489 82f4 | 0000 0041
+  0x00007f209d36a288: 81e0 feff | 1f00 4585 | c00f 84d9 | 0500 0049 | 8bd1 83e2
+
+  0x00007f209d36a29c: ;   {metadata(method data for {method} {0x00007f203b0ecff0} 'isStatic' '(I)Z' in 'java/lang/reflect/Modifier')}
+  0x00007f209d36a29c: 0885 d248 | ba20 1c0b | 3720 7f00 | 0049 c7c0 | 3801 0000 | 7407 49c7 | c048 0100 | 004a 8b34
+  0x00007f209d36a2bc: 0248 8d76 | 014a 8934 | 020f 841a
+
+  0x00007f209d36a2c8: ;   {metadata(method data for {method} {0x00007f203b0ecff0} 'isStatic' '(I)Z' in 'java/lang/reflect/Modifier')}
+  0x00007f209d36a2c8: 0000 0048 | ba20 1c0b | 3720 7f00 | 00ff 8258 | 0100 00ba | 0100 0000 | e905 0000 | 00ba 0000
+  0x00007f209d36a2e8: 0000 83e2
+
+  0x00007f209d36a2ec: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a2ec: 0185 d248 | ba58 f827 | 3720 7f00 | 0049 c7c0 | f001 0000 | 7407 49c7 | c000 0200 | 004a 8b34
+  0x00007f209d36a30c: 0248 8d76 | 014a 8934 | 020f 841f
+
+  0x00007f209d36a318: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a318: 0000 0048 | ba58 f827 | 3720 7f00 | 00ff 8210
+
+  0x00007f209d36a328: ;   {oop(nullptr)}
+  0x00007f209d36a328: 0200 0049 | b800 0000 | 0000 0000 | 00e9 3800 | 0000 488b | 9424 9800 | 0000 483b | 024c 8bc2
+  0x00007f209d36a348: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a348: 48be 58f8 | 2737 207f | 0000 4883 | 8628 0200 | 0001 448b | 4208 49ba | 0000 003b | 207f 0000
+  0x00007f209d36a368: 4d03 c24d | 8b40 704d | 8b00 488b
+
+  0x00007f209d36a374: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a374: f748 b858 | f827 3720 | 7f00 0048 | 8380 6002 | 0000 0148 | 8bd3 488b | f748 899c | 24c8 0000
+  0x00007f209d36a394: ;   {optimized virtual_call}
+  0x00007f209d36a394: 0066 90e8
+
+  0x00007f209d36a398: ; ImmutableOopMap {[152]=Oop [160]=Oop [168]=Oop [192]=Oop [200]=Oop }
+                      ;*invokevirtual checkAccess {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.reflect.Method::invoke@60 (line 571)
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@92 (line 728)
+  0x00007f209d36a398: e453 9f06
+
+  0x00007f209d36a39c: ;   {other}
+  0x00007f209d36a39c: 0f1f 8400 | 8c0c 0008 | 488b bc24 | c000 0000 | 8b77 4c48 | c1e6 0348
+
+  0x00007f209d36a3b4: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a3b4: 85f6 48bb | 58f8 2737 | 207f 0000 | 48c7 c098 | 0200 0075 | 0748 c7c0 | a802 0000 | 488b 1403
+  0x00007f209d36a3d4: 488d 5201 | 4889 1403 | 0f85 2d00 | 0000 488b
+
+  0x00007f209d36a3e4: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a3e4: f748 bb58 | f827 3720 | 7f00 0048 | 8383 b802 | 0000 0148 | 8bf7 0f1f
+
+  0x00007f209d36a3fc: ;   {optimized virtual_call}
+  0x00007f209d36a3fc: 4400 00e8
+
+  0x00007f209d36a400: ; ImmutableOopMap {[152]=Oop [160]=Oop [168]=Oop [200]=Oop }
+                      ;*invokevirtual acquireMethodAccessor {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.reflect.Method::invoke@75 (line 577)
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@92 (line 728)
+  0x00007f209d36a400: bcc6 1000
+
+  0x00007f209d36a404: ;   {other}
+  0x00007f209d36a404: 0f1f 8400 | f40c 0009 | 488b f08b | 8424 bc00 | 0000 85c0
+
+  0x00007f209d36a418: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a418: 48ba 58f8 | 2737 207f | 0000 48c7 | c1f0 0200 | 0074 0748 | c7c1 0003 | 0000 4c8b | 040a 4d8d
+  0x00007f209d36a438: 4001 4c89 | 040a 0f84 | dd00 0000 | 488b 9c24 | c800 0000
+
+  0x00007f209d36a44c: ; implicit exception: dispatches to 0x00007f209d36a896
+  0x00007f209d36a44c: 483b 0648
+
+  0x00007f209d36a450: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a450: 8bd6 48b9 | 58f8 2737 | 207f 0000 | 8b52 0849 | ba00 0000 | 3b20 7f00 | 0049 03d2 | 483b 9120
+  0x00007f209d36a470: 0300 0075 | 0d48 8381 | 2803 0000 | 01e9 6000 | 0000 483b | 9130 0300 | 0075 0d48 | 8381 3803
+  0x00007f209d36a490: 0000 01e9 | 4a00 0000 | 4883 b920 | 0300 0000 | 7517 4889 | 9120 0300 | 0048 c781 | 2803 0000
+  0x00007f209d36a4b0: 0100 0000 | e929 0000 | 0048 83b9 | 3003 0000 | 0075 1748 | 8991 3003 | 0000 48c7 | 8138 0300
+  0x00007f209d36a4d0: 0001 0000 | 00e9 0800 | 0000 4883 | 8110 0300 | 0001 488b | 9424 9800 | 0000 488b | 8c24 a000
+  0x00007f209d36a4f0: 0000 4c8b | c348 b8ff | ffff ffff
+
+  0x00007f209d36a4fc: ;   {virtual_call}
+  0x00007f209d36a4fc: ffff ffe8
+
+  0x00007f209d36a500: ; ImmutableOopMap {[168]=Oop }
+                      ;*invokeinterface invoke {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.reflect.Method::invoke@90 (line 580)
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@92 (line 728)
+  0x00007f209d36a500: 7c57 9f06
+
+  0x00007f209d36a504: ;   {other}
+  0x00007f209d36a504: 0f1f 8400 | f40d 000a
+
+  0x00007f209d36a50c: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a50c: 48ba 58f8 | 2737 207f | 0000 ff82 | 4803 0000 | e9c3 0000 | 0048 8b8c | 24a0 0000 | 0048 8b94
+  0x00007f209d36a52c: 2498 0000 | 0048 3b06
+
+  0x00007f209d36a534: ;   {metadata(method data for {method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a534: 488b fe48 | bb58 f827 | 3720 7f00 | 008b 7f08 | 49ba 0000 | 003b 207f | 0000 4903 | fa48 3bbb
+  0x00007f209d36a554: 7003 0000 | 750d 4883 | 8378 0300 | 0001 e960 | 0000 0048 | 3bbb 8003 | 0000 750d | 4883 8388
+  0x00007f209d36a574: 0300 0001 | e94a 0000 | 0048 83bb | 7003 0000 | 0075 1748 | 89bb 7003 | 0000 48c7 | 8378 0300
+  0x00007f209d36a594: 0001 0000 | 00e9 2900 | 0000 4883 | bb80 0300 | 0000 7517 | 4889 bb80 | 0300 0048 | c783 8803
+  0x00007f209d36a5b4: 0000 0100 | 0000 e908 | 0000 0048 | 8383 6003 | 0000 0166 | 0f1f 4400 | 0048 b890 | d019 3b20
+  0x00007f209d36a5d4: ;   {virtual_call}
+  0x00007f209d36a5d4: 7f00 00e8
+
+  0x00007f209d36a5d8: ; ImmutableOopMap {[168]=Oop }
+                      ;*invokeinterface invoke {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.reflect.Method::invoke@102 (line 580)
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@92 (line 728)
+  0x00007f209d36a5d8: 043b ccff
+
+  0x00007f209d36a5dc: ;   {other}
+  0x00007f209d36a5dc: 0f1f 8400 | cc0e 000b | 488b bc24 | a800 0000 | 817f 0ca3 | 0000 000f | 86a7 0200 | 00c6 87b3
+  0x00007f209d36a5fc: 0000 0001 | 4881 c4e0 | 0000 005d
+
+  0x00007f209d36a608: ;   {poll_return}
+  0x00007f209d36a608: 493b a748 | 0400 000f | 879d 0200 | 00c3 488b | bc24 a800 | 0000 498b | 87f8 0400 | 004d 33d2
+  0x00007f209d36a628: 4d89 97f8 | 0400 004d | 33d2 4d89 | 9700 0500 | 0081 7f0c | a400 0000 | 0f86 8202 | 0000 c687
+  0x00007f209d36a648: b400 0000
+
+  0x00007f209d36a64c: ;   {metadata(method data for {method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d36a64c: 0148 bef8 | 8f74 3720 | 7f00 0048 | 8386 9802 | 0000 0148 | 8bf0 0f1f
+
+  0x00007f209d36a664: ;   {static_call}
+  0x00007f209d36a664: 4400 00e8
+
+  0x00007f209d36a668: ; ImmutableOopMap {[168]=Oop }
+                      ;*invokestatic getUnderlyingCause {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@114 (line 731)
+  0x00007f209d36a668: 2403 0000
+
+  0x00007f209d36a66c: ;   {other}
+  0x00007f209d36a66c: 0f1f 8400 | 5c0f 000c
+
+  0x00007f209d36a674: ;   {static_call}
+  0x00007f209d36a674: 488b f0e8
+
+  0x00007f209d36a678: ; ImmutableOopMap {[168]=Oop }
+                      ;*invokestatic throwAsUncheckedException {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@117 (line 731)
+  0x00007f209d36a678: c902 0000
+
+  0x00007f209d36a67c: ;   {other}
+  0x00007f209d36a67c: 0f1f 8400 | 6c0f 000d | 488b b424 | a800 0000 | 817e 0ca5 | 0000 000f | 8641 0200 | 00c6 86b5
+  0x00007f209d36a69c: 0000 0001
+
+  0x00007f209d36a6a0: ; implicit exception: dispatches to 0x00007f209d36a8ec
+  0x00007f209d36a6a0: 483b 00e9 | 6602 0000
+
+  0x00007f209d36a6a8: ;   {metadata({method} {0x00007f2037699110} 'invokeMethod' '(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'org/junit/platform/commons/util/ReflectionUtils')}
+  0x00007f209d36a6a8: 49ba 1091 | 6937 207f | 0000 4c89 | 5424 0848 | c704 24ff
+
+  0x00007f209d36a6bc: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d36a6bc: ffff ffe8
+
+  0x00007f209d36a6c0: ; ImmutableOopMap {rsi=Oop rdx=Oop rcx=Oop [144]=Oop [152]=Oop }
+                      ;*synchronization entry
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@-1
+  0x00007f209d36a6c0: bc9e ac06 | e9cd f3ff
+
+  0x00007f209d36a6c8: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d36a6c8: ffe8 5217
+
+  0x00007f209d36a6cc: ; ImmutableOopMap {rax=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@19 (line 723)
+                      ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d36a6cc: ac06 e84d
+
+  0x00007f209d36a6d0: ; ImmutableOopMap {rax=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@19 (line 723)
+  0x00007f209d36a6d0: 17ac 0648 | c704 249d | 0000 0048 | 8944 2408
+
+  0x00007f209d36a6e0: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d36a6e0: e8bb 08ac
+
+  0x00007f209d36a6e4: ; ImmutableOopMap {rax=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@19 (line 723)
+  0x00007f209d36a6e4: 0648 c704 | 249e 0000 | 0048 8944
+
+  0x00007f209d36a6f0: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d36a6f0: 2408 e8a9
+
+  0x00007f209d36a6f4: ; ImmutableOopMap {rax=Oop rdx=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@30 (line 724)
+  0x00007f209d36a6f4: 08ac 0648 | c704 249f | 0000 0048 | 8944 2408
+
+  0x00007f209d36a704: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d36a704: e897 08ac
+
+  0x00007f209d36a708: ; ImmutableOopMap {rax=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@47 (line 724)
+  0x00007f209d36a708: 0648 c704 | 24a0 0000 | 0048 8944
+
+  0x00007f209d36a714: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d36a714: 2408 e885
+
+  0x00007f209d36a718: ; ImmutableOopMap {rax=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@55 (line 724)
+  0x00007f209d36a718: 08ac 0648 | c704 24a1 | 0000 0048 | 8944 2408
+
+  0x00007f209d36a728: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d36a728: e873 08ac
+
+  0x00007f209d36a72c: ; ImmutableOopMap {rax=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@66 (line 724)
+                      ;   {metadata({method} {0x00007f203b0b03c8} 'linkToTargetMethod' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/Invokers$Holder')}
+  0x00007f209d36a72c: 0649 bac8 | 030b 3b20 | 7f00 004c | 8954 2408 | 48c7 0424 | ffff ffff
+
+  0x00007f209d36a744: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d36a744: e837 9eac
+
+  0x00007f209d36a748: ; ImmutableOopMap {rsi=Oop rbx=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.Invokers$Holder::linkToTargetMethod@-1
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@68 (line 724)
+  0x00007f209d36a748: 06e9 85f5
+
+  0x00007f209d36a74c: ;   {metadata({method} {0x00007f203b0b65d8} 'newInvokeSpecial' '(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle$Holder')}
+  0x00007f209d36a74c: ffff 49ba | d865 0b3b | 207f 0000 | 4c89 5424 | 0848 c704 | 24ff ffff
+
+  0x00007f209d36a764: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d36a764: ffe8 169e
+
+  0x00007f209d36a768: ; ImmutableOopMap {rsi=Oop rbx=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.DirectMethodHandle$Holder::newInvokeSpecial@-1
+                      ; - java.lang.invoke.Invokers$Holder::linkToTargetMethod@5
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@68 (line 724)
+  0x00007f209d36a768: ac06 e9bd
+
+  0x00007f209d36a76c: ;   {metadata({method} {0x00007f203b0a2f58} 'allocateInstance' '(Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle')}
+  0x00007f209d36a76c: f5ff ff49 | ba58 2f0a | 3b20 7f00 | 004c 8954 | 2408 48c7 | 0424 ffff
+
+  0x00007f209d36a784: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d36a784: ffff e8f5
+
+  0x00007f209d36a788: ; ImmutableOopMap {rsi=Oop rbx=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.DirectMethodHandle::allocateInstance@-1 (line 500)
+                      ; - java.lang.invoke.DirectMethodHandle$Holder::newInvokeSpecial@1
+                      ; - java.lang.invoke.Invokers$Holder::linkToTargetMethod@5
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@68 (line 724)
+  0x00007f209d36a788: 9dac 06e9 | f7f5 ffff
+
+  0x00007f209d36a790: ;   {metadata({method} {0x00007f203b0a3a00} 'constructorMethod' '(Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/invoke/DirectMethodHandle')}
+  0x00007f209d36a790: 49ba 003a | 0a3b 207f | 0000 4c89 | 5424 0848 | c704 24ff
+
+  0x00007f209d36a7a4: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d36a7a4: ffff ffe8
+
+  0x00007f209d36a7a8: ; ImmutableOopMap {rax=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.invoke.DirectMethodHandle::constructorMethod@-1 (line 494)
+                      ; - java.lang.invoke.DirectMethodHandle$Holder::newInvokeSpecial@6
+                      ; - java.lang.invoke.Invokers$Holder::linkToTargetMethod@5
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@68 (line 724)
+  0x00007f209d36a7a8: d49d ac06 | e99e f6ff
+
+  0x00007f209d36a7b0: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d36a7b0: ffe8 6a16
+
+  0x00007f209d36a7b4: ; ImmutableOopMap {rax=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*invokestatic linkToSpecial {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.invoke.DirectMethodHandle$Holder::newInvokeSpecial@16
+                      ; - java.lang.invoke.Invokers$Holder::linkToTargetMethod@5
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@68 (line 724)
+                      ;   {metadata({method} {0x00007f2037915d38} '<init>' '(Ljava/lang/reflect/Method;)V' in 'org/junit/platform/commons/util/ReflectionUtils$$Lambda+0x00007f203c137b00')}
+  0x00007f209d36a7b4: ac06 49ba | 385d 9137 | 207f 0000 | 4c89 5424 | 0848 c704 | 24ff ffff
+
+  0x00007f209d36a7cc: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d36a7cc: ffe8 ae9d
+
+  0x00007f209d36a7d0: ; ImmutableOopMap {rax=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*synchronization entry
+                      ; - org.junit.platform.commons.util.ReflectionUtils$$Lambda/0x00007f203c137b00::<init>@-1
+                      ; - java.lang.invoke.DirectMethodHandle$Holder::newInvokeSpecial@16
+                      ; - java.lang.invoke.Invokers$Holder::linkToTargetMethod@5
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@68 (line 724)
+  0x00007f209d36a7d0: ac06 e9e1
+
+  0x00007f209d36a7d4: ;   {metadata({method} {0x00007f203b470b68} '<init>' '()V' in 'java/lang/Object')}
+  0x00007f209d36a7d4: f6ff ff49 | ba68 0b47 | 3b20 7f00 | 004c 8954 | 2408 48c7 | 0424 ffff
+
+  0x00007f209d36a7ec: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d36a7ec: ffff e88d
+
+  0x00007f209d36a7f0: ; ImmutableOopMap {rax=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.Object::<init>@-1 (line 45)
+                      ; - org.junit.platform.commons.util.ReflectionUtils$$Lambda/0x00007f203c137b00::<init>@1
+                      ; - java.lang.invoke.DirectMethodHandle$Holder::newInvokeSpecial@16
+                      ; - java.lang.invoke.Invokers$Holder::linkToTargetMethod@5
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@68 (line 724)
+  0x00007f209d36a7f0: 9dac 06e9 | fcf6 ffff | 8b70 0c48 | c1e6 0348 | 83fe 000f | 84f8 f6ff | ff48 8934
+
+  0x00007f209d36a80c: ;   {runtime_call g1_pre_barrier_slow}
+  0x00007f209d36a80c: 24e8 eea9 | ac06 e9ea | f6ff ff48 | 83fe 000f | 8407 f7ff | ff48 8904
+
+  0x00007f209d36a824: ;   {runtime_call g1_post_barrier_slow}
+  0x00007f209d36a824: 24e8 56ad | ac06 e9f9 | f6ff ff48 | c704 24a2 | 0000 0048 | 8944 2408
+
+  0x00007f209d36a83c: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d36a83c: e85f 07ac
+
+  0x00007f209d36a840: ; ImmutableOopMap {rsi=Oop rax=Oop [144]=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@82 (line 724)
+  0x00007f209d36a840: 0648 8904
+
+  0x00007f209d36a844: ;   {runtime_call throw_class_cast_exception Runtime1 stub}
+  0x00007f209d36a844: 24e8 564e
+
+  0x00007f209d36a848: ; ImmutableOopMap {[152]=Oop [160]=Oop [168]=Oop }
+                      ;*checkcast {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@87 (line 728)
+                      ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d36a848: ac06 e8d1
+
+  0x00007f209d36a84c: ; ImmutableOopMap {rdi=Oop [152]=Oop [160]=Oop [168]=Oop [192]=Oop }
+                      ;*invokevirtual invoke {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@92 (line 728)
+                      ;   {metadata({method} {0x00007f203b0448a0} 'invoke' '(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' in 'java/lang/reflect/Method')}
+  0x00007f209d36a84c: 15ac 0649 | baa0 4804 | 3b20 7f00 | 004c 8954 | 2408 48c7 | 0424 ffff
+
+  0x00007f209d36a864: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d36a864: ffff e815
+
+  0x00007f209d36a868: ; ImmutableOopMap {rdi=Oop [152]=Oop [160]=Oop [168]=Oop [192]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.reflect.Method::invoke@-1 (line 561)
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@92 (line 728)
+  0x00007f209d36a868: 9dac 06e9 | c5f8 ffff
+
+  0x00007f209d36a870: ;   {metadata({method} {0x00007f203b0ecff0} 'isStatic' '(I)Z' in 'java/lang/reflect/Modifier')}
+  0x00007f209d36a870: 49ba f0cf | 0e3b 207f | 0000 4c89 | 5424 0848 | c704 24ff
+
+  0x00007f209d36a884: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d36a884: ffff ffe8
+
+  0x00007f209d36a888: ; ImmutableOopMap {rbx=Oop rdi=Oop rcx=Oop [152]=Oop [160]=Oop [168]=Oop [192]=Oop }
+                      ;*synchronization entry
+                      ; - java.lang.reflect.Modifier::isStatic@-1 (line 98)
+                      ; - java.lang.reflect.Method::invoke@42 (line 572)
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@92 (line 728)
+  0x00007f209d36a888: f49c ac06 | e906 faff
+
+  0x00007f209d36a890: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d36a890: ffe8 8a15
+
+  0x00007f209d36a894: ; ImmutableOopMap {rbx=Oop rdi=Oop rcx=Oop rdx=Oop [152]=Oop [160]=Oop [168]=Oop [192]=Oop }
+                      ;*invokevirtual getClass {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.reflect.Method::invoke@53 (line 572)
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@92 (line 728)
+                      ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d36a894: ac06 e885
+
+  0x00007f209d36a898: ; ImmutableOopMap {rsi=Oop rbx=Oop [152]=Oop [160]=Oop [168]=Oop }
+                      ;*invokeinterface invoke {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.reflect.Method::invoke@90 (line 580)
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@92 (line 728)
+                      ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d36a898: 15ac 06e8
+
+  0x00007f209d36a89c: ; ImmutableOopMap {rdx=Oop rcx=Oop rsi=Oop [152]=Oop [168]=Oop }
+                      ;*invokeinterface invoke {reexecute=0 rethrow=0 return_oop=0}
+                      ; - java.lang.reflect.Method::invoke@102 (line 580)
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@92 (line 728)
+  0x00007f209d36a89c: 8015 ac06 | 48c7 0424 | a300 0000 | 4889 7c24
+
+  0x00007f209d36a8ac: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d36a8ac: 08e8 ee06
+
+  0x00007f209d36a8b0: ; ImmutableOopMap {rax=Oop rdi=Oop [168]=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@101 (line 728)
+                      ;   {internal_word}
+  0x00007f209d36a8b0: ac06 49ba | 08a6 369d | 207f 0000 | 4d89 9760
+
+  0x00007f209d36a8c0: ;   {runtime_call SafepointBlob}
+  0x00007f209d36a8c0: 0400 00e9 | 38cb 9f06 | 48c7 0424 | a400 0000 | 4889 7c24
+
+  0x00007f209d36a8d4: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d36a8d4: 08e8 c606
+
+  0x00007f209d36a8d8: ; ImmutableOopMap {rdi=Oop rax=Oop [168]=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@111 (line 730)
+  0x00007f209d36a8d8: ac06 48c7 | 0424 a500 | 0000 4889
+
+  0x00007f209d36a8e4: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d36a8e4: 7424 08e8
+
+  0x00007f209d36a8e8: ; ImmutableOopMap {rax=Oop rsi=Oop [168]=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.platform.commons.util.ReflectionUtils::invokeMethod@126 (line 731)
+  0x00007f209d36a8e8: b406 ac06
+
+  0x00007f209d36a8ec: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d36a8ec: e82f 15ac
+
+  0x00007f209d36a8f0: ; ImmutableOopMap {rax=Oop }
+                      ;*athrow {reexecute=1 rethrow=0 return_oop=0}
+                      ; - (reexecute) org.junit.platform.commons.util.ReflectionUtils::invokeMethod@127 (line 731)
+  0x00007f209d36a8f0: 0649 8b87 | f804 0000 | 49c7 87f8 | 0400 0000 | 0000 0049 | c787 0005 | 0000 0000 | 0000 4881
+  0x00007f209d36a910: c4e0 0000
+
+  0x00007f209d36a914: ;   {runtime_call unwind_exception Runtime1 stub}
+  0x00007f209d36a914: 005d e965 | 00ac 06f4 | f4f4 f4f4
+[Stub Code]
+  0x00007f209d36a920: ;   {no_reloc}
+  0x00007f209d36a920: 0f1f 4400
+
+  0x00007f209d36a924: ;   {static_stub}
+  0x00007f209d36a924: 0048 bb00 | 0000 0000
+
+  0x00007f209d36a92c: ;   {runtime_call nmethod}
+  0x00007f209d36a92c: 0000 00e9 | fbff ffff
+
+  0x00007f209d36a934: ;   {static_stub}
+  0x00007f209d36a934: 9048 bb00 | 0000 0000
+
+  0x00007f209d36a93c: ;   {runtime_call nmethod}
+  0x00007f209d36a93c: 0000 00e9 | fbff ffff
+
+  0x00007f209d36a944: ;   {static_stub}
+  0x00007f209d36a944: 9048 bb18 | c975 3720
+
+  0x00007f209d36a94c: ;   {runtime_call I2C/C2I adapters}
+  0x00007f209d36a94c: 7f00 00e9 | 2f9e 9f06
+
+  0x00007f209d36a954: ;   {static_stub}
+  0x00007f209d36a954: 48bb 0000 | 0000 0000
+
+  0x00007f209d36a95c: ;   {runtime_call nmethod}
+  0x00007f209d36a95c: 0000 e9fb
+
+  0x00007f209d36a960: ;   {static_stub}
+  0x00007f209d36a960: ffff ff48 | bb00 0000 | 0000 0000
+
+  0x00007f209d36a96c: ;   {runtime_call nmethod}
+  0x00007f209d36a96c: 00e9 fbff
+
+  0x00007f209d36a970: ;   {static_stub}
+  0x00007f209d36a970: ffff 48bb | 0000 0000 | 0000 0000
+
+  0x00007f209d36a97c: ;   {runtime_call nmethod}
+  0x00007f209d36a97c: e9fb ffff
+
+  0x00007f209d36a980: ;   {static_stub}
+  0x00007f209d36a980: ff48 bb18 | 4d04 3b20
+
+  0x00007f209d36a988: ;   {runtime_call I2C/C2I adapters}
+  0x00007f209d36a988: 7f00 00e9 | f39d 9f06
+
+  0x00007f209d36a990: ;   {static_stub}
+  0x00007f209d36a990: 48bb c8e0 | 6937 207f
+
+  0x00007f209d36a998: ;   {runtime_call I2C/C2I adapters}
+  0x00007f209d36a998: 0000 e9e4
+
+  0x00007f209d36a99c: ;   {static_stub}
+  0x00007f209d36a99c: 9d9f 0648 | bb00 0000 | 0000 0000
+
+  0x00007f209d36a9a8: ;   {runtime_call nmethod}
+  0x00007f209d36a9a8: 00e9 fbff
+
+  0x00007f209d36a9ac: ;   {static_stub}
+  0x00007f209d36a9ac: ffff 48bb | 0000 0000 | 0000 0000
+
+  0x00007f209d36a9b8: ;   {runtime_call nmethod}
+  0x00007f209d36a9b8: e9fb ffff
+
+  0x00007f209d36a9bc: ;   {static_stub}
+  0x00007f209d36a9bc: ff48 bb00 | 0000 0000
+
+  0x00007f209d36a9c4: ;   {runtime_call nmethod}
+  0x00007f209d36a9c4: 0000 00e9 | fbff ffff
+
+  0x00007f209d36a9cc: ;   {static_stub}
+  0x00007f209d36a9cc: 48bb 0000 | 0000 0000
+
+  0x00007f209d36a9d4: ;   {runtime_call nmethod}
+  0x00007f209d36a9d4: 0000 e9fb
+
+  0x00007f209d36a9d8: ;   {static_stub}
+  0x00007f209d36a9d8: ffff ff48 | bb00 0000 | 0000 0000
+
+  0x00007f209d36a9e4: ;   {runtime_call nmethod}
+  0x00007f209d36a9e4: 00e9 fbff
+
+  0x00007f209d36a9e8: ;   {static_stub}
+  0x00007f209d36a9e8: ffff 48bb | 0000 0000 | 0000 0000
+
+  0x00007f209d36a9f4: ;   {runtime_call nmethod}
+  0x00007f209d36a9f4: e9fb ffff
+
+  0x00007f209d36a9f8: ;   {runtime_call handle_exception_from_callee Runtime1 stub}
+  0x00007f209d36a9f8: ffe8 8246
+
+  0x00007f209d36a9fc: ;   {external_word}
+  0x00007f209d36a9fc: ac06 48bf | 390f 15bb | 207f 0000 | 4883 e4f0
+
+  0x00007f209d36aa0c: ;   {runtime_call MacroAssembler::debug64(char*, long, long*)}
+  0x00007f209d36aa0c: e82f f686
+
+  0x00007f209d36aa10: ;   {section_word}
+  0x00007f209d36aa10: 1df4 49ba | 12aa 369d | 207f 0000
+
+  0x00007f209d36aa1c: ;   {runtime_call DeoptimizationBlob}
+  0x00007f209d36aa1c: 4152 e97d | de9f 06f4 | f4f4 f4f4
+[/MachCode]
+
+
+Compiled method (c1) 9541 5993       3       org.junit.jupiter.engine.execution.MethodInvocation::proceed (28 bytes)
+ total in heap  [0x00007f209d4a5190,0x00007f209d4a5720] = 1424
+ relocation     [0x00007f209d4a52e8,0x00007f209d4a5350] = 104
+ main code      [0x00007f209d4a5360,0x00007f209d4a5598] = 568
+ stub code      [0x00007f209d4a5598,0x00007f209d4a55e0] = 72
+ oops           [0x00007f209d4a55e0,0x00007f209d4a55e8] = 8
+ metadata       [0x00007f209d4a55e8,0x00007f209d4a55f8] = 16
+ scopes data    [0x00007f209d4a55f8,0x00007f209d4a5658] = 96
+ scopes pcs     [0x00007f209d4a5658,0x00007f209d4a56f8] = 160
+ dependencies   [0x00007f209d4a56f8,0x00007f209d4a5700] = 8
+ nul chk table  [0x00007f209d4a5700,0x00007f209d4a5720] = 32
+
+[Constant Pool (empty)]
+
+[MachCode]
+[Entry Point]
+  # {method} {0x00007f2037f8bc40} 'proceed' '()Ljava/lang/Object;' in 'org/junit/jupiter/engine/execution/MethodInvocation'
+  #           [sp+0x70]  (sp of caller)
+  0x00007f209d4a5360: 448b 5608 | 49bb 0000 | 003b 207f | 0000 4d03 | d34c 3bd0
+
+  0x00007f209d4a5374: ;   {runtime_call ic_miss_stub}
+  0x00007f209d4a5374: 0f85 069f | 8b06 660f | 1f44 0000
+[Verified Entry Point]
+  0x00007f209d4a5380: 8984 2400 | c0fe ff55 | 4883 ec60 | 4181 7f20 | 0100 0000
+
+  0x00007f209d4a5394: ;   {runtime_call StubRoutines (final stubs)}
+  0x00007f209d4a5394: 7405 e885
+
+  0x00007f209d4a5398: ;   {metadata(method data for {method} {0x00007f2037f8bc40} 'proceed' '()Ljava/lang/Object;' in 'org/junit/jupiter/engine/execution/MethodInvocation')}
+  0x00007f209d4a5398: 1e8a 0648 | bf50 d324 | 3820 7f00 | 008b 9ff4 | 0000 0083 | c302 899f | f400 0000 | 81e3 fe07
+  0x00007f209d4a53b8: 0000 85db | 0f84 3001 | 0000 4889
+
+  0x00007f209d4a53c4: ;   {metadata(method data for {method} {0x00007f2037f8bc40} 'proceed' '()Ljava/lang/Object;' in 'org/junit/jupiter/engine/execution/MethodInvocation')}
+  0x00007f209d4a53c4: 7424 4848 | bf50 d324 | 3820 7f00 | 0048 8387 | 3801 0000 | 0166 0f1f
+
+  0x00007f209d4a53dc: ;   {static_call}
+  0x00007f209d4a53dc: 4400 00e8
+
+  0x00007f209d4a53e0: ; ImmutableOopMap {[72]=Oop }
+                      ;*invokestatic $jacocoInit {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.jupiter.engine.execution.MethodInvocation::proceed@0
+  0x00007f209d4a53e0: bc48 eaff
+
+  0x00007f209d4a53e4: ;   {other}
+  0x00007f209d4a53e4: 0f1f 8400 | 5402 0000 | 488b 7424 | 488b 560c | 48c1 e203 | 8b4e 1048 | c1e1 0348 | 3b01 488b
+  0x00007f209d4a5404: ;   {metadata(method data for {method} {0x00007f2037f8bc40} 'proceed' '()Ljava/lang/Object;' in 'org/junit/jupiter/engine/execution/MethodInvocation')}
+  0x00007f209d4a5404: f948 bb50 | d324 3820 | 7f00 0048 | 8383 4801
+
+  0x00007f209d4a5414: ;   {metadata(method data for {method} {0x00007f203b0e6ef8} 'orElse' '(Ljava/lang/Object;)Ljava/lang/Object;' in 'java/util/Optional')}
+  0x00007f209d4a5414: 0000 0148 | bf88 3a03 | 3720 7f00 | 008b 9ff4 | 0000 0083 | c302 899f | f400 0000 | 81e3 feff
+  0x00007f209d4a5434: 1f00 85db | 0f84 da00 | 0000 8b49 | 0c48 c1e1 | 0348 85c9
+
+  0x00007f209d4a5448: ;   {metadata(method data for {method} {0x00007f203b0e6ef8} 'orElse' '(Ljava/lang/Object;)Ljava/lang/Object;' in 'java/util/Optional')}
+  0x00007f209d4a5448: 48bf 883a | 0337 207f | 0000 48c7 | c338 0100 | 0074 0748 | c7c3 4801 | 0000 4c8b | 041f 4d8d
+  0x00007f209d4a5468: 4001 4c89 | 041f 0f84 | 1500 0000
+
+  0x00007f209d4a5474: ;   {metadata(method data for {method} {0x00007f203b0e6ef8} 'orElse' '(Ljava/lang/Object;)Ljava/lang/Object;' in 'java/util/Optional')}
+  0x00007f209d4a5474: 48bf 883a | 0337 207f | 0000 ff87 | 5801 0000 | e90a 0000
+
+  0x00007f209d4a5488: ;   {oop(nullptr)}
+  0x00007f209d4a5488: 0048 b900 | 0000 0000 | 0000 0048 | 8944 2450 | 8b7e 1448
+
+  0x00007f209d4a549c: ;   {metadata(method data for {method} {0x00007f2037f8bc40} 'proceed' '()Ljava/lang/Object;' in 'org/junit/jupiter/engine/execution/MethodInvocation')}
+  0x00007f209d4a549c: c1e7 0348 | be50 d324 | 3820 7f00 | 0048 8386 | 8001 0000 | 0148 8bf2 | 488b d148 | 8bcf 0f1f
+  0x00007f209d4a54bc: ;   {static_call}
+  0x00007f209d4a54bc: 4400 00e8
+
+  0x00007f209d4a54c0: ; ImmutableOopMap {[80]=Oop }
+                      ;*invokestatic invokeMethod {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.jupiter.engine.execution.MethodInvocation::proceed@20 (line 60)
+  0x00007f209d4a54c0: 7c45 ecff
+
+  0x00007f209d4a54c4: ;   {other}
+  0x00007f209d4a54c4: 0f1f 8400 | 3403 0001 | 488b 7424 | 5083 7e0c | 050f 8668 | 0000 00c6 | 4615 0148 | 83c4 605d
+  0x00007f209d4a54e4: ;   {poll_return}
+  0x00007f209d4a54e4: 493b a748 | 0400 000f | 8764 0000
+
+  0x00007f209d4a54f0: ;   {metadata({method} {0x00007f2037f8bc40} 'proceed' '()Ljava/lang/Object;' in 'org/junit/jupiter/engine/execution/MethodInvocation')}
+  0x00007f209d4a54f0: 00c3 49ba | 40bc f837 | 207f 0000 | 4c89 5424 | 0848 c704 | 24ff ffff
+
+  0x00007f209d4a5508: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d4a5508: ffe8 72f0
+
+  0x00007f209d4a550c: ; ImmutableOopMap {rsi=Oop }
+                      ;*synchronization entry
+                      ; - org.junit.jupiter.engine.execution.MethodInvocation::proceed@-1
+  0x00007f209d4a550c: 9806 e9af
+
+  0x00007f209d4a5510: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d4a5510: feff ffe8
+
+  0x00007f209d4a5514: ; ImmutableOopMap {rax=Oop rsi=Oop rdx=Oop rcx=Oop }
+                      ;*invokevirtual orElse {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.jupiter.engine.execution.MethodInvocation::proceed@13 (line 60)
+  0x00007f209d4a5514: 0869 9806
+
+  0x00007f209d4a5518: ;   {metadata({method} {0x00007f203b0e6ef8} 'orElse' '(Ljava/lang/Object;)Ljava/lang/Object;' in 'java/util/Optional')}
+  0x00007f209d4a5518: 49ba f86e | 0e3b 207f | 0000 4c89 | 5424 0848 | c704 24ff
+
+  0x00007f209d4a552c: ;   {runtime_call counter_overflow Runtime1 stub}
+  0x00007f209d4a552c: ffff ffe8
+
+  0x00007f209d4a5530: ; ImmutableOopMap {rax=Oop rsi=Oop rdx=Oop rcx=Oop }
+                      ;*synchronization entry
+                      ; - java.util.Optional::orElse@-1 (line 350)
+                      ; - org.junit.jupiter.engine.execution.MethodInvocation::proceed@13 (line 60)
+  0x00007f209d4a5530: 4cf0 9806 | e905 ffff
+
+  0x00007f209d4a5538: ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d4a5538: ffe8 e268
+
+  0x00007f209d4a553c: ; ImmutableOopMap {rax=Oop rsi=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.jupiter.engine.execution.MethodInvocation::proceed@26 (line 60)
+                      ;   {runtime_call throw_null_pointer_exception Runtime1 stub}
+  0x00007f209d4a553c: 9806 e8dd
+
+  0x00007f209d4a5540: ; ImmutableOopMap {rax=Oop rsi=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.jupiter.engine.execution.MethodInvocation::proceed@26 (line 60)
+  0x00007f209d4a5540: 6898 0648 | c704 2405 | 0000 0048 | 8974 2408
+
+  0x00007f209d4a5550: ;   {runtime_call throw_range_check_failed Runtime1 stub}
+  0x00007f209d4a5550: e84b 5a98
+
+  0x00007f209d4a5554: ; ImmutableOopMap {rax=Oop rsi=Oop }
+                      ;*bastore {reexecute=0 rethrow=0 return_oop=0}
+                      ; - org.junit.jupiter.engine.execution.MethodInvocation::proceed@26 (line 60)
+                      ;   {internal_word}
+  0x00007f209d4a5554: 0649 bae4 | 544a 9d20 | 7f00 004d | 8997 6004
+
+  0x00007f209d4a5564: ;   {runtime_call SafepointBlob}
+  0x00007f209d4a5564: 0000 e995 | 1e8c 0649 | 8b87 f804 | 0000 49c7 | 87f8 0400 | 0000 0000 | 0049 c787 | 0005 0000
+  0x00007f209d4a5584: 0000 0000 | 4883 c460
+
+  0x00007f209d4a558c: ;   {runtime_call unwind_exception Runtime1 stub}
+  0x00007f209d4a558c: 5de9 ee53 | 9806 f4f4 | f4f4 f4f4
+[Stub Code]
+  0x00007f209d4a5598: ;   {no_reloc}
+  0x00007f209d4a5598: 48bb 0000 | 0000 0000
+
+  0x00007f209d4a55a0: ;   {runtime_call nmethod}
+  0x00007f209d4a55a0: 0000 e9fb
+
+  0x00007f209d4a55a4: ;   {static_stub}
+  0x00007f209d4a55a4: ffff ff48 | bb00 0000 | 0000 0000
+
+  0x00007f209d4a55b0: ;   {runtime_call nmethod}
+  0x00007f209d4a55b0: 00e9 fbff
+
+  0x00007f209d4a55b4: ;   {runtime_call handle_exception_from_callee Runtime1 stub}
+  0x00007f209d4a55b4: ffff e8c5
+
+  0x00007f209d4a55b8: ;   {external_word}
+  0x00007f209d4a55b8: 9a98 0648 | bf39 0f15 | bb20 7f00 | 0048 83e4
+
+  0x00007f209d4a55c8: ;   {runtime_call MacroAssembler::debug64(char*, long, long*)}
+  0x00007f209d4a55c8: f0e8 724a
+
+  0x00007f209d4a55cc: ;   {section_word}
+  0x00007f209d4a55cc: 731d f449 | bacf 554a | 9d20 7f00
+
+  0x00007f209d4a55d8: ;   {runtime_call DeoptimizationBlob}
+  0x00007f209d4a55d8: 0041 52e9 | c032 8c06
+[/MachCode]
+
+
+---------------  P R O C E S S  ---------------
+
+Threads class SMR info:
+_java_thread_list=0x00007f20000d0840, length=14, elements={
+0x00007f20b402cd40, 0x00007f20b417af40, 0x00007f20b417c4a0, 0x00007f20b417dc20,
+0x00007f20b417f250, 0x00007f20b41807e0, 0x00007f20b4182390, 0x00007f20b4183a40,
+0x00007f20b4194770, 0x00007f2010076d90, 0x00007f20b4601860, 0x00007f20b4657530,
+0x00007f20b4670790, 0x00007f20b4a64510
+}
+
+Java Threads: ( => current thread )
+=>0x00007f20b402cd40 JavaThread "main"                              [_thread_in_native, id=17969, stack(0x00007f20b9e20000,0x00007f20b9f20000) (1024K)]
+  0x00007f20b417af40 JavaThread "Reference Handler"          daemon [_thread_blocked, id=17980, stack(0x00007f2088e14000,0x00007f2088f14000) (1024K)]
+  0x00007f20b417c4a0 JavaThread "Finalizer"                  daemon [_thread_blocked, id=17981, stack(0x00007f2088d13000,0x00007f2088e13000) (1024K)]
+  0x00007f20b417dc20 JavaThread "Signal Dispatcher"          daemon [_thread_blocked, id=17982, stack(0x00007f2088c12000,0x00007f2088d12000) (1024K)]
+  0x00007f20b417f250 JavaThread "Service Thread"             daemon [_thread_blocked, id=17983, stack(0x00007f2088b11000,0x00007f2088c11000) (1024K)]
+  0x00007f20b41807e0 JavaThread "Monitor Deflation Thread"   daemon [_thread_blocked, id=17984, stack(0x00007f2088a10000,0x00007f2088b10000) (1024K)]
+  0x00007f20b4182390 JavaThread "C2 CompilerThread0"         daemon [_thread_blocked, id=17985, stack(0x00007f208890f000,0x00007f2088a0f000) (1024K)]
+  0x00007f20b4183a40 JavaThread "C1 CompilerThread0"         daemon [_thread_blocked, id=17986, stack(0x00007f208880e000,0x00007f208890e000) (1024K)]
+  0x00007f20b4194770 JavaThread "Common-Cleaner"             daemon [_thread_blocked, id=17987, stack(0x00007f208870d000,0x00007f208880d000) (1024K)]
+  0x00007f2010076d90 JavaThread "C1 CompilerThread1"         daemon [_thread_blocked, id=17988, stack(0x00007f2088300000,0x00007f2088400000) (1024K)]
+  0x00007f20b4601860 JavaThread "Notification Thread"        daemon [_thread_blocked, id=17991, stack(0x00007f2036f00000,0x00007f2037000000) (1024K)]
+  0x00007f20b4657530 JavaThread "surefire-forkedjvm-stream-flusher" daemon [_thread_blocked, id=17992, stack(0x00007f2036b00000,0x00007f2036c00000) (1024K)]
+  0x00007f20b4670790 JavaThread "surefire-forkedjvm-command-thread" daemon [_thread_in_native, id=17993, stack(0x00007f2036700000,0x00007f2036800000) (1024K)]
+  0x00007f20b4a64510 JavaThread "jnr.ffi.util.ref.internal.Finalizer" daemon [_thread_blocked, id=18030, stack(0x00007f1fdf6b6000,0x00007f1fdf7b6000) (1024K)]
+Total: 14
+
+Other Threads:
+  0x00007f20b4171080 VMThread "VM Thread"                           [id=17979, stack(0x00007f2088f15000,0x00007f2089015000) (1024K)]
+  0x00007f20b415ecc0 WatcherThread "VM Periodic Task Thread"        [id=17978, stack(0x00007f2089016000,0x00007f2089116000) (1024K)]
+  0x00007f20b4093800 WorkerThread "GC Thread#0"                     [id=17972, stack(0x00007f2098348000,0x00007f2098448000) (1024K)]
+  0x00007f2030008bd0 WorkerThread "GC Thread#1"                     [id=17994, stack(0x00007f2036300000,0x00007f2036400000) (1024K)]
+  0x00007f2030009670 WorkerThread "GC Thread#2"                     [id=17995, stack(0x00007f2035f00000,0x00007f2036000000) (1024K)]
+  0x00007f203000a150 WorkerThread "GC Thread#3"                     [id=17996, stack(0x00007f2035b00000,0x00007f2035c00000) (1024K)]
+  0x00007f203000ac30 WorkerThread "GC Thread#4"                     [id=17997, stack(0x00007f2035700000,0x00007f2035800000) (1024K)]
+  0x00007f20300118f0 WorkerThread "GC Thread#5"                     [id=18021, stack(0x00007f1fdf4b4000,0x00007f1fdf5b4000) (1024K)]
+  0x00007f2030016ff0 WorkerThread "GC Thread#6"                     [id=18022, stack(0x00007f1fdf3b3000,0x00007f1fdf4b3000) (1024K)]
+  0x00007f2030017760 WorkerThread "GC Thread#7"                     [id=18023, stack(0x00007f1fdf2b2000,0x00007f1fdf3b2000) (1024K)]
+  0x00007f20300182a0 WorkerThread "GC Thread#8"                     [id=18024, stack(0x00007f1fdf1b1000,0x00007f1fdf2b1000) (1024K)]
+  0x00007f2030018de0 WorkerThread "GC Thread#9"                     [id=18025, stack(0x00007f1fdf0b0000,0x00007f1fdf1b0000) (1024K)]
+  0x00007f2030019920 WorkerThread "GC Thread#10"                    [id=18026, stack(0x00007f1fdefaf000,0x00007f1fdf0af000) (1024K)]
+  0x00007f2030010c10 WorkerThread "GC Thread#11"                    [id=18040, stack(0x00007f1fdf5b5000,0x00007f1fdf6b5000) (1024K)]
+  0x00007f203001adf0 WorkerThread "GC Thread#12"                    [id=18041, stack(0x00007f1fdeeae000,0x00007f1fdefae000) (1024K)]
+  0x00007f20b40a4170 ConcurrentGCThread "G1 Main Marker"            [id=17973, stack(0x00007f2098247000,0x00007f2098347000) (1024K)]
+  0x00007f20b40a5110 WorkerThread "G1 Conc#0"                       [id=17974, stack(0x00007f2098146000,0x00007f2098246000) (1024K)]
+  0x00007f20b414bea0 ConcurrentGCThread "G1 Refine#0"               [id=17976, stack(0x00007f20892f4000,0x00007f20893f4000) (1024K)]
+  0x00007f20b414ce50 ConcurrentGCThread "G1 Service"                [id=17977, stack(0x00007f20891f3000,0x00007f20892f3000) (1024K)]
+Total: 19
+
+Threads with active compile tasks:
+Total: 0
+
+VM state: not at safepoint (normal execution)
+
+VM Mutex/Monitor currently owned by a thread: None
+
+Heap address: 0x000000070cc00000, size: 3892 MB, Compressed Oops mode: Zero based, Oop shift amount: 3
+
+CDS archive(s) mapped at: [0x00007f203b000000-0x00007f203bc97000-0x00007f203bc97000), size 13201408, SharedBaseAddress: 0x00007f203b000000, ArchiveRelocationMode: 1.
+Compressed class space mapped at: 0x00007f203c000000-0x00007f207c000000, reserved size: 1073741824
+Narrow klass base: 0x00007f203b000000, Narrow klass shift: 0, Narrow klass range: 0x100000000
+
+GC Precious Log:
+ CardTable entry size: 512
+ Card Set container configuration: InlinePtr #cards 4 size 8 Array Of Cards #cards 16 size 48 Howl #buckets 8 coarsen threshold 3686 Howl Bitmap #cards 512 size 80 coarsen threshold 460 Card regions per heap region 1 cards per card region 4096
+ CPUs: 16 total, 16 available
+ Memory: 15564M
+ Large Page Support: Disabled
+ NUMA Support: Disabled
+ Compressed Oops: Enabled (Zero based)
+ Heap Region Size: 2M
+ Heap Min Capacity: 8M
+ Heap Initial Capacity: 244M
+ Heap Max Capacity: 3892M
+ Pre-touch: Disabled
+ Parallel Workers: 13
+ Concurrent Workers: 3
+ Concurrent Refinement Workers: 13
+ Periodic GC: Disabled
+
+Heap:
+ garbage-first heap   total 251904K, used 85506K [0x000000070cc00000, 0x0000000800000000)
+  region size 2048K, 11 young (22528K), 2 survivors (4096K)
+ Metaspace       used 20024K, committed 20800K, reserved 1114112K
+  class space    used 1788K, committed 2112K, reserved 1048576K
+
+Heap Regions: E=young(eden), S=young(survivor), O=old, HS=humongous(starts), HC=humongous(continues), CS=collection set, F=free, TAMS=top-at-mark-start, PB=parsable bottom
+|   0|0x000000070cc00000, 0x000000070ce00000, 0x000000070ce00000|100%|HS|  |TAMS 0x000000070cc00000| PB 0x000000070cc00000| Complete
+|   1|0x000000070ce00000, 0x000000070d000000, 0x000000070d000000|100%|HC|  |TAMS 0x000000070ce00000| PB 0x000000070ce00000| Complete
+|   2|0x000000070d000000, 0x000000070d200000, 0x000000070d200000|100%| O|  |TAMS 0x000000070d000000| PB 0x000000070d000000| Untracked
+|   3|0x000000070d200000, 0x000000070d400000, 0x000000070d400000|100%| O|  |TAMS 0x000000070d200000| PB 0x000000070d200000| Untracked
+|   4|0x000000070d400000, 0x000000070d600000, 0x000000070d600000|100%| O|  |TAMS 0x000000070d400000| PB 0x000000070d400000| Untracked
+|   5|0x000000070d600000, 0x000000070d6b1600, 0x000000070d800000| 34%| O|  |TAMS 0x000000070d600000| PB 0x000000070d600000| Untracked
+|   6|0x000000070d800000, 0x000000070da00000, 0x000000070da00000|100%|HS|  |TAMS 0x000000070d800000| PB 0x000000070d800000| Complete
+|   7|0x000000070da00000, 0x000000070dc00000, 0x000000070dc00000|100%|HC|  |TAMS 0x000000070da00000| PB 0x000000070da00000| Complete
+|   8|0x000000070dc00000, 0x000000070de00000, 0x000000070de00000|100%|HS|  |TAMS 0x000000070dc00000| PB 0x000000070dc00000| Complete
+|   9|0x000000070de00000, 0x000000070e000000, 0x000000070e000000|100%|HC|  |TAMS 0x000000070de00000| PB 0x000000070de00000| Complete
+|  10|0x000000070e000000, 0x000000070e200000, 0x000000070e200000|100%|HS|  |TAMS 0x000000070e000000| PB 0x000000070e000000| Complete
+|  11|0x000000070e200000, 0x000000070e400000, 0x000000070e400000|100%|HC|  |TAMS 0x000000070e200000| PB 0x000000070e200000| Complete
+|  12|0x000000070e400000, 0x000000070e600000, 0x000000070e600000|100%|HS|  |TAMS 0x000000070e400000| PB 0x000000070e400000| Complete
+|  13|0x000000070e600000, 0x000000070e800000, 0x000000070e800000|100%|HC|  |TAMS 0x000000070e600000| PB 0x000000070e600000| Complete
+|  14|0x000000070e800000, 0x000000070ea00000, 0x000000070ea00000|100%|HS|  |TAMS 0x000000070e800000| PB 0x000000070e800000| Complete
+|  15|0x000000070ea00000, 0x000000070ec00000, 0x000000070ec00000|100%|HC|  |TAMS 0x000000070ea00000| PB 0x000000070ea00000| Complete
+|  16|0x000000070ec00000, 0x000000070ee00000, 0x000000070ee00000|100%|HS|  |TAMS 0x000000070ec00000| PB 0x000000070ec00000| Complete
+|  17|0x000000070ee00000, 0x000000070f000000, 0x000000070f000000|100%|HC|  |TAMS 0x000000070ee00000| PB 0x000000070ee00000| Complete
+|  18|0x000000070f000000, 0x000000070f200000, 0x000000070f200000|100%|HS|  |TAMS 0x000000070f000000| PB 0x000000070f000000| Complete
+|  19|0x000000070f200000, 0x000000070f400000, 0x000000070f400000|100%|HC|  |TAMS 0x000000070f200000| PB 0x000000070f200000| Complete
+|  20|0x000000070f400000, 0x000000070f600000, 0x000000070f600000|100%|HS|  |TAMS 0x000000070f400000| PB 0x000000070f400000| Complete
+|  21|0x000000070f600000, 0x000000070f800000, 0x000000070f800000|100%|HC|  |TAMS 0x000000070f600000| PB 0x000000070f600000| Complete
+|  22|0x000000070f800000, 0x000000070fa00000, 0x000000070fa00000|100%|HS|  |TAMS 0x000000070f800000| PB 0x000000070f800000| Complete
+|  23|0x000000070fa00000, 0x000000070fc00000, 0x000000070fc00000|100%|HC|  |TAMS 0x000000070fa00000| PB 0x000000070fa00000| Complete
+|  24|0x000000070fc00000, 0x000000070fe00000, 0x000000070fe00000|100%|HS|  |TAMS 0x000000070fc00000| PB 0x000000070fc00000| Complete
+|  25|0x000000070fe00000, 0x0000000710000000, 0x0000000710000000|100%|HC|  |TAMS 0x000000070fe00000| PB 0x000000070fe00000| Complete
+|  26|0x0000000710000000, 0x0000000710200000, 0x0000000710200000|100%|HS|  |TAMS 0x0000000710000000| PB 0x0000000710000000| Complete
+|  27|0x0000000710200000, 0x0000000710400000, 0x0000000710400000|100%|HC|  |TAMS 0x0000000710200000| PB 0x0000000710200000| Complete
+|  28|0x0000000710400000, 0x0000000710600000, 0x0000000710600000|100%|HS|  |TAMS 0x0000000710400000| PB 0x0000000710400000| Complete
+|  29|0x0000000710600000, 0x0000000710800000, 0x0000000710800000|100%|HC|  |TAMS 0x0000000710600000| PB 0x0000000710600000| Complete
+|  30|0x0000000710800000, 0x0000000710a00000, 0x0000000710a00000|100%|HS|  |TAMS 0x0000000710800000| PB 0x0000000710800000| Complete
+|  31|0x0000000710a00000, 0x0000000710c00000, 0x0000000710c00000|100%|HC|  |TAMS 0x0000000710a00000| PB 0x0000000710a00000| Complete
+|  32|0x0000000710c00000, 0x0000000710c00000, 0x0000000710e00000|  0%| F|  |TAMS 0x0000000710c00000| PB 0x0000000710c00000| Untracked
+|  33|0x0000000710e00000, 0x0000000710e00000, 0x0000000711000000|  0%| F|  |TAMS 0x0000000710e00000| PB 0x0000000710e00000| Untracked
+|  34|0x0000000711000000, 0x0000000711000000, 0x0000000711200000|  0%| F|  |TAMS 0x0000000711000000| PB 0x0000000711000000| Untracked
+|  35|0x0000000711200000, 0x0000000711200000, 0x0000000711400000|  0%| F|  |TAMS 0x0000000711200000| PB 0x0000000711200000| Untracked
+|  36|0x0000000711400000, 0x0000000711400000, 0x0000000711600000|  0%| F|  |TAMS 0x0000000711400000| PB 0x0000000711400000| Untracked
+|  37|0x0000000711600000, 0x0000000711600000, 0x0000000711800000|  0%| F|  |TAMS 0x0000000711600000| PB 0x0000000711600000| Untracked
+|  38|0x0000000711800000, 0x0000000711800000, 0x0000000711a00000|  0%| F|  |TAMS 0x0000000711800000| PB 0x0000000711800000| Untracked
+|  39|0x0000000711a00000, 0x0000000711a00000, 0x0000000711c00000|  0%| F|  |TAMS 0x0000000711a00000| PB 0x0000000711a00000| Untracked
+|  40|0x0000000711c00000, 0x0000000711c00000, 0x0000000711e00000|  0%| F|  |TAMS 0x0000000711c00000| PB 0x0000000711c00000| Untracked
+|  41|0x0000000711e00000, 0x0000000711e00000, 0x0000000712000000|  0%| F|  |TAMS 0x0000000711e00000| PB 0x0000000711e00000| Untracked
+|  42|0x0000000712000000, 0x0000000712000000, 0x0000000712200000|  0%| F|  |TAMS 0x0000000712000000| PB 0x0000000712000000| Untracked
+|  43|0x0000000712200000, 0x0000000712200000, 0x0000000712400000|  0%| F|  |TAMS 0x0000000712200000| PB 0x0000000712200000| Untracked
+|  44|0x0000000712400000, 0x0000000712400000, 0x0000000712600000|  0%| F|  |TAMS 0x0000000712400000| PB 0x0000000712400000| Untracked
+|  45|0x0000000712600000, 0x0000000712600000, 0x0000000712800000|  0%| F|  |TAMS 0x0000000712600000| PB 0x0000000712600000| Untracked
+|  46|0x0000000712800000, 0x0000000712800000, 0x0000000712a00000|  0%| F|  |TAMS 0x0000000712800000| PB 0x0000000712800000| Untracked
+|  47|0x0000000712a00000, 0x0000000712a00000, 0x0000000712c00000|  0%| F|  |TAMS 0x0000000712a00000| PB 0x0000000712a00000| Untracked
+|  48|0x0000000712c00000, 0x0000000712c00000, 0x0000000712e00000|  0%| F|  |TAMS 0x0000000712c00000| PB 0x0000000712c00000| Untracked
+|  49|0x0000000712e00000, 0x0000000712e00000, 0x0000000713000000|  0%| F|  |TAMS 0x0000000712e00000| PB 0x0000000712e00000| Untracked
+|  50|0x0000000713000000, 0x0000000713000000, 0x0000000713200000|  0%| F|  |TAMS 0x0000000713000000| PB 0x0000000713000000| Untracked
+|  51|0x0000000713200000, 0x0000000713200000, 0x0000000713400000|  0%| F|  |TAMS 0x0000000713200000| PB 0x0000000713200000| Untracked
+|  52|0x0000000713400000, 0x0000000713400000, 0x0000000713600000|  0%| F|  |TAMS 0x0000000713400000| PB 0x0000000713400000| Untracked
+|  53|0x0000000713600000, 0x0000000713600000, 0x0000000713800000|  0%| F|  |TAMS 0x0000000713600000| PB 0x0000000713600000| Untracked
+|  54|0x0000000713800000, 0x0000000713800000, 0x0000000713a00000|  0%| F|  |TAMS 0x0000000713800000| PB 0x0000000713800000| Untracked
+|  55|0x0000000713a00000, 0x0000000713bc2dc0, 0x0000000713c00000| 88%| S|CS|TAMS 0x0000000713a00000| PB 0x0000000713a00000| Complete
+|  56|0x0000000713c00000, 0x0000000713e00000, 0x0000000713e00000|100%| S|CS|TAMS 0x0000000713c00000| PB 0x0000000713c00000| Complete
+|  57|0x0000000713e00000, 0x0000000713e00000, 0x0000000714000000|  0%| F|  |TAMS 0x0000000713e00000| PB 0x0000000713e00000| Untracked
+|  58|0x0000000714000000, 0x0000000714000000, 0x0000000714200000|  0%| F|  |TAMS 0x0000000714000000| PB 0x0000000714000000| Untracked
+|  59|0x0000000714200000, 0x0000000714200000, 0x0000000714400000|  0%| F|  |TAMS 0x0000000714200000| PB 0x0000000714200000| Untracked
+|  60|0x0000000714400000, 0x0000000714400000, 0x0000000714600000|  0%| F|  |TAMS 0x0000000714400000| PB 0x0000000714400000| Untracked
+|  61|0x0000000714600000, 0x0000000714600000, 0x0000000714800000|  0%| F|  |TAMS 0x0000000714600000| PB 0x0000000714600000| Untracked
+|  62|0x0000000714800000, 0x0000000714800000, 0x0000000714a00000|  0%| F|  |TAMS 0x0000000714800000| PB 0x0000000714800000| Untracked
+|  63|0x0000000714a00000, 0x0000000714a00000, 0x0000000714c00000|  0%| F|  |TAMS 0x0000000714a00000| PB 0x0000000714a00000| Untracked
+|  64|0x0000000714c00000, 0x0000000714c00000, 0x0000000714e00000|  0%| F|  |TAMS 0x0000000714c00000| PB 0x0000000714c00000| Untracked
+|  65|0x0000000714e00000, 0x0000000714e00000, 0x0000000715000000|  0%| F|  |TAMS 0x0000000714e00000| PB 0x0000000714e00000| Untracked
+|  66|0x0000000715000000, 0x0000000715000000, 0x0000000715200000|  0%| F|  |TAMS 0x0000000715000000| PB 0x0000000715000000| Untracked
+|  67|0x0000000715200000, 0x0000000715200000, 0x0000000715400000|  0%| F|  |TAMS 0x0000000715200000| PB 0x0000000715200000| Untracked
+|  68|0x0000000715400000, 0x0000000715400000, 0x0000000715600000|  0%| F|  |TAMS 0x0000000715400000| PB 0x0000000715400000| Untracked
+|  69|0x0000000715600000, 0x0000000715600000, 0x0000000715800000|  0%| F|  |TAMS 0x0000000715600000| PB 0x0000000715600000| Untracked
+|  70|0x0000000715800000, 0x0000000715800000, 0x0000000715a00000|  0%| F|  |TAMS 0x0000000715800000| PB 0x0000000715800000| Untracked
+|  71|0x0000000715a00000, 0x0000000715a00000, 0x0000000715c00000|  0%| F|  |TAMS 0x0000000715a00000| PB 0x0000000715a00000| Untracked
+|  72|0x0000000715c00000, 0x0000000715c00000, 0x0000000715e00000|  0%| F|  |TAMS 0x0000000715c00000| PB 0x0000000715c00000| Untracked
+|  73|0x0000000715e00000, 0x0000000715e00000, 0x0000000716000000|  0%| F|  |TAMS 0x0000000715e00000| PB 0x0000000715e00000| Untracked
+|  74|0x0000000716000000, 0x0000000716000000, 0x0000000716200000|  0%| F|  |TAMS 0x0000000716000000| PB 0x0000000716000000| Untracked
+|  75|0x0000000716200000, 0x0000000716200000, 0x0000000716400000|  0%| F|  |TAMS 0x0000000716200000| PB 0x0000000716200000| Untracked
+|  76|0x0000000716400000, 0x0000000716400000, 0x0000000716600000|  0%| F|  |TAMS 0x0000000716400000| PB 0x0000000716400000| Untracked
+|  77|0x0000000716600000, 0x0000000716600000, 0x0000000716800000|  0%| F|  |TAMS 0x0000000716600000| PB 0x0000000716600000| Untracked
+|  78|0x0000000716800000, 0x0000000716800000, 0x0000000716a00000|  0%| F|  |TAMS 0x0000000716800000| PB 0x0000000716800000| Untracked
+|  79|0x0000000716a00000, 0x0000000716a00000, 0x0000000716c00000|  0%| F|  |TAMS 0x0000000716a00000| PB 0x0000000716a00000| Untracked
+|  80|0x0000000716c00000, 0x0000000716c00000, 0x0000000716e00000|  0%| F|  |TAMS 0x0000000716c00000| PB 0x0000000716c00000| Untracked
+|  81|0x0000000716e00000, 0x0000000716e00000, 0x0000000717000000|  0%| F|  |TAMS 0x0000000716e00000| PB 0x0000000716e00000| Untracked
+|  82|0x0000000717000000, 0x0000000717000000, 0x0000000717200000|  0%| F|  |TAMS 0x0000000717000000| PB 0x0000000717000000| Untracked
+|  83|0x0000000717200000, 0x0000000717200000, 0x0000000717400000|  0%| F|  |TAMS 0x0000000717200000| PB 0x0000000717200000| Untracked
+|  84|0x0000000717400000, 0x0000000717400000, 0x0000000717600000|  0%| F|  |TAMS 0x0000000717400000| PB 0x0000000717400000| Untracked
+|  85|0x0000000717600000, 0x0000000717600000, 0x0000000717800000|  0%| F|  |TAMS 0x0000000717600000| PB 0x0000000717600000| Untracked
+|  86|0x0000000717800000, 0x0000000717800000, 0x0000000717a00000|  0%| F|  |TAMS 0x0000000717800000| PB 0x0000000717800000| Untracked
+|  87|0x0000000717a00000, 0x0000000717a00000, 0x0000000717c00000|  0%| F|  |TAMS 0x0000000717a00000| PB 0x0000000717a00000| Untracked
+|  88|0x0000000717c00000, 0x0000000717c00000, 0x0000000717e00000|  0%| F|  |TAMS 0x0000000717c00000| PB 0x0000000717c00000| Untracked
+|  89|0x0000000717e00000, 0x0000000717e00000, 0x0000000718000000|  0%| F|  |TAMS 0x0000000717e00000| PB 0x0000000717e00000| Untracked
+|  90|0x0000000718000000, 0x0000000718000000, 0x0000000718200000|  0%| F|  |TAMS 0x0000000718000000| PB 0x0000000718000000| Untracked
+|  91|0x0000000718200000, 0x0000000718200000, 0x0000000718400000|  0%| F|  |TAMS 0x0000000718200000| PB 0x0000000718200000| Untracked
+|  92|0x0000000718400000, 0x0000000718400000, 0x0000000718600000|  0%| F|  |TAMS 0x0000000718400000| PB 0x0000000718400000| Untracked
+|  93|0x0000000718600000, 0x0000000718600000, 0x0000000718800000|  0%| F|  |TAMS 0x0000000718600000| PB 0x0000000718600000| Untracked
+|  94|0x0000000718800000, 0x0000000718800000, 0x0000000718a00000|  0%| F|  |TAMS 0x0000000718800000| PB 0x0000000718800000| Untracked
+|  95|0x0000000718a00000, 0x0000000718a00000, 0x0000000718c00000|  0%| F|  |TAMS 0x0000000718a00000| PB 0x0000000718a00000| Untracked
+|  96|0x0000000718c00000, 0x0000000718c00000, 0x0000000718e00000|  0%| F|  |TAMS 0x0000000718c00000| PB 0x0000000718c00000| Untracked
+|  97|0x0000000718e00000, 0x0000000718e00000, 0x0000000719000000|  0%| F|  |TAMS 0x0000000718e00000| PB 0x0000000718e00000| Untracked
+|  98|0x0000000719000000, 0x0000000719000000, 0x0000000719200000|  0%| F|  |TAMS 0x0000000719000000| PB 0x0000000719000000| Untracked
+|  99|0x0000000719200000, 0x0000000719200000, 0x0000000719400000|  0%| F|  |TAMS 0x0000000719200000| PB 0x0000000719200000| Untracked
+| 100|0x0000000719400000, 0x0000000719400000, 0x0000000719600000|  0%| F|  |TAMS 0x0000000719400000| PB 0x0000000719400000| Untracked
+| 101|0x0000000719600000, 0x0000000719600000, 0x0000000719800000|  0%| F|  |TAMS 0x0000000719600000| PB 0x0000000719600000| Untracked
+| 102|0x0000000719800000, 0x0000000719800000, 0x0000000719a00000|  0%| F|  |TAMS 0x0000000719800000| PB 0x0000000719800000| Untracked
+| 103|0x0000000719a00000, 0x0000000719a00000, 0x0000000719c00000|  0%| F|  |TAMS 0x0000000719a00000| PB 0x0000000719a00000| Untracked
+| 104|0x0000000719c00000, 0x0000000719c00000, 0x0000000719e00000|  0%| F|  |TAMS 0x0000000719c00000| PB 0x0000000719c00000| Untracked
+| 105|0x0000000719e00000, 0x0000000719e00000, 0x000000071a000000|  0%| F|  |TAMS 0x0000000719e00000| PB 0x0000000719e00000| Untracked
+| 106|0x000000071a000000, 0x000000071a000000, 0x000000071a200000|  0%| F|  |TAMS 0x000000071a000000| PB 0x000000071a000000| Untracked
+| 107|0x000000071a200000, 0x000000071a200000, 0x000000071a400000|  0%| F|  |TAMS 0x000000071a200000| PB 0x000000071a200000| Untracked
+| 108|0x000000071a400000, 0x000000071a400000, 0x000000071a600000|  0%| F|  |TAMS 0x000000071a400000| PB 0x000000071a400000| Untracked
+| 109|0x000000071a600000, 0x000000071a600000, 0x000000071a800000|  0%| F|  |TAMS 0x000000071a600000| PB 0x000000071a600000| Untracked
+| 110|0x000000071a800000, 0x000000071a800000, 0x000000071aa00000|  0%| F|  |TAMS 0x000000071a800000| PB 0x000000071a800000| Untracked
+| 111|0x000000071aa00000, 0x000000071aa00000, 0x000000071ac00000|  0%| F|  |TAMS 0x000000071aa00000| PB 0x000000071aa00000| Untracked
+| 112|0x000000071ac00000, 0x000000071ac00000, 0x000000071ae00000|  0%| F|  |TAMS 0x000000071ac00000| PB 0x000000071ac00000| Untracked
+| 113|0x000000071ae00000, 0x000000071af00000, 0x000000071b000000| 50%| E|  |TAMS 0x000000071ae00000| PB 0x000000071ae00000| Complete
+| 114|0x000000071b000000, 0x000000071b200000, 0x000000071b200000|100%| E|CS|TAMS 0x000000071b000000| PB 0x000000071b000000| Complete
+| 115|0x000000071b200000, 0x000000071b400000, 0x000000071b400000|100%| E|CS|TAMS 0x000000071b200000| PB 0x000000071b200000| Complete
+| 116|0x000000071b400000, 0x000000071b600000, 0x000000071b600000|100%| E|CS|TAMS 0x000000071b400000| PB 0x000000071b400000| Complete
+| 117|0x000000071b600000, 0x000000071b800000, 0x000000071b800000|100%| E|CS|TAMS 0x000000071b600000| PB 0x000000071b600000| Complete
+| 118|0x000000071b800000, 0x000000071ba00000, 0x000000071ba00000|100%| E|CS|TAMS 0x000000071b800000| PB 0x000000071b800000| Complete
+| 119|0x000000071ba00000, 0x000000071bc00000, 0x000000071bc00000|100%| E|CS|TAMS 0x000000071ba00000| PB 0x000000071ba00000| Complete
+| 120|0x000000071bc00000, 0x000000071be00000, 0x000000071be00000|100%| E|CS|TAMS 0x000000071bc00000| PB 0x000000071bc00000| Complete
+| 121|0x000000071be00000, 0x000000071c000000, 0x000000071c000000|100%| E|CS|TAMS 0x000000071be00000| PB 0x000000071be00000| Complete
+|1945|0x00000007ffe00000, 0x00000007fff0c670, 0x0000000800000000| 52%| O|  |TAMS 0x00000007ffe00000| PB 0x00000007ffe00000| Untracked
+
+Card table byte_map: [0x00007f209c118000,0x00007f209c8b2000] _byte_map_base: 0x00007f20988b2000
+
+Marking Bits: (CMBitMap*) 0x00007f20b4094320
+ Bits: [0x00007f2098448000, 0x00007f209c118000)
+
+Polling page: 0x00007f20bbc4d000
+
+Metaspace:
+
+Usage:
+  Non-class:     17.81 MB used.
+      Class:      1.75 MB used.
+       Both:     19.56 MB used.
+
+Virtual space:
+  Non-class space:       64.00 MB reserved,      18.25 MB ( 29%) committed,  1 nodes.
+      Class space:        1.00 GB reserved,       2.06 MB ( <1%) committed,  1 nodes.
+             Both:        1.06 GB reserved,      20.31 MB (  2%) committed.
+
+Chunk freelists:
+   Non-Class:  13.04 MB
+       Class:  13.89 MB
+        Both:  26.93 MB
+
+MaxMetaspaceSize: unlimited
+CompressedClassSpaceSize: 1.00 GB
+Initial GC threshold: 21.00 MB
+Current GC threshold: 21.00 MB
+CDS: on
+ - commit_granule_bytes: 65536.
+ - commit_granule_words: 8192.
+ - virtual_space_node_default_size: 8388608.
+ - enlarge_chunks_in_place: 1.
+ - use_allocation_guard: 0.
+
+
+Internal statistics:
+
+num_allocs_failed_limit: 0.
+num_arena_births: 1084.
+num_arena_deaths: 0.
+num_vsnodes_births: 2.
+num_vsnodes_deaths: 0.
+num_space_committed: 320.
+num_space_uncommitted: 0.
+num_chunks_returned_to_freelist: 0.
+num_chunks_taken_from_freelist: 1801.
+num_chunk_merges: 0.
+num_chunk_splits: 1195.
+num_chunks_enlarged: 734.
+num_inconsistent_stats: 0.
+
+CodeHeap 'non-profiled nmethods': size=119168Kb used=4176Kb max_used=4176Kb free=114991Kb
+ bounds [0x00007f20a4452000, 0x00007f20a4872000, 0x00007f20ab8b2000]
+CodeHeap 'profiled nmethods': size=119164Kb used=12644Kb max_used=12644Kb free=106519Kb
+ bounds [0x00007f209c8b2000, 0x00007f209d512000, 0x00007f20a3d11000]
+CodeHeap 'non-nmethods': size=7428Kb used=2430Kb max_used=3584Kb free=4997Kb
+ bounds [0x00007f20a3d11000, 0x00007f20a40a1000, 0x00007f20a4452000]
+ total_blobs=7033 nmethods=6295 adapters=641
+ compilation: enabled
+              stopped_count=0, restarted_count=0
+ full_count=0
+
+Compilation events (20 events):
+Event: 4.301 Thread 0x00007f20100a2c00 nmethod 6278 0x00007f20a485c190 code [0x00007f20a485c300, 0x00007f20a485c3a0]
+Event: 4.301 Thread 0x00007f20b4183a40 6279       3       org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService$$Lambda/0x00007f203c11f780::accept (10 bytes)
+Event: 4.301 Thread 0x00007f20b4183a40 nmethod 6279 0x00007f209d502990 code [0x00007f209d502b40, 0x00007f209d502dd8]
+Event: 4.301 Thread 0x00007f20b4183a40 6280       3       java.lang.invoke.MethodHandles$Lookup::findVirtual (91 bytes)
+Event: 4.302 Thread 0x00007f200813b980 6281       3       org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda/0x00007f203c1134f0::run (4 bytes)
+Event: 4.302 Thread 0x00007f200800ba10 6282       3       org.junit.platform.engine.support.hierarchical.NodeTestTask::lambda$static$0 (10 bytes)
+Event: 4.302 Thread 0x00007f200813b980 nmethod 6281 0x00007f209d502f10 code [0x00007f209d5030c0, 0x00007f209d5031f8]
+Event: 4.302 Thread 0x00007f200800ba10 nmethod 6282 0x00007f209d503290 code [0x00007f209d503440, 0x00007f209d503580]
+Event: 4.302 Thread 0x00007f1fd82fa1b0 nmethod 6258 0x00007f20a485c490 code [0x00007f20a485c740, 0x00007f20a485e518]
+Event: 4.302 Thread 0x00007f20b4183a40 nmethod 6280 0x00007f209d503690 code [0x00007f209d503940, 0x00007f209d504498]
+Event: 4.303 Thread 0x00007f1fd82fa1b0 6286       4       jdk.internal.org.objectweb.asm.Frame::push (59 bytes)
+Event: 4.304 Thread 0x00007f200813b980 6287       3       java.lang.invoke.BoundMethodHandle$Species_LL::copyWithExtendL (25 bytes)
+Event: 4.304 Thread 0x00007f200813b980 nmethod 6287 0x00007f209d504990 code [0x00007f209d504b60, 0x00007f209d504fd8]
+Event: 4.305 Thread 0x00007f20b4183a40 6288       3       org.junit.platform.commons.util.ReflectionUtils::tryToLoadClass (104 bytes)
+Event: 4.305 Thread 0x00007f200813b980 6289       3       java.lang.invoke.LambdaFormEditor::filterReturnForm (383 bytes)
+Event: 4.305 Thread 0x00007f20b4183a40 nmethod 6288 0x00007f209d505110 code [0x00007f209d505400, 0x00007f209d5062d0]
+Event: 4.306 Thread 0x00007f200813b980 nmethod 6289 0x00007f209d506890 code [0x00007f209d506d00, 0x00007f209d508c30]
+Event: 4.307 Thread 0x00007f20b4183a40 6290       3       org.junit.platform.engine.support.hierarchical.Node::after (9 bytes)
+Event: 4.307 Thread 0x00007f20b4183a40 nmethod 6290 0x00007f209d509b10 code [0x00007f209d509cc0, 0x00007f209d509e20]
+Event: 4.308 Thread 0x00007f1fd82fa1b0 nmethod 6286 0x00007f20a485f990 code [0x00007f20a485fbc0, 0x00007f20a4860538]
+
+GC Heap History (8 events):
+Event: 0.488 GC heap before
+{Heap before GC invocations=0 (full 0):
+ garbage-first heap   total 251904K, used 23601K [0x000000070cc00000, 0x0000000800000000)
+  region size 2048K, 11 young (22528K), 0 survivors (0K)
+ Metaspace       used 3659K, committed 3776K, reserved 1114112K
+  class space    used 326K, committed 384K, reserved 1048576K
+}
+Event: 0.492 GC heap after
+{Heap after GC invocations=1 (full 0):
+ garbage-first heap   total 251904K, used 4369K [0x000000070cc00000, 0x0000000800000000)
+  region size 2048K, 2 young (4096K), 2 survivors (4096K)
+ Metaspace       used 3659K, committed 3776K, reserved 1114112K
+  class space    used 326K, committed 384K, reserved 1048576K
+}
+Event: 1.260 GC heap before
+{Heap before GC invocations=1 (full 0):
+ garbage-first heap   total 251904K, used 59665K [0x000000070cc00000, 0x0000000800000000)
+  region size 2048K, 29 young (59392K), 2 survivors (4096K)
+ Metaspace       used 7653K, committed 7808K, reserved 1114112K
+  class space    used 731K, committed 832K, reserved 1048576K
+}
+Event: 1.264 GC heap after
+{Heap after GC invocations=2 (full 0):
+ garbage-first heap   total 251904K, used 5420K [0x000000070cc00000, 0x0000000800000000)
+  region size 2048K, 3 young (6144K), 3 survivors (6144K)
+ Metaspace       used 7653K, committed 7808K, reserved 1114112K
+  class space    used 731K, committed 832K, reserved 1048576K
+}
+Event: 2.659 GC heap before
+{Heap before GC invocations=2 (full 0):
+ garbage-first heap   total 251904K, used 148780K [0x000000070cc00000, 0x0000000800000000)
+  region size 2048K, 73 young (149504K), 3 survivors (6144K)
+ Metaspace       used 14266K, committed 14464K, reserved 1114112K
+  class space    used 1271K, committed 1344K, reserved 1048576K
+}
+Event: 2.669 GC heap after
+{Heap after GC invocations=3 (full 0):
+ garbage-first heap   total 251904K, used 17457K [0x000000070cc00000, 0x0000000800000000)
+  region size 2048K, 8 young (16384K), 8 survivors (16384K)
+ Metaspace       used 14266K, committed 14464K, reserved 1114112K
+  class space    used 1271K, committed 1344K, reserved 1048576K
+}
+Event: 4.172 GC heap before
+{Heap before GC invocations=3 (full 0):
+ garbage-first heap   total 251904K, used 154673K [0x000000070cc00000, 0x0000000800000000)
+  region size 2048K, 73 young (149504K), 8 survivors (16384K)
+ Metaspace       used 19686K, committed 20416K, reserved 1114112K
+  class space    used 1732K, committed 2048K, reserved 1048576K
+}
+Event: 4.179 GC heap after
+{Heap after GC invocations=4 (full 0):
+ garbage-first heap   total 251904K, used 15874K [0x000000070cc00000, 0x0000000800000000)
+  region size 2048K, 2 young (4096K), 2 survivors (4096K)
+ Metaspace       used 19686K, committed 20416K, reserved 1114112K
+  class space    used 1732K, committed 2048K, reserved 1048576K
+}
+
+Dll operation events (12 events):
+Event: 0.005 Loaded shared library /usr/lib/jvm/java-21-amazon-corretto/lib/libjava.so
+Event: 0.028 Loaded shared library /usr/lib/jvm/java-21-amazon-corretto/lib/libjsvml.so
+Event: 0.054 Loaded shared library /usr/lib/jvm/java-21-amazon-corretto/lib/libzip.so
+Event: 0.059 Loaded shared library /usr/lib/jvm/java-21-amazon-corretto/lib/libinstrument.so
+Event: 0.062 Loaded shared library /usr/lib/jvm/java-21-amazon-corretto/lib/libnio.so
+Event: 0.066 Loaded shared library /usr/lib/jvm/java-21-amazon-corretto/lib/libzip.so
+Event: 0.163 Loaded shared library /usr/lib/jvm/java-21-amazon-corretto/lib/libverify.so
+Event: 0.186 Loaded shared library /usr/lib/jvm/java-21-amazon-corretto/lib/libnet.so
+Event: 0.188 Loaded shared library /usr/lib/jvm/java-21-amazon-corretto/lib/libjimage.so
+Event: 0.416 Loaded shared library /usr/lib/jvm/java-21-amazon-corretto/lib/libmanagement.so
+Event: 0.425 Loaded shared library /usr/lib/jvm/java-21-amazon-corretto/lib/libmanagement_ext.so
+Event: 1.903 Loaded shared library /tmp/jffi5633389435295216473.so
+
+Deoptimization events (20 events):
+Event: 4.257 Thread 0x00007f20b402cd40 Uncommon trap: trap_request=0xffffff45 fr.pc=0x00007f20a47cfadc relative=0x00000000000000bc
+Event: 4.257 Thread 0x00007f20b402cd40 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00007f20a47cfadc method=java.lang.invoke.LambdaForm$BasicType.basicType(C)Ljava/lang/invoke/LambdaForm$BasicType; @ 1 c2
+Event: 4.257 Thread 0x00007f20b402cd40 DEOPT PACKING pc=0x00007f20a47cfadc sp=0x00007f20b9f19550
+Event: 4.257 Thread 0x00007f20b402cd40 DEOPT UNPACKING pc=0x00007f20a3d68619 sp=0x00007f20b9f194a0 mode 2
+Event: 4.258 Thread 0x00007f20b402cd40 Uncommon trap: trap_request=0xffffff45 fr.pc=0x00007f20a480840c relative=0x0000000000000fcc
+Event: 4.258 Thread 0x00007f20b402cd40 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00007f20a480840c method=java.lang.invoke.LambdaForm$BasicType.basicType(C)Ljava/lang/invoke/LambdaForm$BasicType; @ 1 c2
+Event: 4.258 Thread 0x00007f20b402cd40 DEOPT PACKING pc=0x00007f20a480840c sp=0x00007f20b9f19750
+Event: 4.258 Thread 0x00007f20b402cd40 DEOPT UNPACKING pc=0x00007f20a3d68619 sp=0x00007f20b9f19550 mode 2
+Event: 4.259 Thread 0x00007f20b402cd40 Uncommon trap: trap_request=0xffffff45 fr.pc=0x00007f20a4810b40 relative=0x0000000000000220
+Event: 4.259 Thread 0x00007f20b402cd40 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00007f20a4810b40 method=java.lang.invoke.LambdaForm.useCount(Ljava/lang/invoke/LambdaForm$Name;)I @ 8 c2
+Event: 4.259 Thread 0x00007f20b402cd40 DEOPT PACKING pc=0x00007f20a4810b40 sp=0x00007f20b9f19300
+Event: 4.259 Thread 0x00007f20b402cd40 DEOPT UNPACKING pc=0x00007f20a3d68619 sp=0x00007f20b9f192b8 mode 2
+Event: 4.259 Thread 0x00007f20b402cd40 Uncommon trap: trap_request=0xffffff45 fr.pc=0x00007f20a47c4ed8 relative=0x0000000000000138
+Event: 4.259 Thread 0x00007f20b402cd40 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00007f20a47c4ed8 method=jdk.internal.org.objectweb.asm.ByteVector.putInt(I)Ljdk/internal/org/objectweb/asm/ByteVector; @ 13 c2
+Event: 4.259 Thread 0x00007f20b402cd40 DEOPT PACKING pc=0x00007f20a47c4ed8 sp=0x00007f20b9f194d0
+Event: 4.259 Thread 0x00007f20b402cd40 DEOPT UNPACKING pc=0x00007f20a3d68619 sp=0x00007f20b9f19488 mode 2
+Event: 4.262 Thread 0x00007f20b402cd40 Uncommon trap: trap_request=0xffffff45 fr.pc=0x00007f20a451e9b0 relative=0x0000000000000110
+Event: 4.262 Thread 0x00007f20b402cd40 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00007f20a451e9b0 method=jdk.internal.org.objectweb.asm.ByteVector.putShort(I)Ljdk/internal/org/objectweb/asm/ByteVector; @ 13 c2
+Event: 4.262 Thread 0x00007f20b402cd40 DEOPT PACKING pc=0x00007f20a451e9b0 sp=0x00007f20b9f19300
+Event: 4.262 Thread 0x00007f20b402cd40 DEOPT UNPACKING pc=0x00007f20a3d68619 sp=0x00007f20b9f192a8 mode 2
+
+Classes loaded (20 events):
+Event: 4.255 Loading class java/lang/invoke/DirectMethodHandle$1
+Event: 4.255 Loading class java/lang/invoke/DirectMethodHandle$1 done
+Event: 4.255 Loading class java/util/ReverseOrderListView
+Event: 4.256 Loading class java/util/ReverseOrderListView done
+Event: 4.256 Loading class java/util/ReverseOrderListView$Rand
+Event: 4.256 Loading class java/util/ReverseOrderListView$Rand done
+Event: 4.256 Loading class java/util/ImmutableCollections$SubList
+Event: 4.256 Loading class java/util/ImmutableCollections$SubList done
+Event: 4.257 Loading class java/lang/invoke/MethodHandleImpl$Makers
+Event: 4.257 Loading class java/lang/invoke/MethodHandleImpl$Makers done
+Event: 4.257 Loading class java/lang/invoke/MethodHandleImpl$Makers$1
+Event: 4.257 Loading class java/lang/invoke/MethodHandleImpl$Makers$1 done
+Event: 4.257 Loading class java/lang/invoke/MethodHandleImpl$Makers$2
+Event: 4.257 Loading class java/lang/invoke/MethodHandleImpl$Makers$2 done
+Event: 4.257 Loading class java/lang/invoke/MethodHandleImpl$Makers$3
+Event: 4.257 Loading class java/lang/invoke/MethodHandleImpl$Makers$3 done
+Event: 4.257 Loading class java/lang/invoke/MethodHandleImpl$CountingWrapper
+Event: 4.257 Loading class java/lang/invoke/MethodHandleImpl$CountingWrapper done
+Event: 4.259 Loading class java/lang/invoke/MethodHandleImpl$TableSwitchCacheKey
+Event: 4.259 Loading class java/lang/invoke/MethodHandleImpl$TableSwitchCacheKey done
+
+Classes unloaded (0 events):
+No events
+
+Classes redefined (0 events):
+No events
+
+Internal exceptions (20 events):
+Event: 3.873 Thread 0x00007f20b402cd40 Exception <a 'java/lang/ClassCastException'{0x0000000716752bc0}: class jnr.ffi.provider.jffi.NativeRuntime cannot be cast to class jnr.ffi.provider.LoadedLibrary (jnr.ffi.provider.jffi.NativeRuntime and jnr.ffi.provider.LoadedLibrary are in unnamed module of loader 'app')> (0x0000000716752bc0)
+thrown [src/hotspot/share/interpreter/interpreterRuntime.cpp, line 455]
+Event: 3.873 Thread 0x00007f20b402cd40 Exception <a 'java/lang/ClassCastException'{0x000000071678a5f0}: class jnr.ffi.provider.jffi.NativeRuntime cannot be cast to class jnr.ffi.provider.LoadedLibrary (jnr.ffi.provider.jffi.NativeRuntime and jnr.ffi.provider.LoadedLibrary are in unnamed module of loader 'app')> (0x000000071678a5f0)
+thrown [src/hotspot/share/interpreter/interpreterRuntime.cpp, line 455]
+Event: 4.039 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x00000007155f1d38}: 'void java.lang.invoke.DelegatingMethodHandle$Holder.reinvoke_L(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, int, int)'> (0x00000007155f1d38)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.080 Thread 0x00007f20b402cd40 Implicit null exception at 0x00007f20a484038a to 0x00007f20a484044c
+Event: 4.254 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b6039f8}: 'java.lang.Object java.lang.invoke.DirectMethodHandle$Holder.invokeStaticInit(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)'> (0x000000071b6039f8)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.254 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b608150}: 'int java.lang.invoke.DirectMethodHandle$Holder.invokeSpecial(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)'> (0x000000071b608150)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.254 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b60ef80}: 'int java.lang.invoke.DirectMethodHandle$Holder.invokeStaticInit(java.lang.Object, java.lang.Object, java.lang.Object)'> (0x000000071b60ef80)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.254 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b616858}: 'int java.lang.invoke.DirectMethodHandle$Holder.invokeStaticInit(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)'> (0x000000071b616858)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.255 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b61a8f8}: 'int java.lang.invoke.DirectMethodHandle$Holder.invokeStaticInit(java.lang.Object, int)'> (0x000000071b61a8f8)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.255 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b622568}: 'int java.lang.invoke.DirectMethodHandle$Holder.invokeStaticInit(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)'> (0x000000071b622568)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.257 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b63b1d8}: 'java.lang.Object java.lang.invoke.DirectMethodHandle$Holder.invokeSpecial(java.lang.Object, java.lang.Object, int, java.lang.Object, java.lang.Object)'> (0x000000071b63b1d8)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.257 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b63f368}: 'java.lang.Object java.lang.invoke.DelegatingMethodHandle$Holder.delegate(java.lang.Object, int, java.lang.Object, java.lang.Object)'> (0x000000071b63f368)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.257 Thread 0x00007f20b402cd40 Implicit null exception at 0x00007f20a47f0874 to 0x00007f20a47f0ad0
+Event: 4.259 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b6679c0}: 'java.lang.Object java.lang.invoke.DirectMethodHandle$Holder.invokeSpecial(java.lang.Object, java.lang.Object, java.lang.Object, int, java.lang.Object)'> (0x000000071b6679c0)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.262 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b68adf8}: 'int java.lang.invoke.DirectMethodHandle$Holder.invokeSpecial(java.lang.Object, java.lang.Object, int)'> (0x000000071b68adf8)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.262 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b692e88}: 'int java.lang.invoke.Invokers$Holder.linkToTargetMethod(java.lang.Object, int, java.lang.Object)'> (0x000000071b692e88)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.295 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b01f290}: 'void java.lang.invoke.DirectMethodHandle$Holder.invokeVirtual(java.lang.Object, java.lang.Object)'> (0x000000071b01f290)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.302 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b180580}: 'void java.lang.invoke.DirectMethodHandle$Holder.invokeVirtual(java.lang.Object, java.lang.Object, java.lang.Object, float)'> (0x000000071b180580)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.302 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b1848b0}: 'void java.lang.invoke.DirectMethodHandle$Holder.invokeSpecial(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, float)'> (0x000000071b1848b0)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+Event: 4.302 Thread 0x00007f20b402cd40 Exception <a 'java/lang/NoSuchMethodError'{0x000000071b1885b8}: 'void java.lang.invoke.DelegatingMethodHandle$Holder.reinvoke_L(java.lang.Object, java.lang.Object, java.lang.Object, float)'> (0x000000071b1885b8)
+thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 773]
+
+ZGC Phase Switch (0 events):
+No events
+
+VM Operations (20 events):
+Event: 2.942 Executing VM operation: HandshakeAllThreads (Deoptimize)
+Event: 2.942 Executing VM operation: HandshakeAllThreads (Deoptimize) done
+Event: 2.944 Executing VM operation: HandshakeAllThreads (Deoptimize)
+Event: 2.944 Executing VM operation: HandshakeAllThreads (Deoptimize) done
+Event: 2.958 Executing VM operation: HandshakeAllThreads (Deoptimize)
+Event: 2.958 Executing VM operation: HandshakeAllThreads (Deoptimize) done
+Event: 3.057 Executing VM operation: ICBufferFull
+Event: 3.057 Executing VM operation: ICBufferFull done
+Event: 3.193 Executing VM operation: ICBufferFull
+Event: 3.193 Executing VM operation: ICBufferFull done
+Event: 3.213 Executing VM operation: HandshakeAllThreads (Deoptimize)
+Event: 3.213 Executing VM operation: HandshakeAllThreads (Deoptimize) done
+Event: 3.616 Executing VM operation: ICBufferFull
+Event: 3.616 Executing VM operation: ICBufferFull done
+Event: 3.765 Executing VM operation: HandshakeAllThreads (Deoptimize)
+Event: 3.766 Executing VM operation: HandshakeAllThreads (Deoptimize) done
+Event: 4.172 Executing VM operation: G1CollectForAllocation (G1 Evacuation Pause)
+Event: 4.179 Executing VM operation: G1CollectForAllocation (G1 Evacuation Pause) done
+Event: 4.294 Executing VM operation: HandshakeAllThreads (Deoptimize)
+Event: 4.294 Executing VM operation: HandshakeAllThreads (Deoptimize) done
+
+Memory protections (20 events):
+Event: 0.027 Protecting memory [0x00007f2088b11000,0x00007f2088b15000] with protection modes 0
+Event: 0.027 Protecting memory [0x00007f2088a10000,0x00007f2088a14000] with protection modes 0
+Event: 0.027 Protecting memory [0x00007f208890f000,0x00007f2088913000] with protection modes 0
+Event: 0.027 Protecting memory [0x00007f208880e000,0x00007f2088812000] with protection modes 0
+Event: 0.041 Protecting memory [0x00007f208870d000,0x00007f2088711000] with protection modes 0
+Event: 0.045 Protecting memory [0x00007f2088300000,0x00007f2088304000] with protection modes 0
+Event: 0.071 Protecting memory [0x00007f20881ff000,0x00007f2088203000] with protection modes 0
+Event: 0.073 Protecting memory [0x00007f20880fe000,0x00007f2088102000] with protection modes 0
+Event: 0.274 Protecting memory [0x00007f2036f00000,0x00007f2036f04000] with protection modes 0
+Event: 0.468 Protecting memory [0x00007f2036b00000,0x00007f2036b04000] with protection modes 0
+Event: 0.483 Protecting memory [0x00007f2036700000,0x00007f2036704000] with protection modes 0
+Event: 0.496 Protecting memory [0x00007f20355ff000,0x00007f2035603000] with protection modes 0
+Event: 0.498 Protecting memory [0x00007f20354fe000,0x00007f2035502000] with protection modes 0
+Event: 0.500 Protecting memory [0x00007f20353fd000,0x00007f2035401000] with protection modes 0
+Event: 1.494 Protecting memory [0x00007f20353fd000,0x00007f2035401000] with protection modes 0
+Event: 2.541 Protecting memory [0x00007f20355ff000,0x00007f2035603000] with protection modes 0
+Event: 2.604 Protecting memory [0x00007f20354fe000,0x00007f2035502000] with protection modes 0
+Event: 2.604 Protecting memory [0x00007f1fdf6b6000,0x00007f1fdf6ba000] with protection modes 0
+Event: 2.644 Protecting memory [0x00007f1fdf5b5000,0x00007f1fdf5b9000] with protection modes 0
+Event: 2.926 Protecting memory [0x00007f1fdf6b6000,0x00007f1fdf6ba000] with protection modes 0
+
+Nmethod flushes (0 events):
+No events
+
+Events (20 events):
+Event: 0.045 Thread 0x00007f20b4183a40 Thread added: 0x00007f2010076d90
+Event: 0.071 Thread 0x00007f2010076d90 Thread added: 0x00007f200800ba10
+Event: 0.073 Thread 0x00007f20b4183a40 Thread added: 0x00007f20100a2c00
+Event: 0.274 Thread 0x00007f20b402cd40 Thread added: 0x00007f20b4601860
+Event: 0.468 Thread 0x00007f20b402cd40 Thread added: 0x00007f20b4657530
+Event: 0.483 Thread 0x00007f20b402cd40 Thread added: 0x00007f20b4670790
+Event: 0.496 Thread 0x00007f20b4183a40 Thread added: 0x00007f20103aaef0
+Event: 0.498 Thread 0x00007f20b4183a40 Thread added: 0x00007f20103ac4a0
+Event: 0.500 Thread 0x00007f20100a2c00 Thread added: 0x00007f20000d1c70
+Event: 1.148 Thread 0x00007f20000d1c70 Thread exited: 0x00007f20000d1c70
+Event: 1.494 Thread 0x00007f2010076d90 Thread added: 0x00007f200813b980
+Event: 2.119 Thread 0x00007f20103ac4a0 Thread exited: 0x00007f20103ac4a0
+Event: 2.119 Thread 0x00007f20103aaef0 Thread exited: 0x00007f20103aaef0
+Event: 2.541 Thread 0x00007f200813b980 Thread added: 0x00007f1fd811e600
+Event: 2.604 Thread 0x00007f200813b980 Thread added: 0x00007f1fd82fa1b0
+Event: 2.604 Thread 0x00007f200813b980 Thread added: 0x00007f1fd82faeb0
+Event: 2.644 Thread 0x00007f1fd82faeb0 Thread added: 0x00007f1fd400cd10
+Event: 2.863 Thread 0x00007f1fd400cd10 Thread exited: 0x00007f1fd400cd10
+Event: 2.863 Thread 0x00007f1fd82faeb0 Thread exited: 0x00007f1fd82faeb0
+Event: 2.926 Thread 0x00007f20b402cd40 Thread added: 0x00007f20b4a64510
+
+
+Dynamic libraries:
+70cc00000-71c000000 rw-p 00000000 00:00 0
+71c000000-7ffe00000 ---p 00000000 00:00 0
+7ffe00000-7fff0d000 rw-p 00cd6000 08:30 54565                            /usr/lib/jvm/java-21-amazon-corretto/lib/server/classes.jsa
+7fff0d000-800000000 rw-p 00000000 00:00 0
+55edd3000000-55edd3001000 r-xp 00000000 08:30 54066                      /usr/lib/jvm/java-21-amazon-corretto/bin/java
+55edd3201000-55edd3202000 r--p 00001000 08:30 54066                      /usr/lib/jvm/java-21-amazon-corretto/bin/java
+55edd3202000-55edd3203000 rw-p 00002000 08:30 54066                      /usr/lib/jvm/java-21-amazon-corretto/bin/java
+55edde03f000-55edde085000 rw-p 00000000 00:00 0                          [heap]
+7f1fb4000000-7f1fb4021000 rw-p 00000000 00:00 0
+7f1fb4021000-7f1fb8000000 ---p 00000000 00:00 0
+7f1fb8000000-7f1fb8021000 rw-p 00000000 00:00 0
+7f1fb8021000-7f1fbc000000 ---p 00000000 00:00 0
+7f1fbc000000-7f1fbc021000 rw-p 00000000 00:00 0
+7f1fbc021000-7f1fc0000000 ---p 00000000 00:00 0
+7f1fc0000000-7f1fc0021000 rw-p 00000000 00:00 0
+7f1fc0021000-7f1fc4000000 ---p 00000000 00:00 0
+7f1fc4000000-7f1fc4021000 rw-p 00000000 00:00 0
+7f1fc4021000-7f1fc8000000 ---p 00000000 00:00 0
+7f1fc8000000-7f1fc8021000 rw-p 00000000 00:00 0
+7f1fc8021000-7f1fcc000000 ---p 00000000 00:00 0
+7f1fcc000000-7f1fcc3cf000 rw-p 00000000 00:00 0
+7f1fcc3cf000-7f1fd0000000 ---p 00000000 00:00 0
+7f1fd0000000-7f1fd0021000 rw-p 00000000 00:00 0
+7f1fd0021000-7f1fd4000000 ---p 00000000 00:00 0
+7f1fd4000000-7f1fd41d4000 rw-p 00000000 00:00 0
+7f1fd41d4000-7f1fd8000000 ---p 00000000 00:00 0
+7f1fd8000000-7f1fd85b4000 rw-p 00000000 00:00 0
+7f1fd85b4000-7f1fdc000000 ---p 00000000 00:00 0
+7f1fdebc9000-7f1fdeead000 rw-p 00000000 00:00 0
+7f1fdeead000-7f1fdeeae000 ---p 00000000 00:00 0
+7f1fdeeae000-7f1fdefae000 rw-p 00000000 00:00 0
+7f1fdefae000-7f1fdefaf000 ---p 00000000 00:00 0
+7f1fdefaf000-7f1fdf0af000 rw-p 00000000 00:00 0
+7f1fdf0af000-7f1fdf0b0000 ---p 00000000 00:00 0
+7f1fdf0b0000-7f1fdf1b0000 rw-p 00000000 00:00 0
+7f1fdf1b0000-7f1fdf1b1000 ---p 00000000 00:00 0
+7f1fdf1b1000-7f1fdf2b1000 rw-p 00000000 00:00 0
+7f1fdf2b1000-7f1fdf2b2000 ---p 00000000 00:00 0
+7f1fdf2b2000-7f1fdf3b2000 rw-p 00000000 00:00 0
+7f1fdf3b2000-7f1fdf3b3000 ---p 00000000 00:00 0
+7f1fdf3b3000-7f1fdf4b3000 rw-p 00000000 00:00 0
+7f1fdf4b3000-7f1fdf4b4000 ---p 00000000 00:00 0
+7f1fdf4b4000-7f1fdf5b4000 rw-p 00000000 00:00 0
+7f1fdf5b4000-7f1fdf5b5000 ---p 00000000 00:00 0
+7f1fdf5b5000-7f1fdf5b9000 ---p 00000000 00:00 0
+7f1fdf5b9000-7f1fdf6b5000 rw-p 00000000 00:00 0
+7f1fdf6b5000-7f1fdf6b6000 ---p 00000000 00:00 0
+7f1fdf6b6000-7f1fdf6ba000 ---p 00000000 00:00 0
+7f1fdf6ba000-7f1fdf7b6000 rw-p 00000000 00:00 0
+7f1fdf7b6000-7f1fdf7d9000 r--p 00000000 08:30 59751                      /usr/lib/x86_64-linux-gnu/libkrb5.so.3.3
+7f1fdf7d9000-7f1fdf838000 r-xp 00023000 08:30 59751                      /usr/lib/x86_64-linux-gnu/libkrb5.so.3.3
+7f1fdf838000-7f1fdf880000 r--p 00082000 08:30 59751                      /usr/lib/x86_64-linux-gnu/libkrb5.so.3.3
+7f1fdf880000-7f1fdf88d000 r--p 000c9000 08:30 59751                      /usr/lib/x86_64-linux-gnu/libkrb5.so.3.3
+7f1fdf88d000-7f1fdf890000 rw-p 000d6000 08:30 59751                      /usr/lib/x86_64-linux-gnu/libkrb5.so.3.3
+7f1fdf890000-7f1fdf8bb000 r--p 00000000 08:30 1069                       /usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
+7f1fdf8bb000-7f1fdf954000 r-xp 0002b000 08:30 1069                       /usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
+7f1fdf954000-7f1fdf9af000 r--p 000c4000 08:30 1069                       /usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
+7f1fdf9af000-7f1fdf9ba000 r--p 0011f000 08:30 1069                       /usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
+7f1fdf9ba000-7f1fdf9c4000 rw-p 0012a000 08:30 1069                       /usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
+7f1fdf9c4000-7f1fdfa89000 r--p 00000000 08:30 59571                      /usr/lib/x86_64-linux-gnu/libcrypto.so.3
+7f1fdfa89000-7f1fdfd05000 r-xp 000c5000 08:30 59571                      /usr/lib/x86_64-linux-gnu/libcrypto.so.3
+7f1fdfd05000-7f1fdfde3000 r--p 00341000 08:30 59571                      /usr/lib/x86_64-linux-gnu/libcrypto.so.3
+7f1fdfde3000-7f1fdfe44000 r--p 0041f000 08:30 59571                      /usr/lib/x86_64-linux-gnu/libcrypto.so.3
+7f1fdfe44000-7f1fdfe47000 rw-p 00480000 08:30 59571                      /usr/lib/x86_64-linux-gnu/libcrypto.so.3
+7f1fdfe47000-7f1fdfe4a000 rw-p 00000000 00:00 0
+7f1fdfe4a000-7f1fdfe5c000 r--p 00000000 08:30 1107                       /usr/lib/x86_64-linux-gnu/libunistring.so.2.2.0
+7f1fdfe5c000-7f1fdfe9c000 r-xp 00012000 08:30 1107                       /usr/lib/x86_64-linux-gnu/libunistring.so.2.2.0
+7f1fdfe9c000-7f1fdfffb000 r--p 00052000 08:30 1107                       /usr/lib/x86_64-linux-gnu/libunistring.so.2.2.0
+7f1fdfffb000-7f1fdffff000 r--p 001b1000 08:30 1107                       /usr/lib/x86_64-linux-gnu/libunistring.so.2.2.0
+7f1fdffff000-7f1fe0000000 rw-p 001b5000 08:30 1107                       /usr/lib/x86_64-linux-gnu/libunistring.so.2.2.0
+7f1fe0000000-7f1fe0ead000 rw-p 00000000 00:00 0
+7f1fe0ead000-7f1fe4000000 ---p 00000000 00:00 0
+7f1fe4000000-7f1fe4944000 rw-p 00000000 00:00 0
+7f1fe4944000-7f1fe8000000 ---p 00000000 00:00 0
+7f1fe8000000-7f1fe8021000 rw-p 00000000 00:00 0
+7f1fe8021000-7f1fec000000 ---p 00000000 00:00 0
+7f1fec000000-7f1fec021000 rw-p 00000000 00:00 0
+7f1fec021000-7f1ff0000000 ---p 00000000 00:00 0
+7f1ff0000000-7f1ff002b000 rw-p 00000000 00:00 0
+7f1ff002b000-7f1ff4000000 ---p 00000000 00:00 0
+7f1ff4000000-7f1ff4021000 rw-p 00000000 00:00 0
+7f1ff4021000-7f1ff8000000 ---p 00000000 00:00 0
+7f1ff8000000-7f1ff8021000 rw-p 00000000 00:00 0
+7f1ff8021000-7f1ffc000000 ---p 00000000 00:00 0
+7f1ffc000000-7f1ffc021000 rw-p 00000000 00:00 0
+7f1ffc021000-7f2000000000 ---p 00000000 00:00 0
+7f2000000000-7f20010a8000 rw-p 00000000 00:00 0
+7f20010a8000-7f2004000000 ---p 00000000 00:00 0
+7f2004000000-7f2004021000 rw-p 00000000 00:00 0
+7f2004021000-7f2008000000 ---p 00000000 00:00 0
+7f2008000000-7f20081ab000 rw-p 00000000 00:00 0
+7f20081ab000-7f200c000000 ---p 00000000 00:00 0
+7f200c000000-7f200c1cc000 rw-p 00000000 00:00 0
+7f200c1cc000-7f2010000000 ---p 00000000 00:00 0
+7f2010000000-7f2010463000 rw-p 00000000 00:00 0
+7f2010463000-7f2014000000 ---p 00000000 00:00 0
+7f2014000000-7f2014021000 rw-p 00000000 00:00 0
+7f2014021000-7f2018000000 ---p 00000000 00:00 0
+7f2018000000-7f2018021000 rw-p 00000000 00:00 0
+7f2018021000-7f201c000000 ---p 00000000 00:00 0
+7f201c000000-7f201d526000 rw-p 00000000 00:00 0
+7f201d526000-7f2020000000 ---p 00000000 00:00 0
+7f2020000000-7f2020021000 rw-p 00000000 00:00 0
+7f2020021000-7f2024000000 ---p 00000000 00:00 0
+7f2024000000-7f2024021000 rw-p 00000000 00:00 0
+7f2024021000-7f2028000000 ---p 00000000 00:00 0
+7f2028000000-7f2028021000 rw-p 00000000 00:00 0
+7f2028021000-7f202c000000 ---p 00000000 00:00 0
+7f202c000000-7f202c021000 rw-p 00000000 00:00 0
+7f202c021000-7f2030000000 ---p 00000000 00:00 0
+7f2030000000-7f2030021000 rw-p 00000000 00:00 0
+7f2030021000-7f2034000000 ---p 00000000 00:00 0
+7f20340a0000-7f20340c4000 r-xp 00000000 00:00 0
+7f20340c4000-7f20340cf000 r--p 00000000 08:30 1041                       /usr/lib/x86_64-linux-gnu/libgmp.so.10.4.1
+7f20340cf000-7f203412c000 r-xp 0000b000 08:30 1041                       /usr/lib/x86_64-linux-gnu/libgmp.so.10.4.1
+7f203412c000-7f2034143000 r--p 00068000 08:30 1041                       /usr/lib/x86_64-linux-gnu/libgmp.so.10.4.1
+7f2034143000-7f2034144000 r--p 0007f000 08:30 1041                       /usr/lib/x86_64-linux-gnu/libgmp.so.10.4.1
+7f2034144000-7f2034145000 rw-p 00080000 08:30 1041                       /usr/lib/x86_64-linux-gnu/libgmp.so.10.4.1
+7f2034145000-7f203417c000 r--p 00000000 08:30 1043                       /usr/lib/x86_64-linux-gnu/libgnutls.so.30.34.3
+7f203417c000-7f20342af000 r-xp 00037000 08:30 1043                       /usr/lib/x86_64-linux-gnu/libgnutls.so.30.34.3
+7f20342af000-7f203434a000 r--p 0016a000 08:30 1043                       /usr/lib/x86_64-linux-gnu/libgnutls.so.30.34.3
+7f203434a000-7f203435b000 r--p 00205000 08:30 1043                       /usr/lib/x86_64-linux-gnu/libgnutls.so.30.34.3
+7f203435b000-7f203435d000 rw-p 00216000 08:30 1043                       /usr/lib/x86_64-linux-gnu/libgnutls.so.30.34.3
+7f203435d000-7f2034361000 rw-p 00000000 00:00 0
+7f2034361000-7f2034387000 r--p 00000000 08:30 59909                      /usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6
+7f2034387000-7f203447b000 r-xp 00026000 08:30 59909                      /usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6
+7f203447b000-7f20344b6000 r--p 0011a000 08:30 59909                      /usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6
+7f20344b6000-7f20344bc000 r--p 00155000 08:30 59909                      /usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6
+7f20344bc000-7f20344c0000 rw-p 0015b000 08:30 59909                      /usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6
+7f20344c0000-7f2034559000 r--p 00000000 08:30 1094                       /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
+7f2034559000-7f203465a000 r-xp 00099000 08:30 1094                       /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
+7f203465a000-7f20346c9000 r--p 0019a000 08:30 1094                       /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
+7f20346c9000-7f20346d4000 r--p 00209000 08:30 1094                       /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
+7f20346d4000-7f20346d7000 rw-p 00214000 08:30 1094                       /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
+7f20346d7000-7f20346da000 rw-p 00000000 00:00 0
+7f20346da000-7f203479c000 r--p 00000000 08:30 59658                      /usr/lib/x86_64-linux-gnu/libgeos.so.3.11.1
+7f203479c000-7f20348eb000 r-xp 000c2000 08:30 59658                      /usr/lib/x86_64-linux-gnu/libgeos.so.3.11.1
+7f20348eb000-7f2034955000 r--p 00211000 08:30 59658                      /usr/lib/x86_64-linux-gnu/libgeos.so.3.11.1
+7f2034955000-7f2034963000 r--p 0027a000 08:30 59658                      /usr/lib/x86_64-linux-gnu/libgeos.so.3.11.1
+7f2034963000-7f2034964000 rw-p 00288000 08:30 59658                      /usr/lib/x86_64-linux-gnu/libgeos.so.3.11.1
+7f2034964000-7f20349c8000 r--p 00000000 08:30 59680                      /usr/lib/x86_64-linux-gnu/libgsl.so.27.0.0
+7f20349c8000-7f2034ba4000 r-xp 00064000 08:30 59680                      /usr/lib/x86_64-linux-gnu/libgsl.so.27.0.0
+7f2034ba4000-7f2034c1d000 r--p 00240000 08:30 59680                      /usr/lib/x86_64-linux-gnu/libgsl.so.27.0.0
+7f2034c1d000-7f2034c21000 r--p 002b8000 08:30 59680                      /usr/lib/x86_64-linux-gnu/libgsl.so.27.0.0
+7f2034c21000-7f2034c31000 rw-p 002bc000 08:30 59680                      /usr/lib/x86_64-linux-gnu/libgsl.so.27.0.0
+7f2034c31000-7f2034cb5000 r--p 00000000 08:30 59869                      /usr/lib/x86_64-linux-gnu/libproj.so.25.9.1.1
+7f2034cb5000-7f2034f36000 r-xp 00084000 08:30 59869                      /usr/lib/x86_64-linux-gnu/libproj.so.25.9.1.1
+7f2034f36000-7f2034fe0000 r--p 00305000 08:30 59869                      /usr/lib/x86_64-linux-gnu/libproj.so.25.9.1.1
+7f2034fe0000-7f2034ffb000 r--p 003ae000 08:30 59869                      /usr/lib/x86_64-linux-gnu/libproj.so.25.9.1.1
+7f2034ffb000-7f2034ffd000 rw-p 003c9000 08:30 59869                      /usr/lib/x86_64-linux-gnu/libproj.so.25.9.1.1
+7f2034ffd000-7f2035000000 rw-p 00000000 00:00 0
+7f2035000000-7f203501a000 r-xp 00000000 08:30 95180                      /tmp/jffi5633389435295216473.so (deleted)
+7f203501a000-7f203521a000 ---p 0001a000 08:30 95180                      /tmp/jffi5633389435295216473.so (deleted)
+7f203521a000-7f203521b000 r--p 0001a000 08:30 95180                      /tmp/jffi5633389435295216473.so (deleted)
+7f203521b000-7f203521c000 rw-p 0001b000 08:30 95180                      /tmp/jffi5633389435295216473.so (deleted)
+7f2035224000-7f2035227000 r--p 00000000 08:30 1082                       /usr/lib/x86_64-linux-gnu/libresolv.so.2
+7f2035227000-7f203522f000 r-xp 00003000 08:30 1082                       /usr/lib/x86_64-linux-gnu/libresolv.so.2
+7f203522f000-7f2035231000 r--p 0000b000 08:30 1082                       /usr/lib/x86_64-linux-gnu/libresolv.so.2
+7f2035231000-7f2035232000 r--p 0000d000 08:30 1082                       /usr/lib/x86_64-linux-gnu/libresolv.so.2
+7f2035232000-7f2035233000 rw-p 0000e000 08:30 1082                       /usr/lib/x86_64-linux-gnu/libresolv.so.2
+7f2035233000-7f2035235000 rw-p 00000000 00:00 0
+7f2035235000-7f203526b000 r--p 00000000 08:30 76491                      /usr/local/lib/libmeos.so
+7f203526b000-7f203538b000 r-xp 00036000 08:30 76491                      /usr/local/lib/libmeos.so
+7f203538b000-7f20353f0000 r--p 00156000 08:30 76491                      /usr/local/lib/libmeos.so
+7f20353f0000-7f20353f2000 r--p 001bb000 08:30 76491                      /usr/local/lib/libmeos.so
+7f20353f2000-7f20353f6000 rw-p 001bd000 08:30 76491                      /usr/local/lib/libmeos.so
+7f20353f6000-7f20353fc000 rw-p 00000000 00:00 0
+7f20353fc000-7f20353fd000 ---p 00000000 00:00 0
+7f20353fd000-7f2035401000 ---p 00000000 00:00 0
+7f2035401000-7f20354fd000 rw-p 00000000 00:00 0
+7f20354fd000-7f20354fe000 ---p 00000000 00:00 0
+7f20354fe000-7f2035502000 ---p 00000000 00:00 0
+7f2035502000-7f20355fe000 rw-p 00000000 00:00 0
+7f20355fe000-7f20355ff000 ---p 00000000 00:00 0
+7f20355ff000-7f2035603000 ---p 00000000 00:00 0
+7f2035603000-7f20356ff000 rw-p 00000000 00:00 0
+7f20356ff000-7f2035700000 ---p 00000000 00:00 0
+7f2035700000-7f2035800000 rw-p 00000000 00:00 0
+7f2035800000-7f2035805000 r-xp 00000000 08:30 54544                      /usr/lib/jvm/java-21-amazon-corretto/lib/libmanagement_ext.so
+7f2035805000-7f2035a05000 ---p 00005000 08:30 54544                      /usr/lib/jvm/java-21-amazon-corretto/lib/libmanagement_ext.so
+7f2035a05000-7f2035a06000 r--p 00005000 08:30 54544                      /usr/lib/jvm/java-21-amazon-corretto/lib/libmanagement_ext.so
+7f2035a06000-7f2035a07000 rw-p 00000000 00:00 0
+7f2035a17000-7f2035a18000 r--p 00000000 08:30 59546                      /usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.0.9
+7f2035a18000-7f2035a19000 r-xp 00001000 08:30 59546                      /usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.0.9
+7f2035a19000-7f2035a38000 r--p 00002000 08:30 59546                      /usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.0.9
+7f2035a38000-7f2035a39000 r--p 00020000 08:30 59546                      /usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.0.9
+7f2035a39000-7f2035a3a000 rw-p 00021000 08:30 59546                      /usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.0.9
+7f2035a3a000-7f2035a3d000 r--p 00000000 08:30 59892                      /usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25
+7f2035a3d000-7f2035a4f000 r-xp 00003000 08:30 59892                      /usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25
+7f2035a4f000-7f2035a55000 r--p 00015000 08:30 59892                      /usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25
+7f2035a55000-7f2035a56000 r--p 0001a000 08:30 59892                      /usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25
+7f2035a56000-7f2035a57000 rw-p 0001b000 08:30 59892                      /usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25
+7f2035a57000-7f2035a60000 r--p 00000000 08:30 1047                       /usr/lib/x86_64-linux-gnu/libhogweed.so.6.6
+7f2035a60000-7f2035a73000 r-xp 00009000 08:30 1047                       /usr/lib/x86_64-linux-gnu/libhogweed.so.6.6
+7f2035a73000-7f2035a9d000 r--p 0001c000 08:30 1047                       /usr/lib/x86_64-linux-gnu/libhogweed.so.6.6
+7f2035a9d000-7f2035a9f000 r--p 00045000 08:30 1047                       /usr/lib/x86_64-linux-gnu/libhogweed.so.6.6
+7f2035a9f000-7f2035aa0000 rw-p 00047000 08:30 1047                       /usr/lib/x86_64-linux-gnu/libhogweed.so.6.6
+7f2035aa0000-7f2035ab0000 r--p 00000000 08:30 59762                      /usr/lib/x86_64-linux-gnu/libldap-2.5.so.0.1.8
+7f2035ab0000-7f2035ae9000 r-xp 00010000 08:30 59762                      /usr/lib/x86_64-linux-gnu/libldap-2.5.so.0.1.8
+7f2035ae9000-7f2035afa000 r--p 00049000 08:30 59762                      /usr/lib/x86_64-linux-gnu/libldap-2.5.so.0.1.8
+7f2035afa000-7f2035afc000 r--p 0005a000 08:30 59762                      /usr/lib/x86_64-linux-gnu/libldap-2.5.so.0.1.8
+7f2035afc000-7f2035afd000 rw-p 0005c000 08:30 59762                      /usr/lib/x86_64-linux-gnu/libldap-2.5.so.0.1.8
+7f2035afd000-7f2035aff000 rw-p 00000000 00:00 0
+7f2035aff000-7f2035b00000 ---p 00000000 00:00 0
+7f2035b00000-7f2035c00000 rw-p 00000000 00:00 0
+7f2035c00000-7f2035c04000 r-xp 00000000 08:30 54542                      /usr/lib/jvm/java-21-amazon-corretto/lib/libmanagement.so
+7f2035c04000-7f2035e03000 ---p 00004000 08:30 54542                      /usr/lib/jvm/java-21-amazon-corretto/lib/libmanagement.so
+7f2035e03000-7f2035e04000 r--p 00003000 08:30 54542                      /usr/lib/jvm/java-21-amazon-corretto/lib/libmanagement.so
+7f2035e04000-7f2035e05000 rw-p 00000000 00:00 0
+7f2035e0d000-7f2035e0f000 r--p 00000000 08:30 1036                       /usr/lib/x86_64-linux-gnu/libffi.so.8.1.2
+7f2035e0f000-7f2035e15000 r-xp 00002000 08:30 1036                       /usr/lib/x86_64-linux-gnu/libffi.so.8.1.2
+7f2035e15000-7f2035e17000 r--p 00008000 08:30 1036                       /usr/lib/x86_64-linux-gnu/libffi.so.8.1.2
+7f2035e17000-7f2035e18000 r--p 00009000 08:30 1036                       /usr/lib/x86_64-linux-gnu/libffi.so.8.1.2
+7f2035e18000-7f2035e19000 rw-p 0000a000 08:30 1036                       /usr/lib/x86_64-linux-gnu/libffi.so.8.1.2
+7f2035e19000-7f2035e25000 r--p 00000000 08:30 59686                      /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2
+7f2035e25000-7f2035e5b000 r-xp 0000c000 08:30 59686                      /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2
+7f2035e5b000-7f2035e68000 r--p 00042000 08:30 59686                      /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2
+7f2035e68000-7f2035e6a000 r--p 0004f000 08:30 59686                      /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2
+7f2035e6a000-7f2035e6c000 rw-p 00051000 08:30 59686                      /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2
+7f2035e6c000-7f2035e70000 r--p 00000000 08:30 59733                      /usr/lib/x86_64-linux-gnu/libjpeg.so.62.3.0
+7f2035e70000-7f2035ebb000 r-xp 00004000 08:30 59733                      /usr/lib/x86_64-linux-gnu/libjpeg.so.62.3.0
+7f2035ebb000-7f2035efd000 r--p 0004f000 08:30 59733                      /usr/lib/x86_64-linux-gnu/libjpeg.so.62.3.0
+7f2035efd000-7f2035efe000 r--p 00091000 08:30 59733                      /usr/lib/x86_64-linux-gnu/libjpeg.so.62.3.0
+7f2035efe000-7f2035eff000 rw-p 00092000 08:30 59733                      /usr/lib/x86_64-linux-gnu/libjpeg.so.62.3.0
+7f2035eff000-7f2035f00000 ---p 00000000 00:00 0
+7f2035f00000-7f2036000000 rw-p 00000000 00:00 0
+7f2036000000-7f203600d000 r-xp 00000000 08:30 54554                      /usr/lib/jvm/java-21-amazon-corretto/lib/libverify.so
+7f203600d000-7f203620c000 ---p 0000d000 08:30 54554                      /usr/lib/jvm/java-21-amazon-corretto/lib/libverify.so
+7f203620c000-7f203620e000 r--p 0000c000 08:30 54554                      /usr/lib/jvm/java-21-amazon-corretto/lib/libverify.so
+7f203620e000-7f203620f000 rw-p 00000000 00:00 0
+7f2036219000-7f2036226000 r--p 00000000 08:30 1062                       /usr/lib/x86_64-linux-gnu/libnettle.so.8.6
+7f2036226000-7f203624d000 r-xp 0000d000 08:30 1062                       /usr/lib/x86_64-linux-gnu/libnettle.so.8.6
+7f203624d000-7f2036264000 r--p 00034000 08:30 1062                       /usr/lib/x86_64-linux-gnu/libnettle.so.8.6
+7f2036264000-7f2036266000 r--p 0004b000 08:30 1062                       /usr/lib/x86_64-linux-gnu/libnettle.so.8.6
+7f2036266000-7f2036267000 rw-p 0004d000 08:30 1062                       /usr/lib/x86_64-linux-gnu/libnettle.so.8.6
+7f2036267000-7f2036274000 r--p 00000000 08:30 59376                      /usr/lib/x86_64-linux-gnu/libLerc.so.4
+7f2036274000-7f20362f1000 r-xp 0000d000 08:30 59376                      /usr/lib/x86_64-linux-gnu/libLerc.so.4
+7f20362f1000-7f20362fc000 r--p 0008a000 08:30 59376                      /usr/lib/x86_64-linux-gnu/libLerc.so.4
+7f20362fc000-7f20362fe000 r--p 00094000 08:30 59376                      /usr/lib/x86_64-linux-gnu/libLerc.so.4
+7f20362fe000-7f20362ff000 rw-p 00096000 08:30 59376                      /usr/lib/x86_64-linux-gnu/libLerc.so.4
+7f20362ff000-7f2036300000 ---p 00000000 00:00 0
+7f2036300000-7f2036400000 rw-p 00000000 00:00 0
+7f2036400000-7f203640b000 r-xp 00000000 08:30 54546                      /usr/lib/jvm/java-21-amazon-corretto/lib/libnet.so
+7f203640b000-7f203660a000 ---p 0000b000 08:30 54546                      /usr/lib/jvm/java-21-amazon-corretto/lib/libnet.so
+7f203660a000-7f203660b000 r--p 0000a000 08:30 54546                      /usr/lib/jvm/java-21-amazon-corretto/lib/libnet.so
+7f203660b000-7f203660c000 rw-p 00000000 00:00 0
+7f2036616000-7f203661a000 r--p 00000000 08:30 59741                      /usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1
+7f203661a000-7f2036634000 r-xp 00004000 08:30 59741                      /usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1
+7f2036634000-7f2036641000 r--p 0001e000 08:30 59741                      /usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1
+7f2036641000-7f2036642000 r--p 0002b000 08:30 59741                      /usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1
+7f2036642000-7f2036643000 rw-p 0002c000 08:30 59741                      /usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1
+7f2036643000-7f2036648000 r--p 00000000 08:30 1116                       /usr/lib/x86_64-linux-gnu/libzstd.so.1.5.4
+7f2036648000-7f20366e9000 r-xp 00005000 08:30 1116                       /usr/lib/x86_64-linux-gnu/libzstd.so.1.5.4
+7f20366e9000-7f20366fd000 r--p 000a6000 08:30 1116                       /usr/lib/x86_64-linux-gnu/libzstd.so.1.5.4
+7f20366fd000-7f20366fe000 r--p 000b9000 08:30 1116                       /usr/lib/x86_64-linux-gnu/libzstd.so.1.5.4
+7f20366fe000-7f20366ff000 rw-p 000ba000 08:30 1116                       /usr/lib/x86_64-linux-gnu/libzstd.so.1.5.4
+7f20366ff000-7f2036700000 ---p 00000000 00:00 0
+7f2036700000-7f2036704000 ---p 00000000 00:00 0
+7f2036704000-7f2036800000 rw-p 00000000 00:00 0
+7f2036800000-7f2036813000 r-xp 00000000 08:30 54547                      /usr/lib/jvm/java-21-amazon-corretto/lib/libnio.so
+7f2036813000-7f2036a12000 ---p 00013000 08:30 54547                      /usr/lib/jvm/java-21-amazon-corretto/lib/libnio.so
+7f2036a12000-7f2036a13000 r--p 00012000 08:30 54547                      /usr/lib/jvm/java-21-amazon-corretto/lib/libnio.so
+7f2036a13000-7f2036a14000 rw-p 00013000 08:30 54547                      /usr/lib/jvm/java-21-amazon-corretto/lib/libnio.so
+7f2036a1f000-7f2036a22000 r--p 00000000 08:30 59753                      /usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1
+7f2036a22000-7f2036a28000 r-xp 00003000 08:30 59753                      /usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1
+7f2036a28000-7f2036a2b000 r--p 00009000 08:30 59753                      /usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1
+7f2036a2b000-7f2036a2c000 r--p 0000b000 08:30 59753                      /usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1
+7f2036a2c000-7f2036a2d000 rw-p 0000c000 08:30 59753                      /usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1
+7f2036a2d000-7f2036a34000 r--p 00000000 08:30 59911                      /usr/lib/x86_64-linux-gnu/libssh2.so.1.0.1
+7f2036a34000-7f2036a5d000 r-xp 00007000 08:30 59911                      /usr/lib/x86_64-linux-gnu/libssh2.so.1.0.1
+7f2036a5d000-7f2036a6b000 r--p 00030000 08:30 59911                      /usr/lib/x86_64-linux-gnu/libssh2.so.1.0.1
+7f2036a6b000-7f2036a6d000 r--p 0003d000 08:30 59911                      /usr/lib/x86_64-linux-gnu/libssh2.so.1.0.1
+7f2036a6d000-7f2036a6e000 rw-p 0003f000 08:30 59911                      /usr/lib/x86_64-linux-gnu/libssh2.so.1.0.1
+7f2036a6e000-7f2036a73000 r--p 00000000 08:30 59888                      /usr/lib/x86_64-linux-gnu/librtmp.so.1
+7f2036a73000-7f2036a83000 r-xp 00005000 08:30 59888                      /usr/lib/x86_64-linux-gnu/librtmp.so.1
+7f2036a83000-7f2036a8a000 r--p 00015000 08:30 59888                      /usr/lib/x86_64-linux-gnu/librtmp.so.1
+7f2036a8a000-7f2036a8b000 ---p 0001c000 08:30 59888                      /usr/lib/x86_64-linux-gnu/librtmp.so.1
+7f2036a8b000-7f2036a8c000 r--p 0001c000 08:30 59888                      /usr/lib/x86_64-linux-gnu/librtmp.so.1
+7f2036a8c000-7f2036a8d000 rw-p 0001d000 08:30 59888                      /usr/lib/x86_64-linux-gnu/librtmp.so.1
+7f2036a8d000-7f2036a90000 r--p 00000000 08:30 59953                      /usr/lib/x86_64-linux-gnu/libwebp.so.7.1.5
+7f2036a90000-7f2036ae7000 r-xp 00003000 08:30 59953                      /usr/lib/x86_64-linux-gnu/libwebp.so.7.1.5
+7f2036ae7000-7f2036afb000 r--p 0005a000 08:30 59953                      /usr/lib/x86_64-linux-gnu/libwebp.so.7.1.5
+7f2036afb000-7f2036afc000 r--p 0006d000 08:30 59953                      /usr/lib/x86_64-linux-gnu/libwebp.so.7.1.5
+7f2036afc000-7f2036afd000 rw-p 0006e000 08:30 59953                      /usr/lib/x86_64-linux-gnu/libwebp.so.7.1.5
+7f2036afd000-7f2036aff000 rw-p 00000000 00:00 0
+7f2036aff000-7f2036b00000 ---p 00000000 00:00 0
+7f2036b00000-7f2036b04000 ---p 00000000 00:00 0
+7f2036b04000-7f2036c00000 rw-p 00000000 00:00 0
+7f2036c00000-7f2036c07000 r-xp 00000000 08:30 54555                      /usr/lib/jvm/java-21-amazon-corretto/lib/libzip.so
+7f2036c07000-7f2036e06000 ---p 00007000 08:30 54555                      /usr/lib/jvm/java-21-amazon-corretto/lib/libzip.so
+7f2036e06000-7f2036e07000 r--p 00006000 08:30 54555                      /usr/lib/jvm/java-21-amazon-corretto/lib/libzip.so
+7f2036e07000-7f2036e08000 rw-p 00000000 00:00 0
+7f2036e0f000-7f2036e12000 r--p 00000000 08:30 1098                       /usr/lib/x86_64-linux-gnu/libtasn1.so.6.6.3
+7f2036e12000-7f2036e1e000 r-xp 00003000 08:30 1098                       /usr/lib/x86_64-linux-gnu/libtasn1.so.6.6.3
+7f2036e1e000-7f2036e22000 r--p 0000f000 08:30 1098                       /usr/lib/x86_64-linux-gnu/libtasn1.so.6.6.3
+7f2036e22000-7f2036e23000 r--p 00013000 08:30 1098                       /usr/lib/x86_64-linux-gnu/libtasn1.so.6.6.3
+7f2036e23000-7f2036e24000 rw-p 00014000 08:30 1098                       /usr/lib/x86_64-linux-gnu/libtasn1.so.6.6.3
+7f2036e24000-7f2036e26000 r--p 00000000 08:30 1049                       /usr/lib/x86_64-linux-gnu/libidn2.so.0.3.8
+7f2036e26000-7f2036e2d000 r-xp 00002000 08:30 1049                       /usr/lib/x86_64-linux-gnu/libidn2.so.0.3.8
+7f2036e2d000-7f2036e53000 r--p 00009000 08:30 1049                       /usr/lib/x86_64-linux-gnu/libidn2.so.0.3.8
+7f2036e53000-7f2036e54000 r--p 0002f000 08:30 1049                       /usr/lib/x86_64-linux-gnu/libidn2.so.0.3.8
+7f2036e54000-7f2036e55000 rw-p 00030000 08:30 1049                       /usr/lib/x86_64-linux-gnu/libidn2.so.0.3.8
+7f2036e55000-7f2036e64000 r--p 00000000 08:30 59580                      /usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4.8.0
+7f2036e64000-7f2036ed7000 r-xp 0000f000 08:30 59580                      /usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4.8.0
+7f2036ed7000-7f2036ef8000 r--p 00082000 08:30 59580                      /usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4.8.0
+7f2036ef8000-7f2036efc000 r--p 000a3000 08:30 59580                      /usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4.8.0
+7f2036efc000-7f2036eff000 rw-p 000a7000 08:30 59580                      /usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4.8.0
+7f2036eff000-7f2036f00000 ---p 00000000 00:00 0
+7f2036f00000-7f2036f04000 ---p 00000000 00:00 0
+7f2036f04000-7f2037400000 rw-p 00000000 00:00 0
+7f2037400000-7f20379c0000 rw-p 00000000 00:00 0
+7f20379c0000-7f2037c60000 rw-p 00000000 00:00 0
+7f2037c60000-7f2037d00000 rw-p 00000000 00:00 0
+7f2037d00000-7f2037e00000 rw-p 00000000 00:00 0
+7f2037e00000-7f2037f00000 rw-p 00000000 00:00 0
+7f2037f00000-7f2037f30000 rw-p 00000000 00:00 0
+7f2037f30000-7f2037f40000 ---p 00000000 00:00 0
+7f2037f40000-7f2038100000 rw-p 00000000 00:00 0
+7f2038100000-7f2038150000 rw-p 00000000 00:00 0
+7f2038150000-7f2038200000 ---p 00000000 00:00 0
+7f2038200000-7f2038300000 rw-p 00000000 00:00 0
+7f2038300000-7f203b000000 ---p 00000000 00:00 0
+7f203b000000-7f203b47d000 rw-p 00001000 08:30 54565                      /usr/lib/jvm/java-21-amazon-corretto/lib/server/classes.jsa
+7f203b47d000-7f203bc97000 rw-p 0047e000 08:30 54565                      /usr/lib/jvm/java-21-amazon-corretto/lib/server/classes.jsa
+7f203bc97000-7f203c000000 ---p 00000000 00:00 0
+7f203c000000-7f203c040000 rw-p 00000000 00:00 0
+7f203c040000-7f203c0f0000 rw-p 00000000 00:00 0
+7f203c0f0000-7f203c100000 ---p 00000000 00:00 0
+7f203c100000-7f203c220000 rw-p 00000000 00:00 0
+7f203c220000-7f207c000000 ---p 00000000 00:00 0
+7f207c000000-7f207c021000 rw-p 00000000 00:00 0
+7f207c021000-7f2080000000 ---p 00000000 00:00 0
+7f2080000000-7f2080021000 rw-p 00000000 00:00 0
+7f2080021000-7f2084000000 ---p 00000000 00:00 0
+7f2084000000-7f2084021000 rw-p 00000000 00:00 0
+7f2084021000-7f2088000000 ---p 00000000 00:00 0
+7f2088001000-7f2088003000 r--p 00000000 08:30 59743                      /usr/lib/x86_64-linux-gnu/libkeyutils.so.1.10
+7f2088003000-7f2088005000 r-xp 00002000 08:30 59743                      /usr/lib/x86_64-linux-gnu/libkeyutils.so.1.10
+7f2088005000-7f2088006000 r--p 00004000 08:30 59743                      /usr/lib/x86_64-linux-gnu/libkeyutils.so.1.10
+7f2088006000-7f2088007000 r--p 00004000 08:30 59743                      /usr/lib/x86_64-linux-gnu/libkeyutils.so.1.10
+7f2088007000-7f2088008000 rw-p 00005000 08:30 59743                      /usr/lib/x86_64-linux-gnu/libkeyutils.so.1.10
+7f2088008000-7f208800a000 r--p 00000000 08:30 59873                      /usr/lib/x86_64-linux-gnu/libpsl.so.5.3.4
+7f208800a000-7f208800c000 r-xp 00002000 08:30 59873                      /usr/lib/x86_64-linux-gnu/libpsl.so.5.3.4
+7f208800c000-7f208801a000 r--p 00004000 08:30 59873                      /usr/lib/x86_64-linux-gnu/libpsl.so.5.3.4
+7f208801a000-7f208801b000 r--p 00011000 08:30 59873                      /usr/lib/x86_64-linux-gnu/libpsl.so.5.3.4
+7f208801b000-7f208801c000 rw-p 00012000 08:30 59873                      /usr/lib/x86_64-linux-gnu/libpsl.so.5.3.4
+7f208801c000-7f2088021000 r--p 00000000 08:30 59811                      /usr/lib/x86_64-linux-gnu/libnghttp2.so.14.24.1
+7f2088021000-7f2088038000 r-xp 00005000 08:30 59811                      /usr/lib/x86_64-linux-gnu/libnghttp2.so.14.24.1
+7f2088038000-7f2088047000 r--p 0001c000 08:30 59811                      /usr/lib/x86_64-linux-gnu/libnghttp2.so.14.24.1
+7f2088047000-7f208804a000 r--p 0002b000 08:30 59811                      /usr/lib/x86_64-linux-gnu/libnghttp2.so.14.24.1
+7f208804a000-7f208804b000 rw-p 0002e000 08:30 59811                      /usr/lib/x86_64-linux-gnu/libnghttp2.so.14.24.1
+7f208804b000-7f208804c000 r--p 00000000 08:30 59596                      /usr/lib/x86_64-linux-gnu/libdeflate.so.0
+7f208804c000-7f208806a000 r-xp 00001000 08:30 59596                      /usr/lib/x86_64-linux-gnu/libdeflate.so.0
+7f208806a000-7f208806f000 r--p 0001f000 08:30 59596                      /usr/lib/x86_64-linux-gnu/libdeflate.so.0
+7f208806f000-7f2088070000 r--p 00023000 08:30 59596                      /usr/lib/x86_64-linux-gnu/libdeflate.so.0
+7f2088070000-7f2088071000 rw-p 00024000 08:30 59596                      /usr/lib/x86_64-linux-gnu/libdeflate.so.0
+7f2088071000-7f2088079000 r--p 00000000 08:30 59928                      /usr/lib/x86_64-linux-gnu/libtiff.so.6.0.0
+7f2088079000-7f20880c5000 r-xp 00008000 08:30 59928                      /usr/lib/x86_64-linux-gnu/libtiff.so.6.0.0
+7f20880c5000-7f20880f7000 r--p 00054000 08:30 59928                      /usr/lib/x86_64-linux-gnu/libtiff.so.6.0.0
+7f20880f7000-7f20880fc000 r--p 00086000 08:30 59928                      /usr/lib/x86_64-linux-gnu/libtiff.so.6.0.0
+7f20880fc000-7f20880fd000 rw-p 0008b000 08:30 59928                      /usr/lib/x86_64-linux-gnu/libtiff.so.6.0.0
+7f20880fd000-7f20880fe000 ---p 00000000 00:00 0
+7f20880fe000-7f2088102000 ---p 00000000 00:00 0
+7f2088102000-7f20881fe000 rw-p 00000000 00:00 0
+7f20881fe000-7f20881ff000 ---p 00000000 00:00 0
+7f20881ff000-7f2088203000 ---p 00000000 00:00 0
+7f2088203000-7f20882ff000 rw-p 00000000 00:00 0
+7f20882ff000-7f2088300000 ---p 00000000 00:00 0
+7f2088300000-7f2088304000 ---p 00000000 00:00 0
+7f2088304000-7f2088400000 rw-p 00000000 00:00 0
+7f2088400000-7f20884ce000 r-xp 00000000 08:30 54539                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjsvml.so
+7f20884ce000-7f20886cd000 ---p 000ce000 08:30 54539                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjsvml.so
+7f20886cd000-7f20886ce000 r--p 000cd000 08:30 54539                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjsvml.so
+7f20886ce000-7f20886cf000 rw-p 000ce000 08:30 54539                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjsvml.so
+7f20886d0000-7f20886d1000 r--p 00000000 08:30 59548                      /usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.0.9
+7f20886d1000-7f20886d8000 r-xp 00001000 08:30 59548                      /usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.0.9
+7f20886d8000-7f20886db000 r--p 00008000 08:30 59548                      /usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.0.9
+7f20886db000-7f20886dc000 r--p 0000a000 08:30 59548                      /usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.0.9
+7f20886dc000-7f20886dd000 rw-p 0000b000 08:30 59548                      /usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.0.9
+7f20886dd000-7f20886e1000 r--p 00000000 08:30 1053                       /usr/lib/x86_64-linux-gnu/liblzma.so.5.4.1
+7f20886e1000-7f20886fe000 r-xp 00004000 08:30 1053                       /usr/lib/x86_64-linux-gnu/liblzma.so.5.4.1
+7f20886fe000-7f208870a000 r--p 00021000 08:30 1053                       /usr/lib/x86_64-linux-gnu/liblzma.so.5.4.1
+7f208870a000-7f208870b000 r--p 0002d000 08:30 1053                       /usr/lib/x86_64-linux-gnu/liblzma.so.5.4.1
+7f208870b000-7f208870c000 rw-p 0002e000 08:30 1053                       /usr/lib/x86_64-linux-gnu/liblzma.so.5.4.1
+7f208870c000-7f208870d000 ---p 00000000 00:00 0
+7f208870d000-7f2088711000 ---p 00000000 00:00 0
+7f2088711000-7f208880d000 rw-p 00000000 00:00 0
+7f208880d000-7f208880e000 ---p 00000000 00:00 0
+7f208880e000-7f2088812000 ---p 00000000 00:00 0
+7f2088812000-7f208890e000 rw-p 00000000 00:00 0
+7f208890e000-7f208890f000 ---p 00000000 00:00 0
+7f208890f000-7f2088913000 ---p 00000000 00:00 0
+7f2088913000-7f2088a0f000 rw-p 00000000 00:00 0
+7f2088a0f000-7f2088a10000 ---p 00000000 00:00 0
+7f2088a10000-7f2088a14000 ---p 00000000 00:00 0
+7f2088a14000-7f2088b10000 rw-p 00000000 00:00 0
+7f2088b10000-7f2088b11000 ---p 00000000 00:00 0
+7f2088b11000-7f2088b15000 ---p 00000000 00:00 0
+7f2088b15000-7f2088c11000 rw-p 00000000 00:00 0
+7f2088c11000-7f2088c12000 ---p 00000000 00:00 0
+7f2088c12000-7f2088c16000 ---p 00000000 00:00 0
+7f2088c16000-7f2088d12000 rw-p 00000000 00:00 0
+7f2088d12000-7f2088d13000 ---p 00000000 00:00 0
+7f2088d13000-7f2088d17000 ---p 00000000 00:00 0
+7f2088d17000-7f2088e13000 rw-p 00000000 00:00 0
+7f2088e13000-7f2088e14000 ---p 00000000 00:00 0
+7f2088e14000-7f2088e18000 ---p 00000000 00:00 0
+7f2088e18000-7f2088f14000 rw-p 00000000 00:00 0
+7f2088f14000-7f2088f15000 ---p 00000000 00:00 0
+7f2088f15000-7f2089015000 rw-p 00000000 00:00 0
+7f2089015000-7f2089016000 ---p 00000000 00:00 0
+7f2089016000-7f20891f2000 rw-p 00000000 00:00 0
+7f20891f2000-7f20891f3000 ---p 00000000 00:00 0
+7f20891f3000-7f20892f3000 rw-p 00000000 00:00 0
+7f20892f3000-7f20892f4000 ---p 00000000 00:00 0
+7f20892f4000-7f208c000000 rw-p 00000000 00:00 0
+7f208c000000-7f208c021000 rw-p 00000000 00:00 0
+7f208c021000-7f2090000000 ---p 00000000 00:00 0
+7f2090000000-7f2090021000 rw-p 00000000 00:00 0
+7f2090021000-7f2094000000 ---p 00000000 00:00 0
+7f2094000000-7f2094021000 rw-p 00000000 00:00 0
+7f2094021000-7f2098000000 ---p 00000000 00:00 0
+7f2098002000-7f2098004000 r--p 00000000 08:30 59684                      /usr/lib/x86_64-linux-gnu/libgslcblas.so.0.0.0
+7f2098004000-7f209803e000 r-xp 00002000 08:30 59684                      /usr/lib/x86_64-linux-gnu/libgslcblas.so.0.0.0
+7f209803e000-7f2098042000 r--p 0003c000 08:30 59684                      /usr/lib/x86_64-linux-gnu/libgslcblas.so.0.0.0
+7f2098042000-7f2098043000 r--p 0003f000 08:30 59684                      /usr/lib/x86_64-linux-gnu/libgslcblas.so.0.0.0
+7f2098043000-7f2098044000 rw-p 00040000 08:30 59684                      /usr/lib/x86_64-linux-gnu/libgslcblas.so.0.0.0
+7f2098044000-7f2098145000 rw-p 00000000 00:00 0
+7f2098145000-7f2098146000 ---p 00000000 00:00 0
+7f2098146000-7f2098246000 rw-p 00000000 00:00 0
+7f2098246000-7f2098247000 ---p 00000000 00:00 0
+7f2098247000-7f2098347000 rw-p 00000000 00:00 0
+7f2098347000-7f2098348000 ---p 00000000 00:00 0
+7f2098348000-7f2098818000 rw-p 00000000 00:00 0
+7f2098818000-7f209c110000 ---p 00000000 00:00 0
+7f209c110000-7f209c192000 rw-p 00000000 00:00 0
+7f209c192000-7f209c8b1000 ---p 00000000 00:00 0
+7f209c8b1000-7f209c8b2000 rw-p 00000000 00:00 0
+7f209c8b2000-7f209d512000 rwxp 00000000 00:00 0
+7f209d512000-7f20a3d11000 ---p 00000000 00:00 0
+7f20a3d11000-7f20a40a1000 rwxp 00000000 00:00 0
+7f20a40a1000-7f20a4452000 ---p 00000000 00:00 0
+7f20a4452000-7f20a4872000 rwxp 00000000 00:00 0
+7f20a4872000-7f20ab8b2000 ---p 00000000 00:00 0
+7f20ab8b2000-7f20b4000000 r--s 00000000 08:30 54556                      /usr/lib/jvm/java-21-amazon-corretto/lib/modules
+7f20b4000000-7f20b7e6b000 rw-p 00000000 00:00 0
+7f20b7e6b000-7f20b8000000 ---p 00000000 00:00 0
+7f20b8003000-7f20b8005000 r--p 00000000 08:30 59729                      /usr/lib/x86_64-linux-gnu/libjbig.so.0
+7f20b8005000-7f20b800e000 r-xp 00002000 08:30 59729                      /usr/lib/x86_64-linux-gnu/libjbig.so.0
+7f20b800e000-7f20b8010000 r--p 0000b000 08:30 59729                      /usr/lib/x86_64-linux-gnu/libjbig.so.0
+7f20b8010000-7f20b8011000 r--p 0000c000 08:30 59729                      /usr/lib/x86_64-linux-gnu/libjbig.so.0
+7f20b8011000-7f20b8014000 rw-p 0000d000 08:30 59729                      /usr/lib/x86_64-linux-gnu/libjbig.so.0
+7f20b8014000-7f20b8029000 r--p 00000000 08:30 59661                      /usr/lib/x86_64-linux-gnu/libgeos_c.so.1.17.1
+7f20b8029000-7f20b8049000 r-xp 00015000 08:30 59661                      /usr/lib/x86_64-linux-gnu/libgeos_c.so.1.17.1
+7f20b8049000-7f20b8057000 r--p 00035000 08:30 59661                      /usr/lib/x86_64-linux-gnu/libgeos_c.so.1.17.1
+7f20b8057000-7f20b8059000 r--p 00042000 08:30 59661                      /usr/lib/x86_64-linux-gnu/libgeos_c.so.1.17.1
+7f20b8059000-7f20b805a000 rw-p 00044000 08:30 59661                      /usr/lib/x86_64-linux-gnu/libgeos_c.so.1.17.1
+7f20b805a000-7f20b80d4000 rw-p 00000000 00:00 0
+7f20b80d4000-7f20b87f3000 ---p 00000000 00:00 0
+7f20b87f3000-7f20b9400000 rw-p 00000000 00:00 0
+7f20b9400000-7f20b9420000 r-xp 00000000 08:30 54531                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjava.so
+7f20b9420000-7f20b961f000 ---p 00020000 08:30 54531                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjava.so
+7f20b961f000-7f20b9620000 r--p 0001f000 08:30 54531                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjava.so
+7f20b9620000-7f20b9621000 rw-p 00020000 08:30 54531                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjava.so
+7f20b9621000-7f20b9622000 rw-p 00000000 00:00 0
+7f20b9624000-7f20b9627000 r--p 00000000 08:30 1037                       /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+7f20b9627000-7f20b963e000 r-xp 00003000 08:30 1037                       /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+7f20b963e000-7f20b9642000 r--p 0001a000 08:30 1037                       /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+7f20b9642000-7f20b9643000 r--p 0001d000 08:30 1037                       /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+7f20b9643000-7f20b9644000 rw-p 0001e000 08:30 1037                       /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+7f20b9644000-7f20b9800000 rw-p 00000000 00:00 0
+7f20b9800000-7f20b980a000 r-xp 00000000 08:30 54526                      /usr/lib/jvm/java-21-amazon-corretto/lib/libinstrument.so
+7f20b980a000-7f20b9a09000 ---p 0000a000 08:30 54526                      /usr/lib/jvm/java-21-amazon-corretto/lib/libinstrument.so
+7f20b9a09000-7f20b9a0a000 r--p 00009000 08:30 54526                      /usr/lib/jvm/java-21-amazon-corretto/lib/libinstrument.so
+7f20b9a0a000-7f20b9a0b000 rw-p 0000a000 08:30 54526                      /usr/lib/jvm/java-21-amazon-corretto/lib/libinstrument.so
+7f20b9a0b000-7f20b9a0e000 r--p 00000000 08:30 59758                      /usr/lib/x86_64-linux-gnu/liblber-2.5.so.0.1.8
+7f20b9a0e000-7f20b9a16000 r-xp 00003000 08:30 59758                      /usr/lib/x86_64-linux-gnu/liblber-2.5.so.0.1.8
+7f20b9a16000-7f20b9a19000 r--p 0000b000 08:30 59758                      /usr/lib/x86_64-linux-gnu/liblber-2.5.so.0.1.8
+7f20b9a19000-7f20b9a1a000 r--p 0000e000 08:30 59758                      /usr/lib/x86_64-linux-gnu/liblber-2.5.so.0.1.8
+7f20b9a1a000-7f20b9a1b000 rw-p 0000f000 08:30 59758                      /usr/lib/x86_64-linux-gnu/liblber-2.5.so.0.1.8
+7f20b9a1b000-7f20b9a1f000 r--p 00000000 08:30 59737                      /usr/lib/x86_64-linux-gnu/libjson-c.so.5.2.0
+7f20b9a1f000-7f20b9a28000 r-xp 00004000 08:30 59737                      /usr/lib/x86_64-linux-gnu/libjson-c.so.5.2.0
+7f20b9a28000-7f20b9a2c000 r--p 0000d000 08:30 59737                      /usr/lib/x86_64-linux-gnu/libjson-c.so.5.2.0
+7f20b9a2c000-7f20b9a2d000 r--p 00010000 08:30 59737                      /usr/lib/x86_64-linux-gnu/libjson-c.so.5.2.0
+7f20b9a2d000-7f20b9a2e000 rw-p 00011000 08:30 59737                      /usr/lib/x86_64-linux-gnu/libjson-c.so.5.2.0
+7f20b9a2e000-7f20b9a37000 rw-p 00000000 00:00 0
+7f20b9a37000-7f20b9b17000 ---p 00000000 00:00 0
+7f20b9b17000-7f20b9b30000 rw-p 00000000 00:00 0
+7f20b9b30000-7f20b9c00000 ---p 00000000 00:00 0
+7f20b9c00000-7f20b9c1b000 r-xp 00000000 08:30 54535                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjimage.so
+7f20b9c1b000-7f20b9e1a000 ---p 0001b000 08:30 54535                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjimage.so
+7f20b9e1a000-7f20b9e1c000 r--p 0001a000 08:30 54535                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjimage.so
+7f20b9e1c000-7f20b9e1d000 rw-p 0001c000 08:30 54535                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjimage.so
+7f20b9e20000-7f20b9e24000 ---p 00000000 00:00 0
+7f20b9e24000-7f20b9f20000 rw-p 00000000 00:00 0
+7f20b9f20000-7f20b9f30000 r--p 00000000 08:30 1054                       /usr/lib/x86_64-linux-gnu/libm.so.6
+7f20b9f30000-7f20b9fa4000 r-xp 00010000 08:30 1054                       /usr/lib/x86_64-linux-gnu/libm.so.6
+7f20b9fa4000-7f20b9ffe000 r--p 00084000 08:30 1054                       /usr/lib/x86_64-linux-gnu/libm.so.6
+7f20b9ffe000-7f20b9fff000 r--p 000dd000 08:30 1054                       /usr/lib/x86_64-linux-gnu/libm.so.6
+7f20b9fff000-7f20ba000000 rw-p 000de000 08:30 1054                       /usr/lib/x86_64-linux-gnu/libm.so.6
+7f20ba000000-7f20bb457000 r-xp 00000000 08:30 54568                      /usr/lib/jvm/java-21-amazon-corretto/lib/server/libjvm.so
+7f20bb457000-7f20bb656000 ---p 01457000 08:30 54568                      /usr/lib/jvm/java-21-amazon-corretto/lib/server/libjvm.so
+7f20bb656000-7f20bb72a000 r--p 01456000 08:30 54568                      /usr/lib/jvm/java-21-amazon-corretto/lib/server/libjvm.so
+7f20bb72a000-7f20bb75a000 rw-p 0152a000 08:30 54568                      /usr/lib/jvm/java-21-amazon-corretto/lib/server/libjvm.so
+7f20bb75a000-7f20bb7c0000 rw-p 00000000 00:00 0
+7f20bb7c7000-7f20bb810000 rw-p 00000000 00:00 0
+7f20bb810000-7f20bb817000 ---p 00000000 00:00 0
+7f20bb817000-7f20bb81f000 rw-s 00000000 08:30 95177                      /tmp/hsperfdata_root/17967
+7f20bb81f000-7f20bb845000 r--p 00000000 08:30 1015                       /usr/lib/x86_64-linux-gnu/libc.so.6
+7f20bb845000-7f20bb99a000 r-xp 00026000 08:30 1015                       /usr/lib/x86_64-linux-gnu/libc.so.6
+7f20bb99a000-7f20bb9ed000 r--p 0017b000 08:30 1015                       /usr/lib/x86_64-linux-gnu/libc.so.6
+7f20bb9ed000-7f20bb9f1000 r--p 001ce000 08:30 1015                       /usr/lib/x86_64-linux-gnu/libc.so.6
+7f20bb9f1000-7f20bb9f3000 rw-p 001d2000 08:30 1015                       /usr/lib/x86_64-linux-gnu/libc.so.6
+7f20bb9f3000-7f20bba00000 rw-p 00000000 00:00 0
+7f20bba00000-7f20bba0f000 r-xp 00000000 08:30 54536                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjli.so
+7f20bba0f000-7f20bbc0f000 ---p 0000f000 08:30 54536                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjli.so
+7f20bbc0f000-7f20bbc10000 r--p 0000f000 08:30 54536                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjli.so
+7f20bbc10000-7f20bbc11000 rw-p 00010000 08:30 54536                      /usr/lib/jvm/java-21-amazon-corretto/lib/libjli.so
+7f20bbc11000-7f20bbc13000 r--p 00000000 08:30 1022                       /usr/lib/x86_64-linux-gnu/libcom_err.so.2.1
+7f20bbc13000-7f20bbc14000 r-xp 00002000 08:30 1022                       /usr/lib/x86_64-linux-gnu/libcom_err.so.2.1
+7f20bbc14000-7f20bbc15000 r--p 00003000 08:30 1022                       /usr/lib/x86_64-linux-gnu/libcom_err.so.2.1
+7f20bbc15000-7f20bbc16000 r--p 00003000 08:30 1022                       /usr/lib/x86_64-linux-gnu/libcom_err.so.2.1
+7f20bbc16000-7f20bbc17000 rw-p 00004000 08:30 1022                       /usr/lib/x86_64-linux-gnu/libcom_err.so.2.1
+7f20bbc17000-7f20bbc18000 r--p 00000000 08:30 1083                       /usr/lib/x86_64-linux-gnu/librt.so.1
+7f20bbc18000-7f20bbc19000 r-xp 00001000 08:30 1083                       /usr/lib/x86_64-linux-gnu/librt.so.1
+7f20bbc19000-7f20bbc1a000 r--p 00002000 08:30 1083                       /usr/lib/x86_64-linux-gnu/librt.so.1
+7f20bbc1a000-7f20bbc1b000 r--p 00002000 08:30 1083                       /usr/lib/x86_64-linux-gnu/librt.so.1
+7f20bbc1b000-7f20bbc1c000 rw-p 00003000 08:30 1083                       /usr/lib/x86_64-linux-gnu/librt.so.1
+7f20bbc1c000-7f20bbc20000 rw-p 00000000 00:00 0
+7f20bbc20000-7f20bbc21000 r--p 00000000 08:30 1028                       /usr/lib/x86_64-linux-gnu/libdl.so.2
+7f20bbc21000-7f20bbc22000 r-xp 00001000 08:30 1028                       /usr/lib/x86_64-linux-gnu/libdl.so.2
+7f20bbc22000-7f20bbc23000 r--p 00002000 08:30 1028                       /usr/lib/x86_64-linux-gnu/libdl.so.2
+7f20bbc23000-7f20bbc24000 r--p 00002000 08:30 1028                       /usr/lib/x86_64-linux-gnu/libdl.so.2
+7f20bbc24000-7f20bbc25000 rw-p 00003000 08:30 1028                       /usr/lib/x86_64-linux-gnu/libdl.so.2
+7f20bbc25000-7f20bbc26000 r--p 00000000 08:30 1081                       /usr/lib/x86_64-linux-gnu/libpthread.so.0
+7f20bbc26000-7f20bbc27000 r-xp 00001000 08:30 1081                       /usr/lib/x86_64-linux-gnu/libpthread.so.0
+7f20bbc27000-7f20bbc28000 r--p 00002000 08:30 1081                       /usr/lib/x86_64-linux-gnu/libpthread.so.0
+7f20bbc28000-7f20bbc29000 r--p 00002000 08:30 1081                       /usr/lib/x86_64-linux-gnu/libpthread.so.0
+7f20bbc29000-7f20bbc2a000 rw-p 00003000 08:30 1081                       /usr/lib/x86_64-linux-gnu/libpthread.so.0
+7f20bbc2a000-7f20bbc2d000 r--p 00000000 08:30 1114                       /usr/lib/x86_64-linux-gnu/libz.so.1.2.13
+7f20bbc2d000-7f20bbc40000 r-xp 00003000 08:30 1114                       /usr/lib/x86_64-linux-gnu/libz.so.1.2.13
+7f20bbc40000-7f20bbc47000 r--p 00016000 08:30 1114                       /usr/lib/x86_64-linux-gnu/libz.so.1.2.13
+7f20bbc47000-7f20bbc48000 r--p 0001c000 08:30 1114                       /usr/lib/x86_64-linux-gnu/libz.so.1.2.13
+7f20bbc48000-7f20bbc49000 rw-p 0001d000 08:30 1114                       /usr/lib/x86_64-linux-gnu/libz.so.1.2.13
+7f20bbc4c000-7f20bbc4d000 r-xp 00000000 00:00 0
+7f20bbc4d000-7f20bbc4e000 ---p 00000000 00:00 0
+7f20bbc4e000-7f20bbc4f000 r--p 00000000 00:00 0
+7f20bbc4f000-7f20bbc50000 ---p 00000000 00:00 0
+7f20bbc50000-7f20bbc52000 rw-p 00000000 00:00 0
+7f20bbc52000-7f20bbc53000 r--p 00000000 08:30 997                        /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+7f20bbc53000-7f20bbc79000 r-xp 00001000 08:30 997                        /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+7f20bbc79000-7f20bbc83000 r--p 00027000 08:30 997                        /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+7f20bbc83000-7f20bbc85000 r--p 00031000 08:30 997                        /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+7f20bbc85000-7f20bbc87000 rw-p 00033000 08:30 997                        /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+7ffd56a89000-7ffd56aaa000 rw-p 00000000 00:00 0                          [stack]
+7ffd56b35000-7ffd56b39000 r--p 00000000 00:00 0                          [vvar]
+7ffd56b39000-7ffd56b3b000 r-xp 00000000 00:00 0                          [vdso]
+Total number of mappings: 557
+
+
+VM Arguments:
+jvm_args: -javaagent:/root/.m2/repository/org/jacoco/org.jacoco.agent/0.8.11/org.jacoco.agent-0.8.11-runtime.jar=destfile=/usr/local/jmeos/target/jacoco.exec
+java_command: /usr/local/jmeos/target/surefire/surefirebooter-20250905100721159_3.jar /usr/local/jmeos/target/surefire 2025-09-05T10-07-20_570-jvmRun1 surefire-20250905100721159_1tmp surefire_0-20250905100721159_2tmp
+java_class_path (initial): /usr/local/jmeos/target/surefire/surefirebooter-20250905100721159_3.jar
+Launcher Type: SUN_STANDARD
+
+[Global flags]
+     intx CICompilerCount                          = 12                                        {product} {ergonomic}
+     uint ConcGCThreads                            = 3                                         {product} {ergonomic}
+     uint G1ConcRefinementThreads                  = 13                                        {product} {ergonomic}
+   size_t G1HeapRegionSize                         = 2097152                                   {product} {ergonomic}
+    uintx GCDrainStackTargetSize                   = 64                                        {product} {ergonomic}
+   size_t InitialHeapSize                          = 255852544                                 {product} {ergonomic}
+   size_t MarkStackSize                            = 4194304                                   {product} {ergonomic}
+   size_t MaxHeapSize                              = 4081057792                                {product} {ergonomic}
+   size_t MaxNewSize                               = 2447376384                                {product} {ergonomic}
+   size_t MinHeapDeltaBytes                        = 2097152                                   {product} {ergonomic}
+   size_t MinHeapSize                              = 8388608                                   {product} {ergonomic}
+    uintx NonNMethodCodeHeapSize                   = 7602480                                {pd product} {ergonomic}
+    uintx NonProfiledCodeHeapSize                  = 122027880                              {pd product} {ergonomic}
+    uintx ProfiledCodeHeapSize                     = 122027880                              {pd product} {ergonomic}
+    uintx ReservedCodeCacheSize                    = 251658240                              {pd product} {ergonomic}
+     bool SegmentedCodeCache                       = true                                      {product} {ergonomic}
+   size_t SoftMaxHeapSize                          = 4081057792                             {manageable} {ergonomic}
+     bool UseCompressedOops                        = true                           {product lp64_product} {ergonomic}
+     bool UseG1GC                                  = true                                      {product} {ergonomic}
+
+Logging:
+Log output configuration:
+ #0: stdout all=warning uptime,level,tags foldmultilines=false
+ #1: stderr all=off uptime,level,tags foldmultilines=false
+
+Environment Variables:
+PATH=/vscode/vscode-server/bin/linux-x64/2901c5ac6db8a986a5666c3af51ff804d05af0d4/bin/remote-cli:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+SHELL=/bin/bash
+LANG=en_US.UTF-8
+TERM=xterm-256color
+
+Active Locale:
+LC_ALL=C
+LC_COLLATE=C
+LC_CTYPE=C
+LC_MESSAGES=C
+LC_MONETARY=C
+LC_NUMERIC=C
+LC_TIME=C
+
+Signal Handlers:
+   SIGSEGV: crash_handler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, unblocked
+    SIGBUS: crash_handler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, unblocked
+    SIGFPE: crash_handler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, unblocked
+   SIGPIPE: javaSignalHandler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, blocked
+   SIGXFSZ: javaSignalHandler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, blocked
+    SIGILL: crash_handler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, unblocked
+   SIGUSR2: SR_handler in libjvm.so, mask=00000000000000000000000000000000, flags=SA_RESTART|SA_SIGINFO, blocked
+    SIGHUP: UserHandler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, blocked
+    SIGINT: UserHandler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, blocked
+   SIGTERM: UserHandler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, blocked
+   SIGQUIT: UserHandler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, blocked
+   SIGTRAP: crash_handler in libjvm.so, mask=11100100010111111101111111111110, flags=SA_RESTART|SA_SIGINFO, unblocked
+
+
+Periodic native trim disabled
+
+---------------  S Y S T E M  ---------------
+
+OS:
+PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+NAME="Debian GNU/Linux"
+VERSION_ID="12"
+VERSION="12 (bookworm)"
+VERSION_CODENAME=bookworm
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"
+uname: Linux 5.15.167.4-microsoft-standard-WSL2 #1 SMP Tue Nov 5 00:21:55 UTC 2024 x86_64
+OS uptime: 0 days 1:36 hours
+libc: glibc 2.36 NPTL 2.36
+rlimit (soft/hard): STACK 8192k/infinity , CORE 0k/infinity , NPROC infinity/infinity , NOFILE 1048576/1048576 , AS infinity/infinity , CPU infinity/infinity , DATA infinity/infinity , FSIZE infinity/infinity , MEMLOCK infinity/infinity
+load average: 1.19 0.42 0.20
+
+/proc/meminfo:
+MemTotal:       15937872 kB
+MemFree:        13319208 kB
+MemAvailable:   13603704 kB
+Buffers:            6296 kB
+Cached:           507624 kB
+SwapCached:            0 kB
+Active:           137140 kB
+Inactive:        2082940 kB
+Active(anon):       2212 kB
+Inactive(anon):  1707636 kB
+Active(file):     134928 kB
+Inactive(file):   375304 kB
+Unevictable:           0 kB
+Mlocked:               0 kB
+SwapTotal:       4194304 kB
+SwapFree:        4194304 kB
+Dirty:              1296 kB
+Writeback:             0 kB
+AnonPages:       1662292 kB
+Mapped:           376168 kB
+Shmem:              3652 kB
+KReclaimable:      41916 kB
+Slab:             112204 kB
+SReclaimable:      41916 kB
+SUnreclaim:        70288 kB
+KernelStack:       10080 kB
+PageTables:        15748 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    12163240 kB
+Committed_AS:    3225628 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:       32812 kB
+VmallocChunk:          0 kB
+Percpu:             5568 kB
+AnonHugePages:    768000 kB
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+FileHugePages:         0 kB
+FilePmdMapped:         0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+Hugetlb:               0 kB
+DirectMap4k:       29696 kB
+DirectMap2M:     5812224 kB
+DirectMap1G:    18874368 kB
+
+/sys/kernel/mm/transparent_hugepage/enabled: [always] madvise never
+/sys/kernel/mm/transparent_hugepage/hpage_pmd_size: 2097152
+/sys/kernel/mm/transparent_hugepage/defrag (defrag/compaction efforts parameter): always defer defer+madvise [madvise] never
+
+Process Memory:
+Virtual Size: 8261832K (peak: 8261832K)
+Resident Set Size: 470332K (peak: 470336K) (anon: 433656K, file: 36676K, shmem: 0K)
+Swapped out: 0K
+C-Heap outstanding allocations: 129439K, retained: 50488K
+glibc malloc tunables: (default)
+
+/proc/sys/kernel/threads-max (system-wide limit on the number of threads): 124460
+/proc/sys/vm/max_map_count (maximum number of memory map areas a process may have): 262144
+/proc/sys/vm/swappiness (control to define how aggressively the kernel swaps out anonymous memory): 60
+/proc/sys/kernel/pid_max (system-wide limit on number of process identifiers): 99999
+
+container (cgroup) information:
+container_type: cgroupv1
+cpu_cpuset_cpus: 0-15
+cpu_memory_nodes: 0
+active_processor_count: 16
+cpu_quota: no quota
+cpu_period: 100000
+cpu_shares: no shares
+memory_limit_in_bytes: unlimited
+memory_and_swap_limit_in_bytes: unlimited
+memory_soft_limit_in_bytes: unlimited
+memory_usage_in_bytes: 1479880 k
+memory_max_usage_in_bytes: 1488000 k
+kernel_memory_usage_in_bytes: 26012 k
+kernel_memory_max_usage_in_bytes: unlimited
+kernel_memory_limit_in_bytes: 28116 k
+maximum number of tasks: unlimited
+current number of tasks: 160
+
+Hyper-V virtualization detected
+Steal ticks since vm start: 0
+Steal ticks percentage since vm start:  0.000
+
+CPU: total 16 (initial active 16) (16 cores per cpu, 2 threads per core) family 25 model 97 stepping 2 microcode 0xffffffff, cx8, cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4a, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, erms, clmul, bmi1, bmi2, adx, avx512f, avx512dq, avx512cd, avx512bw, avx512vl, sha, fma, vzeroupper, avx512_vpopcntdq, avx512_vpclmulqdq, avx512_vaes, avx512_vnni, clflush, clflushopt, avx512_vbmi2, avx512_vbmi, hv, rdtscp, rdpid, fsrm, gfni, avx512_bitalg, f16c, cet_ss, avx512_ifma
+CPU Model and flags from /proc/cpuinfo:
+model name	: AMD Ryzen 7 7800X3D 8-Core Processor
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid pni pclmulqdq ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext perfctr_core ssbd ibrs ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves avx512_bf16 clzero xsaveerptr arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload avx512vbmi umip avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq rdpid fsrm
+
+Online cpus: 0-15
+Offline cpus:
+BIOS frequency limitation: <Not Available>
+Frequency switch latency (ns): <Not Available>
+Available cpu frequencies: <Not Available>
+Current governor: <Not Available>
+Core performance/turbo boost: <Not Available>
+
+Memory: 4k page, physical 15937872k(13603704k free), swap 4194304k(4194304k free)
+Page Sizes: 4k
+
+vm_info: OpenJDK 64-Bit Server VM (21.0.6+7-LTS) for linux-amd64 JRE (21.0.6+7-LTS), built on 2025-01-07T23:42:45Z by "jenkins" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)
+
+END.

--- a/src/main/java/builder/FunctionsGenerator.java
+++ b/src/main/java/builder/FunctionsGenerator.java
@@ -1,15 +1,22 @@
 package builder;
 
-import utils.BuilderUtils;
-import utils.Pair;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import utils.BuilderUtils;
+import utils.Pair;
 
 /**
  * Class used to generate the functions from the MEOS library.
@@ -159,6 +166,7 @@ public class FunctionsGenerator {
 		types.put("Pointer\\[\\]", "Pointer"); // Keep this line, otherwise operand error in JNR-FFI
 		types.put("bool", "boolean");
 		types.put("float", "float");
+		types.put("float8", "double");
 		types.put("double", "double");
 		types.put("void", "void");
 		types.put("int", "int");
@@ -184,6 +192,20 @@ public class FunctionsGenerator {
 		types.put("size_t", "long");
 		types.put("interpType", "int"); // enum in C
 		//types.put("\\char **","Pointer");
+
+		// Nouveaux types pour 1.3
+		types.put("DateADT", "int");
+		types.put("TimeADT", "long");
+		types.put("Timestamp", "long");
+		types.put("TimestampTz", "long");
+		types.put("TimeOffset", "long");
+		types.put("fsec_t", "int");
+		types.put("Datum", "long");
+		types.put("uintptr_t", "long");
+
+		types.put("OffsetDateTime", "OffsetDateTime");
+		types.put("LocalDateTime", "LocalDateTime");
+
 		
 		return types;
 	}
@@ -506,7 +528,8 @@ public class FunctionsGenerator {
 	 */
 	private StringBuilder generateFunctions(String filePath, boolean performTypesConversion) {
 		var builder = new StringBuilder();
-		
+		Set<String> seen = new HashSet<>();
+
 		BuilderUtils.readFileLines(filePath, line -> {
 			line = performTypeConversion(line);
 			
@@ -523,11 +546,15 @@ public class FunctionsGenerator {
 			/* Perform equivalent type conversion */
 			line = BuilderUtils.replaceTypes(equivalentTypes, line);
 			unsupportedEquivalentTypes.addAll(getUnsupportedTypes(line, equivalentTypes).stream().filter(type -> !unsupportedEquivalentTypes.contains(type)).toList());
-			
-			builder.append(BuilderUtils.formattingLine(line, "", "\n"));
+
+			String fnName = BuilderUtils.extractFunctionName(line);
+			int arity = BuilderUtils.extractParamTypesAndNames(line).size();
+			String key = fnName + "#" + arity;
+
+			if (seen.add(key)){
+				builder.append(line).append("\n"); 
+			}
 		});
 		return builder;
 	}
-	
-	
 }

--- a/src/main/java/functions/functions.java
+++ b/src/main/java/functions/functions.java
@@ -1,27 +1,24 @@
 package functions;
 
-import jnr.ffi.*;
+import jnr.ffi.Pointer;
+import jnr.ffi.Memory;
 import jnr.ffi.Runtime;
-import org.w3c.dom.ls.LSOutput;
+import jnr.ffi.byref.PointerByReference;
+import jnr.ffi.Struct;
 import utils.JarLibraryLoader;
-import jnr.ffi.LibraryLoader;
+import utils.meosCatalog.MeosEnums.meosType;
+import utils.meosCatalog.MeosEnums.meosOper;
 
 import java.time.*;
-import java.util.HashMap;
-import java.util.Map;
 
 public class functions {
 	public interface MeosLibrary {
 
-		String gitLibraryPath= "/home/runner/work/JMEOS/JMEOS/src/lib";
+	    String libraryPath = "libmeos.so";
 
-		String libraryName= "meos";
-
-		MeosLibrary INSTANCE = JarLibraryLoader.create(MeosLibrary.class, libraryName).getLibraryInstance();
+		MeosLibrary INSTANCE = JarLibraryLoader.create(MeosLibrary.class, libraryPath).getLibraryInstance();
 
 		MeosLibrary meos = MeosLibrary.INSTANCE;
-
-		int geo_get_srid(Pointer g);
 
 		void meos_error(int errlevel, int errcode, String format, Pointer args);
 
@@ -47,7 +44,7 @@ public class functions {
 
 		String meos_get_intervalstyle();
 
-		void meos_initialize(String tz_str, error_handler_fn err_handler);
+		void meos_initialize();
 
 		void meos_finalize();
 
@@ -63,7 +60,11 @@ public class functions {
 
 		Pointer cstring2text(String str);
 
+		long date_to_timestamp(int dateVal);
+
 		long date_to_timestamptz(int d);
+
+		double float_round(double d, int maxdd);
 
 		Pointer minus_date_date(int d1, int d2);
 
@@ -74,30 +75,6 @@ public class functions {
 		Pointer minus_timestamptz_timestamptz(long t1, long t2);
 
 		Pointer mult_interval_double(Pointer interv, double factor);
-
-		int pg_date_in(String str);
-
-		String pg_date_out(int d);
-
-		int pg_interval_cmp(Pointer interv1, Pointer interv2);
-
-		Pointer pg_interval_in(String str, int typmod);
-
-		Pointer pg_interval_make(int years, int months, int weeks, int days, int hours, int mins, double secs);
-
-		String pg_interval_out(Pointer interv);
-
-		long pg_time_in(String str, int typmod);
-
-		String pg_time_out(long t);
-
-		long pg_timestamp_in(String str, int typmod);
-
-		String pg_timestamp_out(long t);
-
-		long pg_timestamptz_in(String str, int typmod);
-
-		String pg_timestamptz_out(long t);
 
 		String text2cstring(Pointer txt);
 
@@ -115,37 +92,9 @@ public class functions {
 
 		Pointer textcat_text_text(Pointer txt1, Pointer txt2);
 
+		int timestamp_to_date(long t);
+
 		int timestamptz_to_date(long t);
-
-		Pointer geo_as_ewkb(Pointer gs, String endian);
-
-		String geo_as_ewkt(Pointer gs, int precision);
-
-		String geo_as_geojson(Pointer gs, int option, int precision, String srs);
-
-		String geo_as_hexewkb(Pointer gs, String endian);
-
-		String geo_as_text(Pointer gs, int precision);
-
-		Pointer geo_from_ewkb(Pointer bytea_wkb, int srid);
-
-		Pointer geo_from_geojson(String geojson);
-
-		String geo_out(Pointer gs);
-
-		boolean geo_same(Pointer gs1, Pointer gs2);
-
-		Pointer geography_from_hexewkb(String wkt);
-
-		Pointer geography_from_text(String wkt, int srid);
-
-		Pointer geometry_from_hexewkb(String wkt);
-
-		Pointer geometry_from_text(String wkt, int srid);
-
-		Pointer pgis_geography_in(String str, int typmod);
-
-		Pointer pgis_geometry_in(String str, int typmod);
 
 		Pointer bigintset_in(String str);
 
@@ -183,16 +132,6 @@ public class functions {
 
 		String floatspanset_out(Pointer ss, int maxdd);
 
-		Pointer geogset_in(String str);
-
-		Pointer geomset_in(String str);
-
-		String geoset_as_ewkt(Pointer set, int maxdd);
-
-		String geoset_as_text(Pointer set, int maxdd);
-
-		String geoset_out(Pointer set, int maxdd);
-
 		Pointer intset_in(String str);
 
 		String intset_out(Pointer set);
@@ -213,6 +152,8 @@ public class functions {
 
 		Pointer set_from_wkb(Pointer wkb, long size);
 
+		Pointer set_round(Pointer s, int maxdd);
+
 		String span_as_hexwkb(Pointer s, byte variant, Pointer size_out);
 
 		Pointer span_as_wkb(Pointer s, byte variant, Pointer size_out);
@@ -228,6 +169,10 @@ public class functions {
 		Pointer spanset_from_hexwkb(String hexwkb);
 
 		Pointer spanset_from_wkb(Pointer wkb, long size);
+
+		String spatialset_as_ewkt(Pointer set, int maxdd);
+
+		String spatialset_as_text(Pointer set, int maxdd);
 
 		Pointer textset_in(String str);
 
@@ -257,8 +202,6 @@ public class functions {
 
 		Pointer floatspan_make(double lower, double upper, boolean lower_inc, boolean upper_inc);
 
-		Pointer geoset_make(Pointer values, int count);
-
 		Pointer intset_make(Pointer values, int count);
 
 		Pointer intspan_make(int lower, int upper, boolean lower_inc, boolean upper_inc);
@@ -269,7 +212,7 @@ public class functions {
 
 		Pointer spanset_copy(Pointer ss);
 
-		Pointer spanset_make(Pointer spans, int count, boolean normalize, boolean order);
+		Pointer spanset_make(Pointer spans, int count);
 
 		Pointer textset_make(Pointer values, int count);
 
@@ -277,67 +220,65 @@ public class functions {
 
 		Pointer tstzspan_make(long lower, long upper, boolean lower_inc, boolean upper_inc);
 
-		Pointer bigint_to_set(long i);
+		Pointer bigint_set(long i);
 
-		Pointer bigint_to_span(int i);
+		Pointer bigint_span(int i);
 
-		Pointer bigint_to_spanset(int i);
+		Pointer bigint_spanset(int i);
 
-		Pointer date_to_set(int d);
+		Pointer date_set(int d);
 
-		Pointer date_to_span(int d);
+		Pointer date_span(int d);
 
-		Pointer date_to_spanset(int d);
+		Pointer date_spanset(int d);
 
-		Pointer dateset_to_tstzset(Pointer s);
+		Pointer dateset_tstzset(Pointer s);
 
-		Pointer datespan_to_tstzspan(Pointer s);
+		Pointer datespan_tstzspan(Pointer s);
 
-		Pointer datespanset_to_tstzspanset(Pointer ss);
+		Pointer datespanset_tstzspanset(Pointer ss);
 
-		Pointer float_to_set(double d);
+		Pointer float_set(double d);
 
-		Pointer float_to_span(double d);
+		Pointer float_span(double d);
 
-		Pointer float_to_spanset(double d);
+		Pointer float_spanset(double d);
 
-		Pointer floatset_to_intset(Pointer s);
+		Pointer floatset_intset(Pointer s);
 
-		Pointer floatspan_to_intspan(Pointer s);
+		Pointer floatspan_intspan(Pointer s);
 
-		Pointer floatspanset_to_intspanset(Pointer ss);
+		Pointer floatspanset_intspanset(Pointer ss);
 
-		Pointer geo_to_set(Pointer gs);
+		Pointer int_set(int i);
 
-		Pointer int_to_set(int i);
+		Pointer int_span(int i);
 
-		Pointer int_to_span(int i);
+		Pointer int_spanset(int i);
 
-		Pointer int_to_spanset(int i);
+		Pointer intset_floatset(Pointer s);
 
-		Pointer intset_to_floatset(Pointer s);
+		Pointer intspan_floatspan(Pointer s);
 
-		Pointer intspan_to_floatspan(Pointer s);
+		Pointer intspanset_floatspanset(Pointer ss);
 
-		Pointer intspanset_to_floatspanset(Pointer ss);
+		Pointer set_spanset(Pointer s);
 
-		Pointer set_to_spanset(Pointer s);
+		Pointer span_spanset(Pointer s);
 
-		Pointer span_to_spanset(Pointer s);
+		Pointer text_set(Pointer txt);
 
-		Pointer text_to_set(Pointer txt);
+		Pointer timestamptz_set(long t);
 
-		Pointer timestamptz_to_set(long t);
+		Pointer timestamptz_span(long t);
 
-		Pointer timestamptz_to_span(long t);
+		Pointer timestamptz_spanset(long t);
 
-		Pointer timestamptz_to_spanset(long t);
+		Pointer tstzset_dateset(Pointer s);
 
-		Pointer tstzset_to_dateset(Pointer s);
+		Pointer tstzspan_datespan(Pointer s);
 
-		Pointer tstzspan_to_datespan(Pointer s);
-
-		Pointer tstzspanset_to_datespanset(Pointer ss);
+		Pointer tstzspanset_datespanset(Pointer ss);
 
 		long bigintset_end_value(Pointer s);
 
@@ -405,16 +346,6 @@ public class functions {
 
 		double floatspanset_width(Pointer ss, boolean boundspan);
 
-		Pointer geoset_end_value(Pointer s);
-
-		int geoset_srid(Pointer s);
-
-		Pointer geoset_start_value(Pointer s);
-
-		boolean geoset_value_n(Pointer s, int n, Pointer result);
-
-		Pointer geoset_values(Pointer s);
-
 		int intset_end_value(Pointer s);
 
 		int intset_start_value(Pointer s);
@@ -441,7 +372,7 @@ public class functions {
 
 		int set_num_values(Pointer s);
 
-		Pointer set_to_span(Pointer s);
+		Pointer set_span(Pointer s);
 
 		int span_hash(Pointer s);
 
@@ -465,7 +396,7 @@ public class functions {
 
 		Pointer spanset_span_n(Pointer ss, int i);
 
-		Pointer spanset_spans(Pointer ss);
+		Pointer spanset_spanarr(Pointer ss);
 
 		Pointer spanset_start_span(Pointer ss);
 
@@ -529,13 +460,15 @@ public class functions {
 
 		Pointer floatset_radians(Pointer s);
 
-		Pointer floatset_round(Pointer s, int maxdd);
-
 		Pointer floatset_shift_scale(Pointer s, double shift, double width, boolean hasshift, boolean haswidth);
 
 		Pointer floatspan_ceil(Pointer s);
 
 		Pointer floatspan_floor(Pointer s);
+
+		Pointer floatspan_degrees(Pointer s, boolean normalize);
+
+		Pointer floatspan_radians(Pointer s);
 
 		Pointer floatspan_round(Pointer s, int maxdd);
 
@@ -545,27 +478,31 @@ public class functions {
 
 		Pointer floatspanset_floor(Pointer ss);
 
+		Pointer floatspanset_degrees(Pointer ss, boolean normalize);
+
+		Pointer floatspanset_radians(Pointer ss);
+
 		Pointer floatspanset_round(Pointer ss, int maxdd);
 
 		Pointer floatspanset_shift_scale(Pointer ss, double shift, double width, boolean hasshift, boolean haswidth);
-
-		Pointer geoset_round(Pointer s, int maxdd);
-
-		Pointer geoset_set_srid(Pointer s, int srid);
-
-		Pointer geoset_transform(Pointer s, int srid);
-
-		Pointer geoset_transform_pipeline(Pointer s, String pipelinestr, int srid, boolean is_forward);
-
-		Pointer point_transform(Pointer gs, int srid);
-
-		Pointer point_transform_pipeline(Pointer gs, String pipelinestr, int srid, boolean is_forward);
 
 		Pointer intset_shift_scale(Pointer s, int shift, int width, boolean hasshift, boolean haswidth);
 
 		Pointer intspan_shift_scale(Pointer s, int shift, int width, boolean hasshift, boolean haswidth);
 
 		Pointer intspanset_shift_scale(Pointer ss, int shift, int width, boolean hasshift, boolean haswidth);
+
+		Pointer set_spans(Pointer s);
+
+		Pointer set_split_each_n_spans(Pointer s, int elem_count, Pointer count);
+
+		Pointer set_split_n_spans(Pointer s, int span_count, Pointer count);
+
+		Pointer spanset_spans(Pointer ss);
+
+		Pointer spanset_split_each_n_spans(Pointer ss, int elem_count, Pointer count);
+
+		Pointer spanset_split_n_spans(Pointer ss, int span_count, Pointer count);
 
 		Pointer textset_initcap(Pointer s);
 
@@ -679,8 +616,6 @@ public class functions {
 
 		boolean contained_float_spanset(double d, Pointer ss);
 
-		boolean contained_geo_set(Pointer gs, Pointer s);
-
 		boolean contained_int_set(int i, Pointer s);
 
 		boolean contained_int_span(int i, Pointer s);
@@ -710,8 +645,6 @@ public class functions {
 		boolean contains_set_date(Pointer s, int d);
 
 		boolean contains_set_float(Pointer s, double d);
-
-		boolean contains_set_geo(Pointer s, Pointer gs);
 
 		boolean contains_set_int(Pointer s, int i);
 
@@ -1061,8 +994,6 @@ public class functions {
 
 		Pointer intersection_float_set(double d, Pointer s);
 
-		Pointer intersection_geo_set(Pointer gs, Pointer s);
-
 		Pointer intersection_int_set(int i, Pointer s);
 
 		Pointer intersection_set_bigint(Pointer s, long i);
@@ -1070,8 +1001,6 @@ public class functions {
 		Pointer intersection_set_date(Pointer s, int d);
 
 		Pointer intersection_set_float(Pointer s, double d);
-
-		Pointer intersection_set_geo(Pointer s, Pointer gs);
 
 		Pointer intersection_set_int(Pointer s, int i);
 
@@ -1131,8 +1060,6 @@ public class functions {
 
 		Pointer minus_float_spanset(double d, Pointer ss);
 
-		Pointer minus_geo_set(Pointer gs, Pointer s);
-
 		Pointer minus_int_set(int i, Pointer s);
 
 		Pointer minus_int_span(int i, Pointer s);
@@ -1144,8 +1071,6 @@ public class functions {
 		Pointer minus_set_date(Pointer s, int d);
 
 		Pointer minus_set_float(Pointer s, double d);
-
-		Pointer minus_set_geo(Pointer s, Pointer gs);
 
 		Pointer minus_set_int(Pointer s, int i);
 
@@ -1209,8 +1134,6 @@ public class functions {
 
 		Pointer union_float_spanset(double d, Pointer ss);
 
-		Pointer union_geo_set(Pointer gs, Pointer s);
-
 		Pointer union_int_set(int i, Pointer s);
 
 		Pointer union_int_span(int i, Pointer s);
@@ -1222,8 +1145,6 @@ public class functions {
 		Pointer union_set_date(Pointer s, int d);
 
 		Pointer union_set_float(Pointer s, double d);
-
-		Pointer union_set_geo(Pointer s, Pointer gs);
 
 		Pointer union_set_int(Pointer s, int i);
 
@@ -1385,29 +1306,13 @@ public class functions {
 
 		Pointer tbox_from_hexwkb(String hexwkb);
 
-		Pointer stbox_from_wkb(Pointer wkb, long size);
-
-		Pointer stbox_from_hexwkb(String hexwkb);
-
 		Pointer tbox_as_wkb(Pointer box, byte variant, Pointer size_out);
 
 		String tbox_as_hexwkb(Pointer box, byte variant, Pointer size);
 
-		Pointer stbox_as_wkb(Pointer box, byte variant, Pointer size_out);
-
-		String stbox_as_hexwkb(Pointer box, byte variant, Pointer size);
-
-		Pointer stbox_in(String str);
-
-		String stbox_out(Pointer box, int maxdd);
-
 		Pointer float_tstzspan_to_tbox(double d, Pointer s);
 
 		Pointer float_timestamptz_to_tbox(double d, long t);
-
-		Pointer geo_tstzspan_to_stbox(Pointer gs, Pointer s);
-
-		Pointer geo_timestamptz_to_stbox(Pointer gs, long t);
 
 		Pointer int_tstzspan_to_tbox(int i, Pointer s);
 
@@ -1417,85 +1322,29 @@ public class functions {
 
 		Pointer numspan_timestamptz_to_tbox(Pointer span, long t);
 
-		Pointer stbox_copy(Pointer box);
-
-		Pointer stbox_make(boolean hasx, boolean hasz, boolean geodetic, int srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, Pointer s);
-
 		Pointer tbox_copy(Pointer box);
 
 		Pointer tbox_make(Pointer s, Pointer p);
 
-		Pointer float_to_tbox(double d);
+		Pointer float_tbox(double d);
 
-		Pointer geo_to_stbox(Pointer gs);
+		Pointer int_tbox(int i);
 
-		Pointer int_to_tbox(int i);
+		Pointer set_tbox(Pointer s);
 
-		Pointer set_to_tbox(Pointer s);
+		Pointer span_tbox(Pointer s);
 
-		Pointer span_to_tbox(Pointer s);
+		Pointer spanset_tbox(Pointer ss);
 
-		Pointer spanset_to_tbox(Pointer ss);
+		Pointer tbox_intspan(Pointer box);
 
-		Pointer spatialset_to_stbox(Pointer s);
+		Pointer tbox_floatspan(Pointer box);
 
-		Pointer stbox_to_gbox(Pointer box);
+		Pointer tbox_tstzspan(Pointer box);
 
-		Pointer stbox_to_box3d(Pointer box);
+		Pointer timestamptz_tbox(long t);
 
-		Pointer stbox_to_geo(Pointer box);
-
-		Pointer stbox_to_tstzspan(Pointer box);
-
-		Pointer tbox_to_intspan(Pointer box);
-
-		Pointer tbox_to_floatspan(Pointer box);
-
-		Pointer tbox_to_tstzspan(Pointer box);
-
-		Pointer timestamptz_to_stbox(long t);
-
-		Pointer timestamptz_to_tbox(long t);
-
-		Pointer tstzset_to_stbox(Pointer s);
-
-		Pointer tstzspan_to_stbox(Pointer s);
-
-		Pointer tstzspanset_to_stbox(Pointer ss);
-
-		Pointer tnumber_to_tbox(Pointer temp);
-
-		Pointer tpoint_to_stbox(Pointer temp);
-
-		boolean stbox_hast(Pointer box);
-
-		boolean stbox_hasx(Pointer box);
-
-		boolean stbox_hasz(Pointer box);
-
-		boolean stbox_isgeodetic(Pointer box);
-
-		int stbox_srid(Pointer box);
-
-		boolean stbox_tmax(Pointer box, Pointer result);
-
-		boolean stbox_tmax_inc(Pointer box, Pointer result);
-
-		boolean stbox_tmin(Pointer box, Pointer result);
-
-		boolean stbox_tmin_inc(Pointer box, Pointer result);
-
-		boolean stbox_xmax(Pointer box, Pointer result);
-
-		boolean stbox_xmin(Pointer box, Pointer result);
-
-		boolean stbox_ymax(Pointer box, Pointer result);
-
-		boolean stbox_ymin(Pointer box, Pointer result);
-
-		boolean stbox_zmax(Pointer box, Pointer result);
-
-		boolean stbox_zmin(Pointer box, Pointer result);
+		Pointer tnumber_tbox(Pointer temp);
 
 		boolean tbox_hast(Pointer box);
 
@@ -1525,24 +1374,6 @@ public class functions {
 
 		boolean tboxint_xmin(Pointer box, Pointer result);
 
-		Pointer stbox_expand_space(Pointer box, double d);
-
-		Pointer stbox_expand_time(Pointer box, Pointer interv);
-
-		Pointer stbox_get_space(Pointer box);
-
-		Pointer stbox_quad_split(Pointer box, Pointer count);
-
-		Pointer stbox_round(Pointer box, int maxdd);
-
-		Pointer stbox_set_srid(Pointer box, int srid);
-
-		Pointer stbox_shift_scale_time(Pointer box, Pointer shift, Pointer duration);
-
-		Pointer stbox_transform(Pointer box, int srid);
-
-		Pointer stbox_transform_pipeline(Pointer box, String pipelinestr, int srid, boolean is_forward);
-
 		Pointer tbox_expand_time(Pointer box, Pointer interv);
 
 		Pointer tbox_expand_float(Pointer box, double d);
@@ -1561,29 +1392,15 @@ public class functions {
 
 		Pointer intersection_tbox_tbox(Pointer box1, Pointer box2);
 
-		Pointer union_stbox_stbox(Pointer box1, Pointer box2, boolean strict);
-
-		Pointer intersection_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean adjacent_stbox_stbox(Pointer box1, Pointer box2);
-
 		boolean adjacent_tbox_tbox(Pointer box1, Pointer box2);
 
 		boolean contained_tbox_tbox(Pointer box1, Pointer box2);
-
-		boolean contained_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean contains_stbox_stbox(Pointer box1, Pointer box2);
 
 		boolean contains_tbox_tbox(Pointer box1, Pointer box2);
 
 		boolean overlaps_tbox_tbox(Pointer box1, Pointer box2);
 
-		boolean overlaps_stbox_stbox(Pointer box1, Pointer box2);
-
 		boolean same_tbox_tbox(Pointer box1, Pointer box2);
-
-		boolean same_stbox_stbox(Pointer box1, Pointer box2);
 
 		boolean left_tbox_tbox(Pointer box1, Pointer box2);
 
@@ -1601,38 +1418,6 @@ public class functions {
 
 		boolean overafter_tbox_tbox(Pointer box1, Pointer box2);
 
-		boolean left_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean overleft_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean right_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean overright_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean below_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean overbelow_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean above_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean overabove_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean front_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean overfront_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean back_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean overback_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean before_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean overbefore_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean after_stbox_stbox(Pointer box1, Pointer box2);
-
-		boolean overafter_stbox_stbox(Pointer box1, Pointer box2);
-
 		boolean tbox_eq(Pointer box1, Pointer box2);
 
 		boolean tbox_ne(Pointer box1, Pointer box2);
@@ -1647,20 +1432,6 @@ public class functions {
 
 		boolean tbox_gt(Pointer box1, Pointer box2);
 
-		boolean stbox_eq(Pointer box1, Pointer box2);
-
-		boolean stbox_ne(Pointer box1, Pointer box2);
-
-		int stbox_cmp(Pointer box1, Pointer box2);
-
-		boolean stbox_lt(Pointer box1, Pointer box2);
-
-		boolean stbox_le(Pointer box1, Pointer box2);
-
-		boolean stbox_ge(Pointer box1, Pointer box2);
-
-		boolean stbox_gt(Pointer box1, Pointer box2);
-
 		Pointer tbool_in(String str);
 
 		Pointer tint_in(String str);
@@ -1669,10 +1440,6 @@ public class functions {
 
 		Pointer ttext_in(String str);
 
-		Pointer tgeompoint_in(String str);
-
-		Pointer tgeogpoint_in(String str);
-
 		Pointer tbool_from_mfjson(String str);
 
 		Pointer tint_from_mfjson(String str);
@@ -1680,10 +1447,6 @@ public class functions {
 		Pointer tfloat_from_mfjson(String str);
 
 		Pointer ttext_from_mfjson(String str);
-
-		Pointer tgeompoint_from_mfjson(String str);
-
-		Pointer tgeogpoint_from_mfjson(String str);
 
 		Pointer temporal_from_wkb(Pointer wkb, long size);
 
@@ -1696,12 +1459,6 @@ public class functions {
 		String tfloat_out(Pointer temp, int maxdd);
 
 		String ttext_out(Pointer temp);
-
-		String tpoint_out(Pointer temp, int maxdd);
-
-		String tpoint_as_text(Pointer temp, int maxdd);
-
-		String tpoint_as_ewkt(Pointer temp, int maxdd);
 
 		String temporal_as_mfjson(Pointer temp, boolean with_bbox, int flags, int precision, String srs);
 
@@ -1741,16 +1498,6 @@ public class functions {
 
 		Pointer tintseqset_from_base_tstzspanset(int i, Pointer ss);
 
-		Pointer tpoint_from_base_temp(Pointer gs, Pointer temp);
-
-		Pointer tpointinst_make(Pointer gs, long t);
-
-		Pointer tpointseq_from_base_tstzspan(Pointer gs, Pointer s, int interp);
-
-		Pointer tpointseq_from_base_tstzset(Pointer gs, Pointer s);
-
-		Pointer tpointseqset_from_base_tstzspanset(Pointer gs, Pointer ss, int interp);
-
 		Pointer tsequence_make(Pointer instants, int count, boolean lower_inc, boolean upper_inc, int interp, boolean normalize);
 
 		Pointer tsequenceset_make(Pointer sequences, int count, boolean normalize);
@@ -1767,13 +1514,15 @@ public class functions {
 
 		Pointer ttextseqset_from_base_tstzspanset(Pointer txt, Pointer ss);
 
-		Pointer temporal_to_tstzspan(Pointer temp);
+		Pointer temporal_tstzspan(Pointer temp);
 
-		Pointer tfloat_to_tint(Pointer temp);
+		Pointer tbool_tint(Pointer temp);
 
-		Pointer tint_to_tfloat(Pointer temp);
+		Pointer tfloat_tint(Pointer temp);
 
-		Pointer tnumber_to_span(Pointer temp);
+		Pointer tint_tfloat(Pointer temp);
+
+		Pointer tnumber_span(Pointer temp);
 
 		boolean tbool_end_value(Pointer temp);
 
@@ -1817,9 +1566,9 @@ public class functions {
 
 		Pointer temporal_sequences(Pointer temp, Pointer count);
 
-		int temporal_lower_inc(Pointer temp);
+		boolean temporal_lower_inc(Pointer temp);
 
-		int temporal_upper_inc(Pointer temp);
+		boolean temporal_upper_inc(Pointer temp);
 
 		Pointer temporal_start_instant(Pointer temp);
 
@@ -1871,16 +1620,6 @@ public class functions {
 
 		Pointer tnumber_valuespans(Pointer temp);
 
-		Pointer tpoint_end_value(Pointer temp);
-
-		Pointer tpoint_start_value(Pointer temp);
-
-		boolean tpoint_value_at_timestamptz(Pointer temp, long t, boolean strict, Pointer value);
-
-		boolean tpoint_value_n(Pointer temp, int n, Pointer result);
-
-		Pointer tpoint_values(Pointer temp, Pointer count);
-
 		Pointer ttext_end_value(Pointer temp);
 
 		Pointer ttext_max_value(Pointer temp);
@@ -1895,11 +1634,21 @@ public class functions {
 
 		Pointer ttext_values(Pointer temp, Pointer count);
 
+		int spheroid_init_from_srid(int srid, Pointer s);
+
+		boolean ensure_srid_is_latlong(int srid);
+
 		double float_degrees(double value, boolean normalize);
+
+		boolean srid_is_latlong(int srid);
+
+		Pointer temparr_round(Pointer temp, int count, int maxdd);
+
+		Pointer temporal_round(Pointer temp, int maxdd);
 
 		Pointer temporal_scale_time(Pointer temp, Pointer duration);
 
-		Pointer temporal_set_interp(Pointer temp, int interp);
+		Pointer temporal_set_interp(Pointer temp, String interp_str);
 
 		Pointer temporal_shift_scale_time(Pointer temp, Pointer shift, Pointer duration);
 
@@ -1919,15 +1668,11 @@ public class functions {
 
 		Pointer tfloat_radians(Pointer temp);
 
-		Pointer tfloat_round(Pointer temp, int maxdd);
-
 		Pointer tfloat_scale_value(Pointer temp, double width);
 
 		Pointer tfloat_shift_scale_value(Pointer temp, double shift, double width);
 
 		Pointer tfloat_shift_value(Pointer temp, double shift);
-
-		Pointer tfloatarr_round(Pointer temp, int count, int maxdd);
 
 		Pointer tint_scale_value(Pointer temp, int width);
 
@@ -1935,19 +1680,7 @@ public class functions {
 
 		Pointer tint_shift_value(Pointer temp, int shift);
 
-		Pointer tpoint_round(Pointer temp, int maxdd);
-
-		Pointer tpoint_transform(Pointer temp, int srid);
-
-		Pointer tpoint_transform_pipeline(Pointer temp, String pipelinestr, int srid, boolean is_forward);
-
-		Pointer tpoint_transform_pj(Pointer temp, int srid, Pointer pj);
-
-		Pointer lwproj_transform(int srid_from, int srid_to);
-
-		Pointer tpointarr_round(Pointer temp, int count, int maxdd);
-
-		Pointer temporal_append_tinstant(Pointer temp, Pointer inst, double maxdist, Pointer maxt, boolean expand);
+		Pointer temporal_append_tinstant(Pointer temp, Pointer inst, int interp, double maxdist, Pointer maxt, boolean expand);
 
 		Pointer temporal_append_tsequence(Pointer temp, Pointer seq, boolean expand);
 
@@ -2019,18 +1752,6 @@ public class functions {
 
 		Pointer tnumber_minus_tbox(Pointer temp, Pointer box);
 
-		Pointer tpoint_at_geom_time(Pointer temp, Pointer gs, Pointer zspan, Pointer period);
-
-		Pointer tpoint_at_stbox(Pointer temp, Pointer box, boolean border_inc);
-
-		Pointer tpoint_at_value(Pointer temp, Pointer gs);
-
-		Pointer tpoint_minus_geom_time(Pointer temp, Pointer gs, Pointer zspan, Pointer period);
-
-		Pointer tpoint_minus_stbox(Pointer temp, Pointer box, boolean border_inc);
-
-		Pointer tpoint_minus_value(Pointer temp, Pointer gs);
-
 		Pointer ttext_at_value(Pointer temp, Pointer txt);
 
 		Pointer ttext_minus_value(Pointer temp, Pointer txt);
@@ -2055,8 +1776,6 @@ public class functions {
 
 		int always_eq_int_tint(int i, Pointer temp);
 
-		int always_eq_point_tpoint(Pointer gs, Pointer temp);
-
 		int always_eq_tbool_bool(Pointer temp, boolean b);
 
 		int always_eq_temporal_temporal(Pointer temp1, Pointer temp2);
@@ -2067,10 +1786,6 @@ public class functions {
 
 		int always_eq_tint_int(Pointer temp, int i);
 
-		int always_eq_tpoint_point(Pointer temp, Pointer gs);
-
-		int always_eq_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		int always_eq_ttext_text(Pointer temp, Pointer txt);
 
 		int always_ne_bool_tbool(boolean b, Pointer temp);
@@ -2078,8 +1793,6 @@ public class functions {
 		int always_ne_float_tfloat(double d, Pointer temp);
 
 		int always_ne_int_tint(int i, Pointer temp);
-
-		int always_ne_point_tpoint(Pointer gs, Pointer temp);
 
 		int always_ne_tbool_bool(Pointer temp, boolean b);
 
@@ -2090,10 +1803,6 @@ public class functions {
 		int always_ne_tfloat_float(Pointer temp, double d);
 
 		int always_ne_tint_int(Pointer temp, int i);
-
-		int always_ne_tpoint_point(Pointer temp, Pointer gs);
-
-		int always_ne_tpoint_tpoint(Pointer temp1, Pointer temp2);
 
 		int always_ne_ttext_text(Pointer temp, Pointer txt);
 
@@ -2159,8 +1868,6 @@ public class functions {
 
 		int ever_eq_int_tint(int i, Pointer temp);
 
-		int ever_eq_point_tpoint(Pointer gs, Pointer temp);
-
 		int ever_eq_tbool_bool(Pointer temp, boolean b);
 
 		int ever_eq_temporal_temporal(Pointer temp1, Pointer temp2);
@@ -2170,10 +1877,6 @@ public class functions {
 		int ever_eq_tfloat_float(Pointer temp, double d);
 
 		int ever_eq_tint_int(Pointer temp, int i);
-
-		int ever_eq_tpoint_point(Pointer temp, Pointer gs);
-
-		int ever_eq_tpoint_tpoint(Pointer temp1, Pointer temp2);
 
 		int ever_eq_ttext_text(Pointer temp, Pointer txt);
 
@@ -2239,8 +1942,6 @@ public class functions {
 
 		int ever_ne_int_tint(int i, Pointer temp);
 
-		int ever_ne_point_tpoint(Pointer gs, Pointer temp);
-
 		int ever_ne_tbool_bool(Pointer temp, boolean b);
 
 		int ever_ne_temporal_temporal(Pointer temp1, Pointer temp2);
@@ -2251,10 +1952,6 @@ public class functions {
 
 		int ever_ne_tint_int(Pointer temp, int i);
 
-		int ever_ne_tpoint_point(Pointer temp, Pointer gs);
-
-		int ever_ne_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		int ever_ne_ttext_text(Pointer temp, Pointer txt);
 
 		Pointer teq_bool_tbool(boolean b, Pointer temp);
@@ -2263,8 +1960,6 @@ public class functions {
 
 		Pointer teq_int_tint(int i, Pointer temp);
 
-		Pointer teq_point_tpoint(Pointer gs, Pointer temp);
-
 		Pointer teq_tbool_bool(Pointer temp, boolean b);
 
 		Pointer teq_temporal_temporal(Pointer temp1, Pointer temp2);
@@ -2272,8 +1967,6 @@ public class functions {
 		Pointer teq_text_ttext(Pointer txt, Pointer temp);
 
 		Pointer teq_tfloat_float(Pointer temp, double d);
-
-		Pointer teq_tpoint_point(Pointer temp, Pointer gs);
 
 		Pointer teq_tint_int(Pointer temp, int i);
 
@@ -2341,8 +2034,6 @@ public class functions {
 
 		Pointer tne_int_tint(int i, Pointer temp);
 
-		Pointer tne_point_tpoint(Pointer gs, Pointer temp);
-
 		Pointer tne_tbool_bool(Pointer temp, boolean b);
 
 		Pointer tne_temporal_temporal(Pointer temp1, Pointer temp2);
@@ -2351,15 +2042,23 @@ public class functions {
 
 		Pointer tne_tfloat_float(Pointer temp, double d);
 
-		Pointer tne_tpoint_point(Pointer temp, Pointer gs);
-
 		Pointer tne_tint_int(Pointer temp, int i);
 
 		Pointer tne_ttext_text(Pointer temp, Pointer txt);
 
-		boolean adjacent_numspan_tnumber(Pointer s, Pointer temp);
+		Pointer temporal_spans(Pointer temp, Pointer count);
 
-		boolean adjacent_stbox_tpoint(Pointer box, Pointer temp);
+		Pointer temporal_split_each_n_spans(Pointer temp, int elem_count, Pointer count);
+
+		Pointer temporal_split_n_spans(Pointer temp, int span_count, Pointer count);
+
+		Pointer tnumber_tboxes(Pointer temp, Pointer count);
+
+		Pointer tnumber_split_each_n_tboxes(Pointer temp, int elem_count, Pointer count);
+
+		Pointer tnumber_split_n_tboxes(Pointer temp, int box_count, Pointer count);
+
+		boolean adjacent_numspan_tnumber(Pointer s, Pointer temp);
 
 		boolean adjacent_tbox_tnumber(Pointer box, Pointer temp);
 
@@ -2373,15 +2072,9 @@ public class functions {
 
 		boolean adjacent_tnumber_tnumber(Pointer temp1, Pointer temp2);
 
-		boolean adjacent_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean adjacent_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		boolean adjacent_tstzspan_temporal(Pointer s, Pointer temp);
 
 		boolean contained_numspan_tnumber(Pointer s, Pointer temp);
-
-		boolean contained_stbox_tpoint(Pointer box, Pointer temp);
 
 		boolean contained_tbox_tnumber(Pointer box, Pointer temp);
 
@@ -2395,15 +2088,9 @@ public class functions {
 
 		boolean contained_tnumber_tnumber(Pointer temp1, Pointer temp2);
 
-		boolean contained_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean contained_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		boolean contained_tstzspan_temporal(Pointer s, Pointer temp);
 
 		boolean contains_numspan_tnumber(Pointer s, Pointer temp);
-
-		boolean contains_stbox_tpoint(Pointer box, Pointer temp);
 
 		boolean contains_tbox_tnumber(Pointer box, Pointer temp);
 
@@ -2417,15 +2104,9 @@ public class functions {
 
 		boolean contains_tnumber_tnumber(Pointer temp1, Pointer temp2);
 
-		boolean contains_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean contains_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		boolean contains_tstzspan_temporal(Pointer s, Pointer temp);
 
 		boolean overlaps_numspan_tnumber(Pointer s, Pointer temp);
-
-		boolean overlaps_stbox_tpoint(Pointer box, Pointer temp);
 
 		boolean overlaps_tbox_tnumber(Pointer box, Pointer temp);
 
@@ -2439,15 +2120,9 @@ public class functions {
 
 		boolean overlaps_tnumber_tnumber(Pointer temp1, Pointer temp2);
 
-		boolean overlaps_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean overlaps_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		boolean overlaps_tstzspan_temporal(Pointer s, Pointer temp);
 
 		boolean same_numspan_tnumber(Pointer s, Pointer temp);
-
-		boolean same_stbox_tpoint(Pointer box, Pointer temp);
 
 		boolean same_tbox_tnumber(Pointer box, Pointer temp);
 
@@ -2461,19 +2136,7 @@ public class functions {
 
 		boolean same_tnumber_tnumber(Pointer temp1, Pointer temp2);
 
-		boolean same_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean same_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		boolean same_tstzspan_temporal(Pointer s, Pointer temp);
-
-		boolean above_stbox_tpoint(Pointer box, Pointer temp);
-
-		boolean above_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean above_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		boolean after_stbox_tpoint(Pointer box, Pointer temp);
 
 		boolean after_tbox_tnumber(Pointer box, Pointer temp);
 
@@ -2485,19 +2148,7 @@ public class functions {
 
 		boolean after_tnumber_tnumber(Pointer temp1, Pointer temp2);
 
-		boolean after_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean after_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		boolean after_tstzspan_temporal(Pointer s, Pointer temp);
-
-		boolean back_stbox_tpoint(Pointer box, Pointer temp);
-
-		boolean back_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean back_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		boolean before_stbox_tpoint(Pointer box, Pointer temp);
 
 		boolean before_tbox_tnumber(Pointer box, Pointer temp);
 
@@ -2509,25 +2160,7 @@ public class functions {
 
 		boolean before_tnumber_tnumber(Pointer temp1, Pointer temp2);
 
-		boolean before_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean before_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		boolean before_tstzspan_temporal(Pointer s, Pointer temp);
-
-		boolean below_stbox_tpoint(Pointer box, Pointer temp);
-
-		boolean below_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean below_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		boolean front_stbox_tpoint(Pointer box, Pointer temp);
-
-		boolean front_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean front_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		boolean left_stbox_tpoint(Pointer box, Pointer temp);
 
 		boolean left_tbox_tnumber(Pointer box, Pointer temp);
 
@@ -2539,18 +2172,6 @@ public class functions {
 
 		boolean left_tnumber_tnumber(Pointer temp1, Pointer temp2);
 
-		boolean left_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean left_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		boolean overabove_stbox_tpoint(Pointer box, Pointer temp);
-
-		boolean overabove_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean overabove_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		boolean overafter_stbox_tpoint(Pointer box, Pointer temp);
-
 		boolean overafter_tbox_tnumber(Pointer box, Pointer temp);
 
 		boolean overafter_temporal_tstzspan(Pointer temp, Pointer s);
@@ -2561,19 +2182,7 @@ public class functions {
 
 		boolean overafter_tnumber_tnumber(Pointer temp1, Pointer temp2);
 
-		boolean overafter_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean overafter_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		boolean overafter_tstzspan_temporal(Pointer s, Pointer temp);
-
-		boolean overback_stbox_tpoint(Pointer box, Pointer temp);
-
-		boolean overback_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean overback_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		boolean overbefore_stbox_tpoint(Pointer box, Pointer temp);
 
 		boolean overbefore_tbox_tnumber(Pointer box, Pointer temp);
 
@@ -2585,27 +2194,9 @@ public class functions {
 
 		boolean overbefore_tnumber_tnumber(Pointer temp1, Pointer temp2);
 
-		boolean overbefore_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean overbefore_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		boolean overbefore_tstzspan_temporal(Pointer s, Pointer temp);
 
-		boolean overbelow_stbox_tpoint(Pointer box, Pointer temp);
-
-		boolean overbelow_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean overbelow_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		boolean overfront_stbox_tpoint(Pointer box, Pointer temp);
-
-		boolean overfront_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean overfront_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		boolean overleft_numspan_tnumber(Pointer s, Pointer temp);
-
-		boolean overleft_stbox_tpoint(Pointer box, Pointer temp);
 
 		boolean overleft_tbox_tnumber(Pointer box, Pointer temp);
 
@@ -2615,13 +2206,7 @@ public class functions {
 
 		boolean overleft_tnumber_tnumber(Pointer temp1, Pointer temp2);
 
-		boolean overleft_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean overleft_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		boolean overright_numspan_tnumber(Pointer s, Pointer temp);
-
-		boolean overright_stbox_tpoint(Pointer box, Pointer temp);
 
 		boolean overright_tbox_tnumber(Pointer box, Pointer temp);
 
@@ -2631,13 +2216,7 @@ public class functions {
 
 		boolean overright_tnumber_tnumber(Pointer temp1, Pointer temp2);
 
-		boolean overright_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean overright_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
 		boolean right_numspan_tnumber(Pointer s, Pointer temp);
-
-		boolean right_stbox_tpoint(Pointer box, Pointer temp);
 
 		boolean right_tbox_tnumber(Pointer box, Pointer temp);
 
@@ -2646,10 +2225,6 @@ public class functions {
 		boolean right_tnumber_tbox(Pointer temp, Pointer box);
 
 		boolean right_tnumber_tnumber(Pointer temp1, Pointer temp2);
-
-		boolean right_tpoint_stbox(Pointer temp, Pointer box);
-
-		boolean right_tpoint_tpoint(Pointer temp1, Pointer temp2);
 
 		Pointer tand_bool_tbool(boolean b, Pointer temp);
 
@@ -2709,6 +2284,12 @@ public class functions {
 
 		Pointer tfloat_derivative(Pointer temp);
 
+		Pointer tfloat_exp(Pointer temp);
+
+		Pointer tfloat_ln(Pointer temp);
+
+		Pointer tfloat_log10(Pointer temp);
+
 		Pointer tnumber_abs(Pointer temp);
 
 		Pointer tnumber_angular_difference(Pointer temp);
@@ -2733,14 +2314,6 @@ public class functions {
 
 		Pointer distance_tnumber_tnumber(Pointer temp1, Pointer temp2);
 
-		Pointer distance_tpoint_point(Pointer temp, Pointer gs);
-
-		Pointer distance_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		double nad_stbox_geo(Pointer box, Pointer gs);
-
-		double nad_stbox_stbox(Pointer box1, Pointer box2);
-
 		int nad_tint_int(Pointer temp, int i);
 
 		int nad_tint_tbox(Pointer temp, Pointer box);
@@ -2756,122 +2329,6 @@ public class functions {
 		double nad_tfloat_tbox(Pointer temp, Pointer box);
 
 		double nad_tboxfloat_tboxfloat(Pointer box1, Pointer box2);
-
-		double nad_tpoint_geo(Pointer temp, Pointer gs);
-
-		double nad_tpoint_stbox(Pointer temp, Pointer box);
-
-		double nad_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		Pointer nai_tpoint_geo(Pointer temp, Pointer gs);
-
-		Pointer nai_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		Pointer shortestline_tpoint_geo(Pointer temp, Pointer gs);
-
-		Pointer shortestline_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		boolean bearing_point_point(Pointer gs1, Pointer gs2, Pointer result);
-
-		Pointer bearing_tpoint_point(Pointer temp, Pointer gs, boolean invert);
-
-		Pointer bearing_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		Pointer tpoint_angular_difference(Pointer temp);
-
-		Pointer tpoint_azimuth(Pointer temp);
-
-		Pointer tpoint_convex_hull(Pointer temp);
-
-		Pointer tpoint_cumulative_length(Pointer temp);
-
-		boolean tpoint_direction(Pointer temp, Pointer result);
-
-		Pointer tpoint_get_x(Pointer temp);
-
-		Pointer tpoint_get_y(Pointer temp);
-
-		Pointer tpoint_get_z(Pointer temp);
-
-		boolean tpoint_is_simple(Pointer temp);
-
-		double tpoint_length(Pointer temp);
-
-		Pointer tpoint_speed(Pointer temp);
-
-		int tpoint_srid(Pointer temp);
-
-		Pointer tpoint_stboxes(Pointer temp, Pointer count);
-
-		Pointer tpoint_trajectory(Pointer temp);
-
-		Pointer tpoint_twcentroid(Pointer temp);
-
-		Pointer geo_expand_space(Pointer gs, double d);
-
-		Pointer geomeas_to_tpoint(Pointer gs);
-
-		Pointer tgeogpoint_to_tgeompoint(Pointer temp);
-
-		Pointer tgeompoint_to_tgeogpoint(Pointer temp);
-
-		boolean tpoint_AsMVTGeom(Pointer temp, Pointer bounds, int extent, int buffer, boolean clip_geom, Pointer gsarr, Pointer timesarr, Pointer count);
-
-		Pointer tpoint_expand_space(Pointer temp, double d);
-
-		Pointer tpoint_make_simple(Pointer temp, Pointer count);
-
-		Pointer tpoint_set_srid(Pointer temp, int srid);
-
-		boolean tpoint_tfloat_to_geomeas(Pointer tpoint, Pointer measure, boolean segmentize, Pointer result);
-
-		int acontains_geo_tpoint(Pointer gs, Pointer temp);
-
-		int adisjoint_tpoint_geo(Pointer temp, Pointer gs);
-
-		int adisjoint_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		int adwithin_tpoint_geo(Pointer temp, Pointer gs, double dist);
-
-		int adwithin_tpoint_tpoint(Pointer temp1, Pointer temp2, double dist);
-
-		int aintersects_tpoint_geo(Pointer temp, Pointer gs);
-
-		int aintersects_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		int atouches_tpoint_geo(Pointer temp, Pointer gs);
-
-		int econtains_geo_tpoint(Pointer gs, Pointer temp);
-
-		int edisjoint_tpoint_geo(Pointer temp, Pointer gs);
-
-		int edisjoint_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		int edwithin_tpoint_geo(Pointer temp, Pointer gs, double dist);
-
-		int edwithin_tpoint_tpoint(Pointer temp1, Pointer temp2, double dist);
-
-		int eintersects_tpoint_geo(Pointer temp, Pointer gs);
-
-		int eintersects_tpoint_tpoint(Pointer temp1, Pointer temp2);
-
-		int etouches_tpoint_geo(Pointer temp, Pointer gs);
-
-		Pointer tcontains_geo_tpoint(Pointer gs, Pointer temp, boolean restr, boolean atvalue);
-
-		Pointer tdisjoint_tpoint_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue);
-
-		Pointer tdisjoint_tpoint_tpoint (Pointer temp1, Pointer temp2, boolean restr, boolean atvalue);
-
-		Pointer tdwithin_tpoint_geo(Pointer temp, Pointer gs, double dist, boolean restr, boolean atvalue);
-
-		Pointer tdwithin_tpoint_tpoint(Pointer temp1, Pointer temp2, double dist, boolean restr, boolean atvalue);
-
-		Pointer tintersects_tpoint_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue);
-
-		Pointer tintersects_tpoint_tpoint (Pointer temp1, Pointer temp2, boolean restr, boolean atvalue);
-
-		Pointer ttouches_tpoint_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue);
 
 		Pointer tbool_tand_transfn(Pointer state, Pointer temp);
 
@@ -2917,12 +2374,6 @@ public class functions {
 
 		Pointer tnumber_wavg_transfn(Pointer state, Pointer temp, Pointer interv);
 
-		Pointer tpoint_extent_transfn(Pointer box, Pointer temp);
-
-		Pointer tpoint_tcentroid_finalfn(Pointer state);
-
-		Pointer tpoint_tcentroid_transfn(Pointer state, Pointer temp);
-
 		Pointer tstzset_tcount_transfn(Pointer state, Pointer s);
 
 		Pointer tstzspan_tcount_transfn(Pointer state, Pointer s);
@@ -2955,51 +2406,1966 @@ public class functions {
 
 		double temporal_hausdorff_distance(Pointer temp1, Pointer temp2);
 
-		double float_bucket(double value, double size, double origin);
+		long bigint_get_bin(long value, long vsize, long vorigin);
 
-		Pointer floatspan_bucket_list(Pointer bounds, double size, double origin, Pointer count);
+		Pointer bigintspan_bins(Pointer s, long vsize, long vorigin, Pointer count);
 
-		int int_bucket(int value, int size, int origin);
+		Pointer bigintspanset_bins(Pointer ss, long vsize, long vorigin, Pointer count);
 
-		Pointer intspan_bucket_list(Pointer bounds, int size, int origin, Pointer count);
+		Pointer bigintspanset_value_spans(Pointer ss, long vsize, long vorigin, Pointer count);
 
-		Pointer stbox_tile(Pointer point, long t, double xsize, double ysize, double zsize, Pointer duration, Pointer sorigin, long torigin, boolean hast);
+		int date_get_bin(int d, Pointer duration, int torigin);
 
-		Pointer stbox_tile_list(Pointer bounds, double xsize, double ysize, double zsize, Pointer duration, Pointer sorigin, long torigin, boolean border_inc, Pointer count);
+		Pointer datespan_bins(Pointer s, Pointer duration, int torigin, Pointer count);
 
-		Pointer temporal_time_split(Pointer temp, Pointer duration, long torigin, Pointer time_buckets, Pointer count);
+		Pointer datespanset_bins(Pointer ss, Pointer duration, int torigin, Pointer count);
 
-		Pointer tfloat_value_split(Pointer temp, double size, double origin, Pointer value_buckets, Pointer count);
+		Pointer datespanset_time_spans(Pointer ss, Pointer duration, int torigin, Pointer count);
 
-		Pointer tfloat_value_time_split(Pointer temp, double size, Pointer duration, double vorigin, long torigin, Pointer value_buckets, Pointer time_buckets, Pointer count);
+		double float_get_bin(double value, double vsize, double vorigin);
 
-		Pointer tfloatbox_tile(double value, long t, double vsize, Pointer duration, double vorigin, long torigin);
+		Pointer floatspan_bins(Pointer s, double vsize, double vorigin, Pointer count);
 
-		Pointer tfloatbox_tile_list(Pointer box, double xsize, Pointer duration, double xorigin, long torigin, Pointer count);
+		Pointer floatspanset_value_spans(Pointer ss, double vsize, double vorigin, Pointer count);
 
-		long timestamptz_bucket(long timestamp, Pointer duration, long origin);
+		int int_get_bin(int value, int vsize, int vorigin);
 
-		Pointer tint_value_split(Pointer temp, int size, int origin, Pointer value_buckets, Pointer count);
+		Pointer intspan_bins(Pointer s, int vsize, int vorigin, Pointer count);
 
-		Pointer tint_value_time_split(Pointer temp, int size, Pointer duration, int vorigin, long torigin, Pointer value_buckets, Pointer time_buckets, Pointer count);
+		Pointer intspanset_bins(Pointer ss, int vsize, int vorigin, Pointer count);
 
-		Pointer tintbox_tile(int value, long t, int vsize, Pointer duration, int vorigin, long torigin);
+		Pointer intspanset_value_spans(Pointer ss, int vsize, int vorigin, Pointer count);
 
-		Pointer tintbox_tile_list(Pointer box, int xsize, Pointer duration, int xorigin, long torigin, Pointer count);
+		long timestamptz_get_bin(long t, Pointer duration, long torigin);
 
-		Pointer tpoint_space_split(Pointer temp, float xsize, float ysize, float zsize, Pointer sorigin, boolean bitmatrix, boolean border_inc, Pointer space_buckets, Pointer count);
+		Pointer tstzspan_bins(Pointer s, Pointer duration, long origin, Pointer count);
 
-		Pointer tpoint_space_time_split(Pointer temp, float xsize, float ysize, float zsize, Pointer duration, Pointer sorigin, long torigin, boolean bitmatrix, boolean border_inc, Pointer space_buckets, Pointer time_buckets, Pointer count);
+		Pointer tstzspanset_bins(Pointer ss, Pointer duration, long torigin, Pointer count);
 
-		Pointer tstzspan_bucket_list(Pointer bounds, Pointer duration, long origin, Pointer count);
+		Pointer tstzspanset_time_spans(Pointer ss, Pointer duration, long torigin, Pointer count);
+
+		Pointer temporal_time_spans(Pointer temp, Pointer duration, long origin, Pointer count);
+
+		Pointer temporal_time_split(Pointer temp, Pointer duration, long torigin, Pointer time_bins, Pointer count);
+
+		Pointer tfloat_value_spans(Pointer temp, double vsize, double vorigin, Pointer count);
+
+		Pointer tfloat_value_split(Pointer temp, double vsize, double vorigin, Pointer value_bins, Pointer count);
+
+		Pointer tfloat_value_time_split(Pointer temp, double vsize, Pointer duration, double vorigin, long torigin, Pointer value_bins, Pointer time_bins, Pointer count);
+
+		Pointer tfloatbox_get_time_tile(long t, Pointer duration, long torigin);
+
+		Pointer tfloatbox_get_value_tile(double value, double vsize, double vorigin);
+
+		Pointer tfloatbox_get_value_time_tile(double value, long t, double vsize, Pointer duration, double vorigin, long torigin);
+
+		Pointer tfloatbox_time_tiles(Pointer box, Pointer duration, long torigin, Pointer count);
+
+		Pointer tfloatbox_value_tiles(Pointer box, double vsize, double vorigin, Pointer count);
+
+		Pointer tfloatbox_value_time_tiles(Pointer box, double vsize, Pointer duration, double vorigin, long torigin, Pointer count);
+
+		Pointer tint_value_spans(Pointer temp, int vsize, int vorigin, Pointer count);
+
+		Pointer tint_value_split(Pointer temp, int vsize, int vorigin, Pointer value_bins, Pointer count);
+
+		Pointer tint_value_time_split(Pointer temp, int size, Pointer duration, int vorigin, long torigin, Pointer value_bins, Pointer time_bins, Pointer count);
+
+		Pointer tintbox_get_time_tile(long t, Pointer duration, long torigin);
+
+		Pointer tintbox_get_value_tile(int value, int vsize, int vorigin);
+
+		Pointer tintbox_get_value_time_tile(int value, long t, int vsize, Pointer duration, int vorigin, long torigin);
+
+		Pointer tintbox_time_tiles(Pointer box, Pointer duration, long torigin, Pointer count);
+
+		Pointer tintbox_value_tiles(Pointer box, int xsize, int xorigin, Pointer count);
+
+		Pointer tintbox_value_time_tiles(Pointer box, int xsize, Pointer duration, int xorigin, long torigin, Pointer count);
+
+		Pointer geo_as_ewkb(Pointer gs, String endian, Pointer size);
+
+		String geo_as_ewkt(Pointer gs, int precision);
+
+		String geo_as_geojson(Pointer gs, int option, int precision, String srs);
+
+		String geo_as_hexewkb(Pointer gs, String endian);
+
+		String geo_as_text(Pointer gs, int precision);
+
+		Pointer geo_collect_garray(Pointer gsarr, int count);
+
+		Pointer geo_copy(Pointer g);
+
+		int geo_equals(Pointer gs1, Pointer gs2);
+
+		Pointer geo_from_ewkb(Pointer wkb, long wkb_size, int srid);
+
+		Pointer geo_from_geojson(String geojson);
+
+		Pointer geo_from_text(String wkt, int srid);
+
+		boolean geo_is_empty(Pointer g);
+
+		Pointer geo_makeline_garray(Pointer gsarr, int count);
+
+		String geo_out(Pointer gs);
+
+		Pointer geo_reverse(Pointer gs);
+
+		Pointer geo_round(Pointer gs, int maxdd);
+
+		boolean geo_same(Pointer gs1, Pointer gs2);
+
+		Pointer  geo_set_srid(Pointer gs, int srid);
+
+		int geo_srid(Pointer gs);
+
+		Pointer geo_transform(Pointer geom, int srid_to);
+
+		Pointer geo_transform_pipeline(Pointer gs, String pipeline, int srid_to, boolean is_forward);
+
+		double geog_area(Pointer g, boolean use_spheroid);
+
+		Pointer geog_centroid(Pointer g, boolean use_spheroid);
+
+		double geog_distance(Pointer g1, Pointer g2);
+
+		boolean geog_dwithin(Pointer g1, Pointer g2, double tolerance, boolean use_spheroid);
+
+		Pointer geog_from_binary(String wkb_bytea);
+
+		Pointer geog_from_geom(Pointer geom);
+
+		Pointer geog_from_hexewkb(String wkt);
+
+		Pointer geog_in(String str, int typmod);
+
+		boolean geog_intersects(Pointer gs1, Pointer gs2, boolean use_spheroid);
+
+		double geog_length(Pointer g, boolean use_spheroid);
+
+		double geog_perimeter(Pointer g, boolean use_spheroid);
+
+		Pointer geom_array_union(Pointer gsarr, int count);
+
+		boolean geom_azimuth(Pointer gs1, Pointer gs2, Pointer result);
+
+		Pointer geom_boundary(Pointer gs);
+
+		Pointer geom_buffer(Pointer gs, double size, String params);
+
+		Pointer geom_centroid(Pointer gs);
+
+		boolean geom_contains(Pointer gs1, Pointer gs2);
+
+		Pointer geom_convex_hull(Pointer gs);
+
+		boolean geom_covers(Pointer gs1, Pointer gs2);
+
+		Pointer geom_difference2d(Pointer gs1, Pointer gs2);
+
+		boolean geom_disjoint2d(Pointer gs1, Pointer gs2);
+
+		double geom_distance2d(Pointer gs1, Pointer gs2);
+
+		double geom_distance3d(Pointer gs1, Pointer gs2);
+
+		boolean geom_dwithin2d(Pointer gs1, Pointer gs2, double tolerance);
+
+		boolean geom_dwithin3d(Pointer gs1, Pointer gs2, double tolerance);
+
+		Pointer geom_from_geog(Pointer geog);
+
+		Pointer geom_from_hexewkb(String wkt);
+
+		Pointer geom_from_text(String wkt, int srid);
+
+		Pointer geom_in(String str, int typmod);
+
+		Pointer geom_intersection2d(Pointer gs1, Pointer gs2);
+
+		boolean geom_intersects2d(Pointer gs1, Pointer gs2);
+
+		boolean geom_intersects3d(Pointer gs1, Pointer gs2);
+
+		double geom_length(Pointer gs);
+
+		double geom_perimeter(Pointer gs);
+
+		boolean geom_relate_pattern(Pointer gs1, Pointer gs2, String patt);
+
+		Pointer geom_shortestline2d(Pointer gs1, Pointer s2);
+
+		Pointer geom_shortestline3d(Pointer gs1, Pointer s2);
+
+		boolean geom_touches(Pointer gs1, Pointer gs2);
+
+		Pointer geom_unary_union(Pointer gs, double prec);
+
+		Pointer line_interpolate_point(Pointer gs, double distance_fraction, boolean repeat);
+
+		int line_numpoints(Pointer gs);
+
+		double line_locate_point(Pointer gs1, Pointer gs2);
+
+		Pointer line_point_n(Pointer geom, int n);
+
+		Pointer line_substring(Pointer gs, double from, double to);
+
+		Pointer geo_stboxes(Pointer gs, Pointer count);
+
+		Pointer geo_split_n_stboxes(Pointer gs, int box_count, Pointer count);
+
+		boolean contained_geo_set(Pointer gs, Pointer s);
+
+		boolean contains_set_geo(Pointer s, Pointer gs);
+
+		Pointer geo_set(Pointer gs);
+
+		Pointer geoset_end_value(Pointer s);
+
+		Pointer geoset_make(Pointer values, int count);
+
+		Pointer geoset_start_value(Pointer s);
+
+		boolean geoset_value_n(Pointer s, int n, Pointer result);
+
+		Pointer geoset_values(Pointer s);
+
+		Pointer intersection_geo_set(Pointer gs, Pointer s);
+
+		Pointer intersection_set_geo(Pointer s, Pointer gs);
+
+		Pointer minus_geo_set(Pointer gs, Pointer s);
+
+		Pointer minus_set_geo(Pointer s, Pointer gs);
+
+		int spatialset_srid(Pointer s);
+
+		Pointer spatialset_set_srid(Pointer s, int srid);
+
+		Pointer spatialset_transform(Pointer s, int srid);
+
+		Pointer spatialset_transform_pipeline(Pointer s, String pipelinestr, int srid, boolean is_forward);
+
+		Pointer union_geo_set(Pointer gs, Pointer s);
+
+		Pointer union_set_geo(Pointer s, Pointer gs);
+
+		Pointer stbox_from_wkb(Pointer wkb, long size);
+
+		Pointer stbox_from_hexwkb(String hexwkb);
+
+		Pointer stbox_as_wkb(Pointer box, byte variant, Pointer size_out);
+
+		String stbox_as_hexwkb(Pointer box, byte variant, Pointer size);
+
+		Pointer stbox_in(String str);
+
+		String stbox_out(Pointer box, int maxdd);
+
+		Pointer geo_tstzspan_to_stbox(Pointer gs, Pointer s);
+
+		Pointer geo_timestamptz_to_stbox(Pointer gs, long t);
+
+		Pointer stbox_copy(Pointer box);
+
+		Pointer stbox_make(boolean hasx, boolean hasz, boolean geodetic, int srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, Pointer s);
+
+		Pointer geo_stbox(Pointer gs);
+
+		Pointer stbox_geo(Pointer box);
+
+		Pointer spatialset_stbox(Pointer s);
+
+		Pointer stbox_gbox(Pointer box);
+
+		Pointer stbox_box3d(Pointer box);
+
+		Pointer stbox_tstzspan(Pointer box);
+
+		Pointer timestamptz_stbox(long t);
+
+		Pointer tstzset_stbox(Pointer s);
+
+		Pointer tstzspan_stbox(Pointer s);
+
+		Pointer tstzspanset_stbox(Pointer ss);
+
+		Pointer tspatial_stbox(Pointer temp);
+
+		double stbox_area(Pointer box, boolean spheroid);
+
+		boolean stbox_hast(Pointer box);
+
+		boolean stbox_hasx(Pointer box);
+
+		boolean stbox_hasz(Pointer box);
+
+		boolean stbox_isgeodetic(Pointer box);
+
+		double stbox_perimeter(Pointer box, boolean spheroid);
+
+		int stbox_srid(Pointer box);
+
+		boolean stbox_tmax(Pointer box, Pointer result);
+
+		boolean stbox_tmax_inc(Pointer box, Pointer result);
+
+		boolean stbox_tmin(Pointer box, Pointer result);
+
+		boolean stbox_tmin_inc(Pointer box, Pointer result);
+
+		double stbox_volume(Pointer box);
+
+		boolean stbox_xmax(Pointer box, Pointer result);
+
+		boolean stbox_xmin(Pointer box, Pointer result);
+
+		boolean stbox_ymax(Pointer box, Pointer result);
+
+		boolean stbox_ymin(Pointer box, Pointer result);
+
+		boolean stbox_zmax(Pointer box, Pointer result);
+
+		boolean stbox_zmin(Pointer box, Pointer result);
+
+		Pointer stbox_expand_space(Pointer box, double d);
+
+		Pointer stbox_expand_time(Pointer box, Pointer interv);
+
+		Pointer stbox_get_space(Pointer box);
+
+		Pointer stbox_quad_split(Pointer box, Pointer count);
+
+		Pointer stbox_round(Pointer box, int maxdd);
+
+		Pointer stbox_set_srid(Pointer box, int srid);
+
+		Pointer stbox_shift_scale_time(Pointer box, Pointer shift, Pointer duration);
+
+		Pointer stbox_transform(Pointer box, int srid);
+
+		Pointer stbox_transform_pipeline(Pointer box, String pipelinestr, int srid, boolean is_forward);
+
+		Pointer stboxarr_round(Pointer boxarr, int count, int maxdd);
+
+		Pointer union_stbox_stbox(Pointer box1, Pointer box2, boolean strict);
+
+		Pointer intersection_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean adjacent_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean contained_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean contains_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean overlaps_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean same_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean left_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean overleft_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean right_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean overright_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean below_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean overbelow_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean above_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean overabove_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean front_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean overfront_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean back_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean overback_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean before_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean overbefore_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean after_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean overafter_stbox_stbox(Pointer box1, Pointer box2);
+
+		boolean stbox_eq(Pointer box1, Pointer box2);
+
+		boolean stbox_ne(Pointer box1, Pointer box2);
+
+		int stbox_cmp(Pointer box1, Pointer box2);
+
+		boolean stbox_lt(Pointer box1, Pointer box2);
+
+		boolean stbox_le(Pointer box1, Pointer box2);
+
+		boolean stbox_ge(Pointer box1, Pointer box2);
+
+		boolean stbox_gt(Pointer box1, Pointer box2);
+
+		Pointer rtree_create_stbox();
+
+		void rtree_insert(Pointer rtree, Pointer box, long id);
+
+		Pointer rtree_search(Pointer rtree,Pointer query, Pointer count);
+
+		void rtree_free(Pointer rtree);
+
+		String tgeo_out(Pointer temp, int maxdd);
+
+		String tspatial_as_text(Pointer temp, int maxdd);
+
+		String tspatial_as_ewkt(Pointer temp, int maxdd);
+
+		Pointer tgeogpoint_in(String str);
+
+		Pointer tgeogpoint_from_mfjson(String str);
+
+		Pointer tgeography_in(String str);
+
+		Pointer tgeometry_in(String str);
+
+		Pointer tgeompoint_in(String str);
+
+		Pointer tgeompoint_from_mfjson(String str);
+
+		Pointer geogset_in(String str);
+
+		Pointer geomset_in(String str);
+
+		Pointer tgeo_from_base_temp(Pointer gs, Pointer temp);
+
+		Pointer tgeoinst_make(Pointer gs, long t);
+
+		Pointer tgeoseq_from_base_tstzset(Pointer gs, Pointer s);
+
+		Pointer tgeoseqset_from_base_tstzspanset(Pointer gs, Pointer ss, int interp);
+
+		Pointer tpoint_from_base_temp(Pointer gs, Pointer temp);
+
+		Pointer tpointinst_make(Pointer gs, long t);
+
+		Pointer tpointseq_from_base_tstzspan(Pointer gs, Pointer s, int interp);
+
+		Pointer tpointseq_from_base_tstzset(Pointer gs, Pointer s);
+
+		Pointer tpointseqset_from_base_tstzspanset(Pointer gs, Pointer ss, int interp);
+
+		Pointer tgeo_end_value(Pointer temp);
+
+		Pointer tgeo_start_value(Pointer temp);
+
+		boolean tgeo_value_at_timestamptz(Pointer temp, long t, boolean strict, Pointer value);
+
+		boolean tgeo_value_n(Pointer temp, int n, Pointer result);
+
+		Pointer tgeo_values(Pointer temp, Pointer count);
+
+		Pointer tgeo_traversed_area(Pointer temp);
+
+		Pointer tgeo_centroid(Pointer temp);
+
+		int tspatial_srid(Pointer temp);
+
+		Pointer tspatial_set_srid(Pointer temp, int srid);
+
+		Pointer tspatial_transform(Pointer temp, int srid);
+
+		Pointer tspatial_transform_pipeline(Pointer temp, String pipelinestr, int srid, boolean is_forward);
+
+		Pointer tgeo_at_geom(Pointer temp, Pointer gs);
+
+		Pointer tgeo_at_stbox(Pointer temp, Pointer box, boolean border_inc);
+
+		Pointer tgeo_minus_geom(Pointer temp, Pointer gs);
+
+		Pointer tgeo_minus_stbox(Pointer temp, Pointer box, boolean border_inc);
+
+		Pointer tpoint_at_geom(Pointer temp, Pointer gs, Pointer zspan);
+
+		Pointer tpoint_at_stbox(Pointer temp, Pointer box, boolean border_inc);
+
+		Pointer tpoint_at_value(Pointer temp, Pointer gs);
+
+		Pointer tpoint_minus_geom(Pointer temp, Pointer gs, Pointer zspan);
+
+		Pointer tpoint_minus_stbox(Pointer temp, Pointer box, boolean border_inc);
+
+		Pointer tpoint_minus_value(Pointer temp, Pointer gs);
+
+		int always_eq_geo_tgeo(Pointer gs, Pointer temp);
+
+		int always_eq_tgeo_geo(Pointer temp, Pointer gs);
+
+		int always_eq_tgeo_tgeo(Pointer temp1, Pointer temp2);
+
+		int always_ne_geo_tgeo(Pointer gs, Pointer temp);
+
+		int always_ne_tgeo_geo(Pointer temp, Pointer gs);
+
+		int always_ne_tgeo_tgeo(Pointer temp1, Pointer temp2);
+
+		int ever_eq_geo_tgeo(Pointer gs, Pointer temp);
+
+		int ever_eq_tgeo_geo(Pointer temp, Pointer gs);
+
+		int ever_eq_tgeo_tgeo(Pointer temp1, Pointer temp2);
+
+		int ever_ne_geo_tgeo(Pointer gs, Pointer temp);
+
+		int ever_ne_tgeo_geo(Pointer temp, Pointer gs);
+
+		int ever_ne_tgeo_tgeo(Pointer temp1, Pointer temp2);
+
+		Pointer teq_geo_tgeo(Pointer gs, Pointer temp);
+
+		Pointer teq_tgeo_geo(Pointer temp, Pointer gs);
+
+		Pointer tne_geo_tgeo(Pointer gs, Pointer temp);
+
+		Pointer tne_tgeo_geo(Pointer temp, Pointer gs);
+
+		Pointer geo_split_each_n_stboxes(Pointer gs, int elem_count, Pointer count);
+
+		Pointer tgeo_stboxes(Pointer temp, Pointer count);
+
+		Pointer tgeo_space_boxes(Pointer temp, double xsize, double ysize, double zsize, Pointer sorigin, boolean bitmatrix, boolean border_inc, Pointer count);
+
+		Pointer tgeo_space_time_boxes(Pointer temp, double xsize, double ysize, double zsize, Pointer duration, Pointer sorigin, long torigin, boolean bitmatrix, boolean border_inc, Pointer count);
+
+		Pointer tgeo_split_each_n_stboxes(Pointer temp, int elem_count, Pointer count);
+
+		Pointer tgeo_split_n_stboxes(Pointer temp, int box_count, Pointer count);
+
+		boolean adjacent_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean adjacent_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean adjacent_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean contained_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean contained_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean contained_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean contains_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean contains_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean contains_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean overlaps_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean overlaps_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean overlaps_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean same_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean same_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean same_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean above_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean above_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean above_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean after_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean after_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean after_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean back_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean back_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean back_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean before_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean before_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean before_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean below_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean below_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean below_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean front_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean front_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean front_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean left_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean left_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean left_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean overabove_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean overabove_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean overabove_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean overafter_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean overafter_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean overafter_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean overback_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean overback_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean overback_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean overbefore_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean overbefore_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean overbefore_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean overbelow_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean overbelow_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean overbelow_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean overfront_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean overfront_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean overfront_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean overleft_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean overleft_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean overleft_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean overright_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean overright_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean overright_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean right_stbox_tspatial(Pointer box, Pointer temp);
+
+		boolean right_tspatial_stbox(Pointer temp, Pointer box);
+
+		boolean right_tspatial_tspatial(Pointer temp1, Pointer temp2);
+
+		boolean bearing_point_point(Pointer gs1, Pointer gs2, Pointer result);
+
+		Pointer bearing_tpoint_point(Pointer temp, Pointer gs, boolean invert);
+
+		Pointer bearing_tpoint_tpoint(Pointer temp1, Pointer temp2);
+
+		Pointer geo_gboxes(Pointer gs, Pointer count);
+
+		Pointer tpoint_angular_difference(Pointer temp);
+
+		Pointer tpoint_azimuth(Pointer temp);
+
+		Pointer tgeo_convex_hull(Pointer temp);
+
+		Pointer tpoint_cumulative_length(Pointer temp);
+
+		boolean tpoint_direction(Pointer temp, Pointer result);
+
+		Pointer tpoint_get_x(Pointer temp);
+
+		Pointer tpoint_get_y(Pointer temp);
+
+		Pointer tpoint_get_z(Pointer temp);
+
+		boolean tpoint_is_simple(Pointer temp);
+
+		double tpoint_length(Pointer temp);
+
+		Pointer tpoint_speed(Pointer temp);
+
+		Pointer tpoint_trajectory(Pointer temp);
+
+		Pointer tpoint_twcentroid(Pointer temp);
+
+		Pointer geo_expand_space(Pointer gs, double d);
+
+		Pointer geomeas_tpoint(Pointer gs);
+
+		Pointer tgeogpoint_tgeography(Pointer temp);
+
+		Pointer tgeography_tgeometry(Pointer temp);
+
+		Pointer tgeography_tgeogpoint(Pointer temp);
+
+		Pointer tgeometry_tgeography(Pointer temp);
+
+		Pointer tgeometry_tgeompoint(Pointer temp);
+
+		Pointer tgeompoint_tgeometry(Pointer temp);
+
+		Pointer tgeo_affine(Pointer temp, Pointer a);
+
+		boolean tpoint_AsMVTGeom(Pointer temp, Pointer bounds, int extent, int buffer, boolean clip_geom, Pointer gsarr, Pointer timesarr, Pointer count);
+
+		Pointer tspatial_expand_space(Pointer temp, double d);
+
+		Pointer tpoint_make_simple(Pointer temp, Pointer count);
+
+		Pointer tgeo_scale(Pointer temp, Pointer scale, Pointer sorigin);
+
+		boolean tpoint_tfloat_to_geomeas(Pointer tpoint, Pointer measure, boolean segmentize, Pointer result);
+
+		int acontains_geo_tgeo(Pointer gs, Pointer temp);
+
+		int adisjoint_tgeo_geo(Pointer temp, Pointer gs);
+
+		int adisjoint_tgeo_tgeo(Pointer temp1, Pointer temp2);
+
+		int adwithin_tgeo_geo(Pointer temp, Pointer gs, double dist);
+
+		int adwithin_tgeo_tgeo(Pointer temp1, Pointer temp2, double dist);
+
+		int aintersects_tgeo_geo(Pointer temp, Pointer gs);
+
+		int aintersects_tgeo_tgeo(Pointer temp1, Pointer temp2);
+
+		int atouches_tgeo_geo(Pointer temp, Pointer gs);
+
+		int econtains_geo_tgeo(Pointer gs, Pointer temp);
+
+		int edisjoint_tgeo_geo(Pointer temp, Pointer gs);
+
+		int edisjoint_tgeo_tgeo(Pointer temp1, Pointer temp2);
+
+		int edwithin_tgeo_geo(Pointer temp, Pointer gs, double dist);
+
+		int edwithin_tgeo_tgeo(Pointer temp1, Pointer temp2, double dist);
+
+		int eintersects_tgeo_geo(Pointer temp, Pointer gs);
+
+		int eintersects_tgeo_tgeo(Pointer temp1, Pointer temp2);
+
+		int etouches_tgeo_geo(Pointer temp, Pointer gs);
+
+		Pointer tcontains_geo_tgeo(Pointer gs, Pointer temp, boolean restr, boolean atvalue);
+
+		Pointer tdisjoint_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue);
+
+		Pointer tdisjoint_tgeo_tgeo (Pointer temp1, Pointer temp2, boolean restr, boolean atvalue);
+
+		Pointer tdwithin_tgeo_geo(Pointer temp, Pointer gs, double dist, boolean restr, boolean atvalue);
+
+		Pointer tdwithin_tgeo_tgeo(Pointer temp1, Pointer temp2, double dist, boolean restr, boolean atvalue);
+
+		Pointer tintersects_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue);
+
+		Pointer tintersects_tgeo_tgeo (Pointer temp1, Pointer temp2, boolean restr, boolean atvalue);
+
+		Pointer ttouches_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue);
+
+		double nad_stbox_geo(Pointer box, Pointer gs);
+
+		double nad_stbox_stbox(Pointer box1, Pointer box2);
+
+		double nad_tgeo_geo(Pointer temp, Pointer gs);
+
+		double nad_tgeo_stbox(Pointer temp, Pointer box);
+
+		double nad_tgeo_tgeo(Pointer temp1, Pointer temp2);
+
+		Pointer nai_tgeo_geo(Pointer temp, Pointer gs);
+
+		Pointer nai_tgeo_tgeo(Pointer temp1, Pointer temp2);
+
+		Pointer shortestline_tgeo_geo(Pointer temp, Pointer gs);
+
+		Pointer shortestline_tgeo_tgeo(Pointer temp1, Pointer temp2);
+
+		Pointer distance_tgeo_geo(Pointer temp, Pointer gs);
+
+		Pointer distance_tgeo_tgeo(Pointer temp1, Pointer temp2);
+
+		Pointer tpoint_tcentroid_finalfn(Pointer state);
+
+		Pointer tpoint_tcentroid_transfn(Pointer state, Pointer temp);
+
+		Pointer tspatial_extent_transfn(Pointer box, Pointer temp);
+
+		Pointer stbox_get_space_tile(Pointer point, double xsize, double ysize, double zsize, Pointer sorigin);
+
+		Pointer stbox_get_space_time_tile(Pointer point, long t, double xsize, double ysize, double zsize, Pointer duration, Pointer sorigin, long torigin);
+
+		Pointer stbox_get_time_tile(long t, Pointer duration, long torigin);
+
+		Pointer stbox_space_tiles(Pointer bounds, double xsize, double ysize, double zsize, Pointer sorigin, boolean border_inc, Pointer count);
+
+		Pointer stbox_space_time_tiles(Pointer bounds, double xsize, double ysize, double zsize, Pointer duration, Pointer sorigin, long torigin, boolean border_inc, Pointer count);
+
+		Pointer stbox_time_tiles(Pointer bounds, Pointer duration, long torigin, boolean border_inc, Pointer count);
+
+		Pointer tpoint_space_split(Pointer temp, double xsize, double ysize, double zsize, Pointer sorigin, boolean bitmatrix, boolean border_inc, Pointer space_bins, Pointer count);
+
+		Pointer tgeo_space_time_split(Pointer temp, double xsize, double ysize, double zsize, Pointer duration, Pointer sorigin, long torigin, boolean bitmatrix, boolean border_inc, Pointer space_bins, Pointer time_bins, Pointer count);
+
+		Pointer tgeo_time_split(Pointer temp, Pointer duration, long torigin, boolean border_inc, Pointer time_bins, Pointer count);
+
+		int int4_in(String str);
+
+		String int4_out(int val);
+
+		long int8_in(String str);
+
+		String int8_out(long val);
+
+		String float8_out(double num, int maxdd);
+
+		double pg_dsin(double arg1);
+
+		double pg_dcos(double arg1);
+
+		double pg_datan(double arg1);
+
+		double pg_datan2(double arg1, double arg2);
+
+		int pg_date_in(String str);
+
+		String pg_date_out(int d);
+
+		int pg_interval_cmp(Pointer interv1, Pointer interv2);
+
+		Pointer pg_interval_in(String str, int prec);
+
+		Pointer pg_interval_justify_hours(Pointer span);
+
+		String pg_interval_out(Pointer interv);
+
+		long pg_time_in(String str, int typmod);
+
+		String pg_time_out(long t);
+
+		long pg_timestamp_in(String str, int typmod);
+
+		String pg_timestamp_out(long t);
+
+		long pg_timestamptz_in(String str, int prec);
+
+		String pg_timestamptz_out(long t);
+
+		int hash_bytes_uint32(int k);
+
+		int pg_hashint8(long val);
+
+		int pg_hashfloat8(double key);
+
+		long hash_bytes_uint32_extended(int k, long seed);
+
+		long pg_hashint8extended(long val, long seed);
+
+		long pg_hashfloat8extended(double key, long seed);
+
+		int pg_hashtext(Pointer key);
+
+		long pg_hashtextextended(Pointer key, long seed);
+
+		Pointer gsl_get_generation_rng();
+
+		Pointer gsl_get_aggregation_rng();
+
+		Pointer proj_get_context();
+
+		long datum_floor(long d);
+
+		long datum_ceil(long d);
+
+		long datum_degrees(long d, long normalize);
+
+		long datum_radians(long d);
+
+		int datum_hash(long d, meosType basetype);
+
+		long datum_hash_extended(long d, meosType basetype, long seed);
+
+		long datum_float_round(long value, long size);
+
+		long datum_geo_round(long value, long size);
+
+		Pointer point_round(Pointer gs, int maxdd);
+
+		void floatspan_round_set(Pointer s, int maxdd, Pointer result);
+
+		Pointer SET_BBOX_PTR(Pointer s);
+
+		Pointer SET_OFFSETS_PTR(Pointer s);
+
+		long SET_VAL_N(Pointer s, int index);
+
+		Pointer SPANSET_SP_N(Pointer ss, int index);
+
+		Pointer TSEQUENCE_OFFSETS_PTR(Pointer seq);
+
+		Pointer TSEQUENCE_INST_N(Pointer seq, int index);
+
+		Pointer TSEQUENCESET_OFFSETS_PTR(Pointer ss);
+
+		Pointer TSEQUENCESET_SEQ_N(Pointer ss, int index);
+
+		Pointer set_in(String str, meosType basetype);
+
+		String set_out(Pointer s, int maxdd);
+
+		Pointer span_in(String str, meosType spantype);
+
+		String span_out(Pointer s, int maxdd);
+
+		Pointer spanset_in(String str, meosType spantype);
+
+		String spanset_out(Pointer ss, int maxdd);
+
+		Pointer set_make(Pointer values, int count, meosType basetype, boolean order);
+
+		Pointer set_make_exp(Pointer values, int count, int maxcount, meosType basetype, boolean order);
+
+		Pointer set_make_free(Pointer values, int count, meosType basetype, boolean order);
+
+		Pointer span_make(long lower, long upper, boolean lower_inc, boolean upper_inc, meosType basetype);
+
+		void span_set(long lower, long upper, boolean lower_inc, boolean upper_inc, meosType basetype, meosType spantype, Pointer s);
+
+		Pointer spanset_make_exp(Pointer spans, int count, int maxcount, boolean normalize, boolean order);
+
+		Pointer spanset_make_free(Pointer spans, int count, boolean normalize, boolean order);
+
+		void value_set_span(long value, meosType basetype, Pointer s);
+
+		Pointer value_set(long d, meosType basetype);
+
+		Pointer value_span(long d, meosType basetype);
+
+		Pointer value_spanset(long d, meosType basetype);
+
+		long numspan_width(Pointer s);
+
+		long numspanset_width(Pointer ss, boolean boundspan);
+
+		long set_end_value(Pointer s);
+
+		int set_mem_size(Pointer s);
+
+		void set_set_subspan(Pointer s, int minidx, int maxidx, Pointer result);
+
+		void set_set_span(Pointer s, Pointer result);
+
+		long set_start_value(Pointer s);
+
+		boolean set_value_n(Pointer s, int n, Pointer result);
+
+		Pointer set_vals(Pointer s);
+
+		Pointer set_values(Pointer s);
+
+		long spanset_lower(Pointer ss);
+
+		int spanset_mem_size(Pointer ss);
+
+		Pointer spanset_sps(Pointer ss);
+
+		long spanset_upper(Pointer ss);
+
+		void datespan_set_tstzspan(Pointer s1, Pointer s2);
+
+		void floatspan_set_intspan(Pointer s1, Pointer s2);
+
+		void intspan_set_floatspan(Pointer s1, Pointer s2);
+
+		Pointer numset_shift_scale(Pointer s, long shift, long width, boolean hasshift, boolean haswidth);
+
+		Pointer numspan_shift_scale(Pointer s, long shift, long width, boolean hasshift, boolean haswidth);
+
+		Pointer numspanset_shift_scale(Pointer ss, long shift, long width, boolean hasshift, boolean haswidth);
+
+		Pointer set_compact(Pointer s);
+
+		void span_expand(Pointer s1, Pointer s2);
+
+		Pointer spanset_compact(Pointer ss);
+
+		Pointer textcat_textset_text_int(Pointer s, Pointer txt, boolean invert);
+
+		void tstzspan_set_datespan(Pointer s1, Pointer s2);
+
+		boolean adjacent_span_value(Pointer s, long value);
+
+		boolean adjacent_spanset_value(Pointer ss, long value);
+
+		boolean adjacent_value_spanset(long value, Pointer ss);
+
+		boolean contained_value_set(long value, Pointer s);
+
+		boolean contained_value_span(long value, Pointer s);
+
+		boolean contained_value_spanset(long value, Pointer ss);
+
+		boolean contains_set_value(Pointer s, long value);
+
+		boolean contains_span_value(Pointer s, long value);
+
+		boolean contains_spanset_value(Pointer ss, long value);
+
+		boolean ovadj_span_span(Pointer s1, Pointer s2);
+
+		boolean left_set_value(Pointer s, long value);
+
+		boolean left_span_value(Pointer s, long value);
+
+		boolean left_spanset_value(Pointer ss, long value);
+
+		boolean left_value_set(long value, Pointer s);
+
+		boolean left_value_span(long value, Pointer s);
+
+		boolean left_value_spanset(long value, Pointer ss);
+
+		boolean lfnadj_span_span(Pointer s1, Pointer s2);
+
+		boolean overleft_set_value(Pointer s, long value);
+
+		boolean overleft_span_value(Pointer s, long value);
+
+		boolean overleft_spanset_value(Pointer ss, long value);
+
+		boolean overleft_value_set(long value, Pointer s);
+
+		boolean overleft_value_span(long value, Pointer s);
+
+		boolean overleft_value_spanset(long value, Pointer ss);
+
+		boolean overright_set_value(Pointer s, long value);
+
+		boolean overright_span_value(Pointer s, long value);
+
+		boolean overright_spanset_value(Pointer ss, long value);
+
+		boolean overright_value_set(long value, Pointer s);
+
+		boolean overright_value_span(long value, Pointer s);
+
+		boolean overright_value_spanset(long value, Pointer ss);
+
+		boolean right_value_set(long value, Pointer s);
+
+		boolean right_set_value(Pointer s, long value);
+
+		boolean right_value_span(long value, Pointer s);
+
+		boolean right_value_spanset(long value, Pointer ss);
+
+		boolean right_span_value(Pointer s, long value);
+
+		boolean right_spanset_value(Pointer ss, long value);
+
+		void bbox_union_span_span(Pointer s1, Pointer s2, Pointer result);
+
+		boolean inter_span_span(Pointer s1, Pointer s2, Pointer result);
+
+		Pointer intersection_set_value(Pointer s, long value);
+
+		Pointer intersection_span_value(Pointer s, long value);
+
+		Pointer intersection_spanset_value(Pointer ss, long value);
+
+		Pointer intersection_value_set(long value, Pointer s);
+
+		Pointer intersection_value_span(long value, Pointer s);
+
+		Pointer intersection_value_spanset(long value, Pointer ss);
+
+		int mi_span_span(Pointer s1, Pointer s2, Pointer result);
+
+		Pointer minus_set_value(Pointer s, long value);
+
+		Pointer minus_span_value(Pointer s, long value);
+
+		Pointer minus_spanset_value(Pointer ss, long value);
+
+		Pointer minus_value_set(long value, Pointer s);
+
+		Pointer minus_value_span(long value, Pointer s);
+
+		Pointer minus_value_spanset(long value, Pointer ss);
+
+		Pointer super_union_span_span(Pointer s1, Pointer s2);
+
+		Pointer union_set_value(Pointer s, long value);
+
+		Pointer union_span_value(Pointer s, long value);
+
+		Pointer union_spanset_value(Pointer ss, long value);
+
+		Pointer union_value_set(long value, Pointer s);
+
+		Pointer union_value_span(long value, Pointer s);
+
+		Pointer union_value_spanset(long value, Pointer ss);
+
+		long distance_set_set(Pointer s1, Pointer s2);
+
+		long distance_set_value(Pointer s, long value);
+
+		long distance_span_span(Pointer s1, Pointer s2);
+
+		long distance_span_value(Pointer s, long value);
+
+		long distance_spanset_span(Pointer ss, Pointer s);
+
+		long distance_spanset_spanset(Pointer ss1, Pointer ss2);
+
+		long distance_spanset_value(Pointer ss, long value);
+
+		long distance_value_value(long l, long r, meosType basetype);
+
+		Pointer spanbase_extent_transfn(Pointer state, long value, meosType basetype);
+
+		Pointer value_union_transfn(Pointer state, long value, meosType basetype);
+
+		Pointer number_tstzspan_to_tbox(long d, meosType basetype, Pointer s);
+
+		Pointer number_timestamptz_to_tbox(long d, meosType basetype, long t);
+
+		void stbox_set(boolean hasx, boolean hasz, boolean geodetic, int srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, Pointer s, Pointer box);
+
+		void tbox_set(Pointer s, Pointer p, Pointer box);
+
+		Pointer box3d_stbox(Pointer box);
+
+		Pointer gbox_stbox(Pointer box);
+
+		void float_set_tbox(double d, Pointer box);
+
+		void gbox_set_stbox(Pointer box, int srid, Pointer result);
+
+		boolean geo_set_stbox(Pointer gs, Pointer box);
+
+		void geoarr_set_stbox(Pointer values, int count, Pointer box);
+
+		void int_set_tbox(int i, Pointer box);
+
+		void number_set_tbox(long d, meosType basetype, Pointer box);
+
+		Pointer number_tbox(long value, meosType basetype);
+
+		void numset_set_tbox(Pointer s, Pointer box);
+
+		void numspan_set_tbox(Pointer span, Pointer box);
+
+		void numspanset_set_tbox(Pointer ss, Pointer box);
+
+		boolean spatial_set_stbox(long d, meosType basetype, Pointer box);
+
+		void spatialset_set_stbox(Pointer set, Pointer box);
+
+		void stbox_set_box3d(Pointer box, Pointer box3d);
+
+		void stbox_set_gbox(Pointer box, Pointer gbox);
+
+		void timestamptz_set_stbox(long t, Pointer box);
+
+		void timestamptz_set_tbox(long t, Pointer box);
+
+		void tstzset_set_stbox(Pointer s, Pointer box);
+
+		void tstzset_set_tbox(Pointer s, Pointer box);
+
+		void tstzspan_set_stbox(Pointer s, Pointer box);
+
+		void tstzspan_set_tbox(Pointer s, Pointer box);
+
+		void tstzspanset_set_stbox(Pointer ss, Pointer box);
+
+		void tstzspanset_set_tbox(Pointer ss, Pointer box);
+
+		Pointer tbox_shift_scale_value(Pointer box, long shift, long width, boolean hasshift, boolean haswidth);
+
+		void stbox_expand(Pointer box1, Pointer box2);
+
+		void tbox_expand(Pointer box1, Pointer box2);
+
+		boolean inter_stbox_stbox(Pointer box1, Pointer box2, Pointer result);
+
+		boolean inter_tbox_tbox(Pointer box1, Pointer box2, Pointer result);
+
+		String tboolinst_as_mfjson(Pointer inst, boolean with_bbox);
+
+		Pointer tboolinst_from_mfjson(Pointer mfjson);
+
+		Pointer tboolinst_in(String str);
+
+		String tboolseq_as_mfjson(Pointer seq, boolean with_bbox);
+
+		Pointer tboolseq_from_mfjson(Pointer mfjson);
+
+		Pointer tboolseq_in(String str, int interp);
+
+		String tboolseqset_as_mfjson(Pointer ss, boolean with_bbox);
+
+		Pointer tboolseqset_from_mfjson(Pointer mfjson);
+
+		Pointer tboolseqset_in(String str);
+
+		Pointer temporal_in(String str, meosType temptype);
+
+		String temporal_out(Pointer temp, int maxdd);
+
+		Pointer temparr_out(Pointer temparr, int count, int maxdd);
+
+		String tfloatinst_as_mfjson(Pointer inst, boolean with_bbox, int precision);
+
+		Pointer tfloatinst_from_mfjson(Pointer mfjson);
+
+		Pointer tfloatinst_in(String str);
+
+		String tfloatseq_as_mfjson(Pointer seq, boolean with_bbox, int precision);
+
+		Pointer tfloatseq_from_mfjson(Pointer mfjson, int interp);
+
+		Pointer tfloatseq_in(String str, int interp);
+
+		String tfloatseqset_as_mfjson(Pointer ss, boolean with_bbox, int precision);
+
+		Pointer tfloatseqset_from_mfjson(Pointer mfjson, int interp);
+
+		Pointer tfloatseqset_in(String str);
+
+		String tgeoinst_as_mfjson(Pointer inst, boolean with_bbox, int precision, String srs);
+
+		Pointer tgeogpointinst_from_mfjson(Pointer mfjson, int srid);
+
+		Pointer tgeogpointinst_in(String str);
+
+		Pointer tgeogpointseq_from_mfjson(Pointer mfjson, int srid, int interp);
+
+		Pointer tgeogpointseq_in(String str, int interp);
+
+		Pointer tgeogpointseqset_from_mfjson(Pointer mfjson, int srid, int interp);
+
+		Pointer tgeogpointseqset_in(String str);
+
+		Pointer tgeompointinst_from_mfjson(Pointer mfjson, int srid);
+
+		Pointer tgeompointinst_in(String str);
+
+		Pointer tgeompointseq_from_mfjson(Pointer mfjson, int srid, int interp);
+
+		Pointer tgeompointseq_in(String str, int interp);
+
+		Pointer tgeompointseqset_from_mfjson(Pointer mfjson, int srid, int interp);
+
+		Pointer tgeompointseqset_in(String str);
+
+		Pointer tgeographyinst_from_mfjson(Pointer mfjson, int srid);
+
+		Pointer tgeographyinst_in(String str);
+
+		Pointer tgeographyseq_from_mfjson(Pointer mfjson, int srid, int interp);
+
+		Pointer tgeographyseq_in(String str, int interp);
+
+		Pointer tgeographyseqset_from_mfjson(Pointer mfjson, int srid, int interp);
+
+		Pointer tgeographyseqset_in(String str);
+
+		Pointer tgeometryinst_from_mfjson(Pointer mfjson, int srid);
+
+		Pointer tgeometryinst_in(String str);
+
+		Pointer tgeometryseq_from_mfjson(Pointer mfjson, int srid, int interp);
+
+		Pointer tgeometryseq_in(String str, int interp);
+
+		Pointer tgeometryseqset_from_mfjson(Pointer mfjson, int srid, int interp);
+
+		Pointer tgeometryseqset_in(String str);
+
+		String tgeoseq_as_mfjson(Pointer seq, boolean with_bbox, int precision, String srs);
+
+		String tgeoseqset_as_mfjson(Pointer ss, boolean with_bbox, int precision, String srs);
+
+		Pointer tinstant_from_mfjson(Pointer mfjson, boolean isgeo, int srid, meosType temptype);
+
+		Pointer tinstant_in(String str, meosType temptype);
+
+		String tinstant_out(Pointer inst, int maxdd);
+
+		String tintinst_as_mfjson(Pointer inst, boolean with_bbox);
+
+		Pointer tintinst_from_mfjson(Pointer mfjson);
+
+		Pointer tintinst_in(String str);
+
+		String tintseq_as_mfjson(Pointer seq, boolean with_bbox);
+
+		Pointer tintseq_from_mfjson(Pointer mfjson);
+
+		Pointer tintseq_in(String str, int interp);
+
+		String tintseqset_as_mfjson(Pointer ss, boolean with_bbox);
+
+		Pointer tintseqset_from_mfjson(Pointer mfjson);
+
+		Pointer tintseqset_in(String str);
+
+		String tpointinst_as_mfjson(Pointer inst, boolean with_bbox, int precision, String srs);
+
+		String tpointseq_as_mfjson(Pointer seq, boolean with_bbox, int precision, String srs);
+
+		String tpointseqset_as_mfjson(Pointer ss, boolean with_bbox, int precision, String srs);
+
+		Pointer tsequence_from_mfjson(Pointer mfjson, boolean isgeo, int srid, meosType temptype, int interp);
+
+		Pointer tsequence_in(String str, meosType temptype, int interp);
+
+		String tsequence_out(Pointer seq, int maxdd);
+
+		Pointer tsequenceset_from_mfjson(Pointer mfjson, boolean isgeo, int srid, meosType temptype, int interp);
+
+		Pointer tsequenceset_in(String str, meosType temptype, int interp);
+
+		String tsequenceset_out(Pointer ss, int maxdd);
+
+		String ttextinst_as_mfjson(Pointer inst, boolean with_bbox);
+
+		Pointer ttextinst_from_mfjson(Pointer mfjson);
+
+		Pointer ttextinst_in(String str);
+
+		String ttextseq_as_mfjson(Pointer seq, boolean with_bbox);
+
+		Pointer ttextseq_from_mfjson(Pointer mfjson);
+
+		Pointer ttextseq_in(String str, int interp);
+
+		String ttextseqset_as_mfjson(Pointer ss, boolean with_bbox);
+
+		Pointer ttextseqset_from_mfjson(Pointer mfjson);
+
+		Pointer ttextseqset_in(String str);
+
+		Pointer temporal_from_mfjson(String mfjson, meosType temptype);
+
+		Pointer temporal_from_base_temp(long value, meosType temptype, Pointer temp);
+
+		Pointer tinstant_copy(Pointer inst);
+
+		Pointer tinstant_make(long value, meosType temptype, long t);
+
+		Pointer tinstant_make_free(long value, meosType temptype, long t);
+
+		Pointer tpointseq_make_coords(Pointer xcoords, Pointer ycoords, Pointer zcoords, Pointer times, int count, int srid, boolean geodetic, boolean lower_inc, boolean upper_inc, int interp, boolean normalize);
+
+		Pointer tsequence_copy(Pointer seq);
+
+		Pointer tsequence_from_base_tstzset(long value, meosType temptype, Pointer ss);
+
+		Pointer tsequence_from_base_tstzspan(long value, meosType temptype, Pointer s, int interp);
+
+		Pointer tsequence_make_exp(Pointer instants, int count, int maxcount, boolean lower_inc, boolean upper_inc, int interp, boolean normalize);
+
+		Pointer tsequence_make_free(Pointer instants, int count, boolean lower_inc, boolean upper_inc, int interp, boolean normalize);
+
+		Pointer tsequenceset_copy(Pointer ss);
+
+		Pointer tseqsetarr_to_tseqset(Pointer seqsets, int count, int totalseqs);
+
+		Pointer tsequenceset_from_base_tstzspanset(long value, meosType temptype, Pointer ss, int interp);
+
+		Pointer tsequenceset_make_exp(Pointer sequences, int count, int maxcount, boolean normalize);
+
+		Pointer tsequenceset_make_free(Pointer sequences, int count, boolean normalize);
+
+		void temporal_set_tstzspan(Pointer temp, Pointer s);
+
+		void tinstant_set_tstzspan(Pointer inst, Pointer s);
+
+		void tnumber_set_tbox(Pointer temp, Pointer box);
+
+		void tnumberinst_set_tbox(Pointer inst, Pointer box);
+
+		void tnumberseq_set_tbox(Pointer seq, Pointer box);
+
+		void tnumberseqset_set_tbox(Pointer ss, Pointer box);
+
+		void tsequence_set_tstzspan(Pointer seq, Pointer s);
+
+		void tsequenceset_set_tstzspan(Pointer ss, Pointer s);
+
+		Pointer temporal_end_inst(Pointer temp);
+
+		long temporal_end_value(Pointer temp);
+
+		Pointer temporal_inst_n(Pointer temp, int n);
+
+		Pointer temporal_instants_p(Pointer temp, Pointer count);
+
+		long temporal_max_value(Pointer temp);
+
+		long temporal_mem_size(Pointer temp);
+
+		long temporal_min_value(Pointer temp);
+
+		Pointer temporal_sequences_p(Pointer temp, Pointer count);
+
+		void temporal_set_bbox(Pointer temp, Pointer box);
+
+		Pointer temporal_start_inst(Pointer temp);
+
+		long temporal_start_value(Pointer temp);
+
+		Pointer temporal_values_p(Pointer temp, Pointer count);
+
+		boolean temporal_value_n(Pointer temp, int n, Pointer result);
+
+		Pointer temporal_values(Pointer temp, Pointer count);
+
+		int tinstant_hash(Pointer inst);
+
+		Pointer tinstant_insts(Pointer inst, Pointer count);
+
+		void tinstant_set_bbox(Pointer inst, Pointer box);
+
+		Pointer tinstant_time(Pointer inst);
+
+		Pointer tinstant_timestamps(Pointer inst, Pointer count);
+
+		long tinstant_value_p(Pointer inst);
+
+		long tinstant_value(Pointer inst);
+
+		boolean tinstant_value_at_timestamptz(Pointer inst, long t, Pointer result);
+
+		Pointer tinstant_values_p(Pointer inst, Pointer count);
+
+		void tnumber_set_span(Pointer temp, Pointer span);
+
+		Pointer tnumberinst_valuespans(Pointer inst);
+
+		Pointer tnumberseq_valuespans(Pointer seq);
+
+		Pointer tnumberseqset_valuespans(Pointer ss);
+
+		Pointer tsequence_duration(Pointer seq);
+
+		long tsequence_end_timestamptz(Pointer seq);
+
+		int tsequence_hash(Pointer seq);
+
+		Pointer tsequence_instants_p(Pointer seq);
+
+		Pointer tsequence_max_inst(Pointer seq);
+
+		long tsequence_max_val(Pointer seq);
+
+		Pointer tsequence_min_inst(Pointer seq);
+
+		long tsequence_min_val(Pointer seq);
+
+		Pointer tsequence_segments(Pointer seq, Pointer count);
+
+		Pointer tsequence_seqs(Pointer seq, Pointer count);
+
+		long tsequence_start_timestamptz(Pointer seq);
+
+		Pointer tsequence_time(Pointer seq);
+
+		Pointer tsequence_timestamps(Pointer seq, Pointer count);
+
+		boolean tsequence_value_at_timestamptz(Pointer seq, long t, boolean strict, Pointer result);
+
+		Pointer tsequence_values_p(Pointer seq, Pointer count);
+
+		Pointer tsequenceset_duration(Pointer ss, boolean boundspan);
+
+		long tsequenceset_end_timestamptz(Pointer ss);
+
+		int tsequenceset_hash(Pointer ss);
+
+		Pointer tsequenceset_inst_n(Pointer ss, int n);
+
+		Pointer tsequenceset_insts(Pointer ss);
+
+		Pointer tsequenceset_max_inst(Pointer ss);
+
+		long tsequenceset_max_val(Pointer ss);
+
+		Pointer tsequenceset_min_inst(Pointer ss);
+
+		long tsequenceset_min_val(Pointer ss);
+
+		int tsequenceset_num_instants(Pointer ss);
+
+		int tsequenceset_num_timestamps(Pointer ss);
+
+		Pointer tsequenceset_segments(Pointer ss, Pointer count);
+
+		Pointer tsequenceset_sequences_p(Pointer ss);
+
+		long tsequenceset_start_timestamptz(Pointer ss);
+
+		Pointer tsequenceset_time(Pointer ss);
+
+		boolean tsequenceset_timestamptz_n(Pointer ss, int n, Pointer result);
+
+		Pointer tsequenceset_timestamps(Pointer ss, Pointer count);
+
+		boolean tsequenceset_value_at_timestamptz(Pointer ss, long t, boolean strict, Pointer result);
+
+		boolean tsequenceset_value_n(Pointer ss, int n, Pointer result);
+
+		Pointer tsequenceset_values_p(Pointer ss, Pointer count);
+
+		void temporal_restart(Pointer temp, int count);
+
+		Pointer temporal_tsequence(Pointer temp, int interp);
+
+		Pointer temporal_tsequenceset(Pointer temp, int interp);
+
+		Pointer tinstant_shift_time(Pointer inst, Pointer interv);
+
+		Pointer tinstant_to_tsequence(Pointer inst, int interp);
+
+		Pointer tinstant_to_tsequence_free(Pointer inst, int interp);
+
+		Pointer tinstant_to_tsequenceset(Pointer inst, int interp);
+
+		Pointer tnumber_shift_scale_value(Pointer temp, long shift, long width, boolean hasshift, boolean haswidth);
+
+		Pointer tnumberinst_shift_value(Pointer inst, long shift);
+
+		Pointer tnumberseq_shift_scale_value(Pointer seq, long shift, long width, boolean hasshift, boolean haswidth);
+
+		Pointer tnumberseqset_shift_scale_value(Pointer ss, long start, long width, boolean hasshift, boolean haswidth);
+
+		void tsequence_restart(Pointer seq, int count);
+
+		Pointer tsequence_set_interp(Pointer seq, int interp);
+
+		Pointer tsequence_shift_scale_time(Pointer seq, Pointer shift, Pointer duration);
+
+		Pointer tsequence_subseq(Pointer seq, int from, int to, boolean lower_inc, boolean upper_inc);
+
+		Pointer tsequence_to_tinstant(Pointer seq);
+
+		Pointer tsequence_to_tsequenceset(Pointer seq);
+
+		Pointer tsequence_to_tsequenceset_free(Pointer seq);
+
+		Pointer tsequence_to_tsequenceset_interp(Pointer seq, int interp);
+
+		void tsequenceset_restart(Pointer ss, int count);
+
+		Pointer tsequenceset_set_interp(Pointer ss, int interp);
+
+		Pointer tsequenceset_shift_scale_time(Pointer ss, Pointer start, Pointer duration);
+
+		Pointer tsequenceset_to_discrete(Pointer ss);
+
+		Pointer tsequenceset_to_linear(Pointer ss);
+
+		Pointer tsequenceset_to_step(Pointer ss);
+
+		Pointer tsequenceset_to_tinstant(Pointer ss);
+
+		Pointer tsequenceset_to_tsequence(Pointer ss);
+
+		Pointer tinstant_merge(Pointer inst1, Pointer inst2);
+
+		Pointer tinstant_merge_array(Pointer instants, int count);
+
+		Pointer tsequence_append_tinstant(Pointer seq, Pointer inst, double maxdist, Pointer maxt, boolean expand);
+
+		Pointer tsequence_append_tsequence(Pointer seq1, Pointer seq2, boolean expand);
+
+		Pointer tsequence_delete_timestamptz(Pointer seq, long t, boolean connect);
+
+		Pointer tsequence_delete_tstzset(Pointer seq, Pointer s, boolean connect);
+
+		Pointer tsequence_delete_tstzspan(Pointer seq, Pointer s, boolean connect);
+
+		Pointer tsequence_delete_tstzspanset(Pointer seq, Pointer ss, boolean connect);
+
+		Pointer tsequence_insert(Pointer seq1, Pointer seq2, boolean connect);
+
+		Pointer tsequence_merge(Pointer seq1, Pointer seq2);
+
+		Pointer tsequence_merge_array(Pointer sequences, int count);
+
+		Pointer tsequenceset_append_tinstant(Pointer ss, Pointer inst, double maxdist, Pointer maxt, boolean expand);
+
+		Pointer tsequenceset_append_tsequence(Pointer ss, Pointer seq, boolean expand);
+
+		Pointer tsequenceset_delete_timestamptz(Pointer ss, long t);
+
+		Pointer tsequenceset_delete_tstzset(Pointer ss, Pointer s);
+
+		Pointer tsequenceset_delete_tstzspan(Pointer ss, Pointer s);
+
+		Pointer tsequenceset_delete_tstzspanset(Pointer ss, Pointer ps);
+
+		Pointer tsequenceset_insert(Pointer ss1, Pointer ss2);
+
+		Pointer tsequenceset_merge(Pointer ss1, Pointer ss2);
+
+		Pointer tsequenceset_merge_array(Pointer seqsets, int count);
+
+		void tspatial_set_stbox(Pointer temp, Pointer box);
+
+		void tgeoinst_set_stbox(Pointer inst, Pointer box);
+
+		void tspatialseq_set_stbox(Pointer seq, Pointer box);
+
+		void tspatialseqset_set_stbox(Pointer ss, Pointer box);
+
+		void tsequence_expand_bbox(Pointer seq, Pointer inst);
+
+		void tsequence_set_bbox(Pointer seq, Pointer box);
+
+		void tsequenceset_expand_bbox(Pointer ss, Pointer seq);
+
+		void tsequenceset_set_bbox(Pointer ss, Pointer box);
+
+		Pointer tdiscseq_restrict_minmax(Pointer seq, boolean min, boolean atfunc);
+
+		Pointer tcontseq_restrict_minmax(Pointer seq, boolean min, boolean atfunc);
+
+		boolean temporal_bbox_restrict_set(Pointer temp, Pointer set);
+
+		Pointer temporal_restrict_minmax(Pointer temp, boolean min, boolean atfunc);
+
+		Pointer temporal_restrict_timestamptz(Pointer temp, long t, boolean atfunc);
+
+		Pointer temporal_restrict_tstzset(Pointer temp, Pointer s, boolean atfunc);
+
+		Pointer temporal_restrict_tstzspan(Pointer temp, Pointer s, boolean atfunc);
+
+		Pointer temporal_restrict_tstzspanset(Pointer temp, Pointer ss, boolean atfunc);
+
+		Pointer temporal_restrict_value(Pointer temp, long value, boolean atfunc);
+
+		Pointer temporal_restrict_values(Pointer temp, Pointer set, boolean atfunc);
+
+		boolean temporal_value_at_timestamptz(Pointer temp, long t, boolean strict, Pointer result);
+
+		Pointer tinstant_restrict_tstzspan(Pointer inst, Pointer period, boolean atfunc);
+
+		Pointer tinstant_restrict_tstzspanset(Pointer inst, Pointer ss, boolean atfunc);
+
+		Pointer tinstant_restrict_timestamptz(Pointer inst, long t, boolean atfunc);
+
+		Pointer tinstant_restrict_tstzset(Pointer inst, Pointer s, boolean atfunc);
+
+		Pointer tinstant_restrict_value(Pointer inst, long value, boolean atfunc);
+
+		Pointer tinstant_restrict_values(Pointer inst, Pointer set, boolean atfunc);
+
+		Pointer tgeo_restrict_geom(Pointer temp, Pointer gs, Pointer zspan, boolean atfunc);
+
+		Pointer tgeo_restrict_stbox(Pointer temp, Pointer box, boolean border_inc, boolean atfunc);
+
+		Pointer tgeoinst_restrict_geom(Pointer inst, Pointer gs, Pointer zspan, boolean atfunc);
+
+		Pointer tgeoinst_restrict_stbox(Pointer inst, Pointer box, boolean border_inc, boolean atfunc);
+
+		Pointer tgeoseq_restrict_geom(Pointer seq, Pointer gs, Pointer zspan, boolean atfunc);
+
+		Pointer tgeotseq_restrict_stbox(Pointer seq, Pointer box, boolean border_inc, boolean atfunc);
+
+		Pointer tgeoseqset_restrict_geom(Pointer ss, Pointer gs, Pointer zspan, boolean atfunc);
+
+		Pointer tgeoseqset_restrict_stbox(Pointer ss, Pointer box, boolean border_inc, boolean atfunc);
+
+		Pointer tnumber_restrict_span(Pointer temp, Pointer span, boolean atfunc);
+
+		Pointer tnumber_restrict_spanset(Pointer temp, Pointer ss, boolean atfunc);
+
+		Pointer tnumberinst_restrict_span(Pointer inst, Pointer span, boolean atfunc);
+
+		Pointer tnumberinst_restrict_spanset(Pointer inst, Pointer ss, boolean atfunc);
+
+		Pointer tnumberseqset_restrict_span(Pointer ss, Pointer span, boolean atfunc);
+
+		Pointer tnumberseqset_restrict_spanset(Pointer ss, Pointer spanset, boolean atfunc);
+
+		Pointer tsequence_at_timestamptz(Pointer seq, long t);
+
+		Pointer tsequence_restrict_tstzspan(Pointer seq, Pointer s, boolean atfunc);
+
+		Pointer tsequence_restrict_tstzspanset(Pointer seq, Pointer ss, boolean atfunc);
+
+		Pointer tsequenceset_restrict_minmax(Pointer ss, boolean min, boolean atfunc);
+
+		Pointer tsequenceset_restrict_tstzspan(Pointer ss, Pointer s, boolean atfunc);
+
+		Pointer tsequenceset_restrict_tstzspanset(Pointer ss, Pointer ps, boolean atfunc);
+
+		Pointer tsequenceset_restrict_timestamptz(Pointer ss, long t, boolean atfunc);
+
+		Pointer tsequenceset_restrict_tstzset(Pointer ss, Pointer s, boolean atfunc);
+
+		Pointer tsequenceset_restrict_value(Pointer ss, long value, boolean atfunc);
+
+		Pointer tsequenceset_restrict_values(Pointer ss, Pointer s, boolean atfunc);
+
+		int tinstant_cmp(Pointer inst1, Pointer inst2);
+
+		boolean tinstant_eq(Pointer inst1, Pointer inst2);
+
+		int tsequence_cmp(Pointer seq1, Pointer seq2);
+
+		boolean tsequence_eq(Pointer seq1, Pointer seq2);
+
+		int tsequenceset_cmp(Pointer ss1, Pointer ss2);
+
+		boolean tsequenceset_eq(Pointer ss1, Pointer ss2);
+
+		int always_eq_base_temporal(long value, Pointer temp);
+
+		int always_eq_temporal_base(Pointer temp, long value);
+
+		int always_ne_base_temporal(long value, Pointer temp);
+
+		int always_ne_temporal_base(Pointer temp, long value);
+
+		int always_ge_base_temporal(long value, Pointer temp);
+
+		int always_ge_temporal_base(Pointer temp, long value);
+
+		int always_gt_base_temporal(long value, Pointer temp);
+
+		int always_gt_temporal_base(Pointer temp, long value);
+
+		int always_le_base_temporal(long value, Pointer temp);
+
+		int always_le_temporal_base(Pointer temp, long value);
+
+		int always_lt_base_temporal(long value, Pointer temp);
+
+		int always_lt_temporal_base(Pointer temp, long value);
+
+		int ever_eq_base_temporal(long value, Pointer temp);
+
+		int ever_eq_temporal_base(Pointer temp, long value);
+
+		int ever_ne_base_temporal(long value, Pointer temp);
+
+		int ever_ne_temporal_base(Pointer temp, long value);
+
+		int ever_ge_base_temporal(long value, Pointer temp);
+
+		int ever_ge_temporal_base(Pointer temp, long value);
+
+		int ever_gt_base_temporal(long value, Pointer temp);
+
+		int ever_gt_temporal_base(Pointer temp, long value);
+
+		int ever_le_base_temporal(long value, Pointer temp);
+
+		int ever_le_temporal_base(Pointer temp, long value);
+
+		int ever_lt_base_temporal(long value, Pointer temp);
+
+		int ever_lt_temporal_base(Pointer temp, long value);
+
+		Pointer tfloatseq_derivative(Pointer seq);
+
+		Pointer tfloatseqset_derivative(Pointer ss);
+
+		Pointer tnumberinst_abs(Pointer inst);
+
+		Pointer tnumberseq_abs(Pointer seq);
+
+		Pointer tnumberseq_angular_difference(Pointer seq);
+
+		Pointer tnumberseq_delta_value(Pointer seq);
+
+		Pointer tnumberseqset_abs(Pointer ss);
+
+		Pointer tnumberseqset_angular_difference(Pointer ss);
+
+		Pointer tnumberseqset_delta_value(Pointer ss);
+
+		Pointer distance_tnumber_number(Pointer temp, long value);
+
+		long nad_tbox_tbox(Pointer box1, Pointer box2);
+
+		long nad_tnumber_number(Pointer temp, long value);
+
+		long nad_tnumber_tbox(Pointer temp, Pointer box);
+
+		long nad_tnumber_tnumber(Pointer temp1, Pointer temp2);
+
+		int spatial_srid(long d, meosType basetype);
+
+		boolean spatial_has_z(long d, meosType basetype);
+
+		boolean spatial_is_geodetic(long d, meosType basetype);
+
+		boolean spatial_set_srid(long d, meosType basetype, int srid);
+
+		int tspatialinst_srid(Pointer inst);
+
+		Pointer tpointseq_azimuth(Pointer seq);
+
+		Pointer tpointseq_cumulative_length(Pointer seq, double prevlength);
+
+		boolean tpointseq_is_simple(Pointer seq);
+
+		double tpointseq_length(Pointer seq);
+
+		Pointer tpointseq_linear_trajectory(Pointer seq, boolean unary_union);
+
+		Pointer tpointseq_speed(Pointer seq);
+
+		Pointer tgeoseq_stboxes(Pointer seq, Pointer count);
+
+		Pointer tpointseq_split_n_stboxes(Pointer seq, int max_count, Pointer count);
+
+		Pointer tpointseqset_azimuth(Pointer ss);
+
+		Pointer tpointseqset_cumulative_length(Pointer ss);
+
+		boolean tpointseqset_is_simple(Pointer ss);
+
+		double tpointseqset_length(Pointer ss);
+
+		Pointer tpointseqset_speed(Pointer ss);
+
+		Pointer tgeoseqset_stboxes(Pointer ss, Pointer count);
+
+		Pointer tpointseqset_split_n_stboxes(Pointer ss, int max_count, Pointer count);
+
+		Pointer tpointseqset_trajectory(Pointer ss);
+
+		Pointer tpoint_get_coord(Pointer temp, int coord);
+
+		Pointer tgeominst_tgeoginst(Pointer inst, boolean oper);
+
+		Pointer tgeomseq_tgeogseq(Pointer seq, boolean oper);
+
+		Pointer tgeomseqset_tgeogseqset(Pointer ss, boolean oper);
+
+		Pointer tgeom_tgeog(Pointer temp, boolean oper);
+
+		Pointer tgeo_tpoint(Pointer temp, boolean oper);
+
+		Pointer tgeompoint_tnpoint(Pointer temp);
+
+		Pointer tnpoint_tgeompoint(Pointer temp);
+
+		void tspatialinst_set_srid(Pointer inst, int srid);
+
+		Pointer tpointseq_make_simple(Pointer seq, Pointer count);
+
+		void tpointseq_set_srid(Pointer seq, int srid);
+
+		Pointer tpointseqset_make_simple(Pointer ss, Pointer count);
+
+		void tpointseqset_set_srid(Pointer ss, int srid);
+
+		double tnumberseq_integral(Pointer seq);
+
+		double tnumberseq_twavg(Pointer seq);
+
+		double tnumberseqset_integral(Pointer ss);
+
+		double tnumberseqset_twavg(Pointer ss);
+
+		Pointer tpointseq_twcentroid(Pointer seq);
+
+		Pointer tpointseqset_twcentroid(Pointer ss);
+
+		Pointer temporal_compact(Pointer temp);
+
+		Pointer tsequence_compact(Pointer seq);
+
+		Pointer tsequenceset_compact(Pointer ss);
+
+		void skiplist_free(Pointer list);
+
+		Pointer temporal_app_tinst_transfn(Pointer state, Pointer inst, int interp, double maxdist, Pointer maxt);
+
+		Pointer temporal_app_tseq_transfn(Pointer state, Pointer seq);
+
+		Pointer numspanset_spans(Pointer ss, long vsize, long vorigin, Pointer count);
+
+		Pointer spanset_time_spans(Pointer ss, Pointer duration, long torigin, Pointer count);
+
+		Pointer spanset_value_spans(Pointer ss, long vsize, long vorigin, Pointer count);
+
+		Pointer timespanset_spans(Pointer ss, Pointer duration, long torigin, Pointer count);
+
+		Pointer tnumber_value_spans(Pointer temp, long size, long origin, Pointer count);
+
+		Pointer tnumber_value_boxes(Pointer temp, long vsize, long vorigin, Pointer count);
+
+		Pointer tnumber_time_boxes(Pointer temp, Pointer duration, long torigin, Pointer count);
+
+		Pointer tnumber_value_time_boxes(Pointer temp, long vsize, Pointer duration, long vorigin, long torigin, Pointer count);
+
+		Pointer tnumber_value_split(Pointer temp, long vsize, long vorigin, Pointer bins, Pointer count);
+
+		Pointer tbox_get_value_time_tile(long value, long t, long vsize, Pointer duration, long vorigin, long torigin, meosType basetype, meosType spantype);
+
+		Pointer tnumber_value_time_split(Pointer temp, long size, Pointer duration, long vorigin, long torigin, Pointer value_bins, Pointer time_bins, Pointer count);
+
+		int date_in(String str);
+
+		String date_out(int d);
+
+		int interval_cmp(Pointer interv1, Pointer interv2);
+
+		Pointer interval_in(String str, int typmod);
+
+		Pointer interval_make(int years, int months, int weeks, int days, int hours, int mins, double secs);
+
+		String interval_out(Pointer interv);
+
+		double pg_exp(double arg1);
+
+		double pg_ln(double arg1);
+
+		double pg_log10(double arg1);
+
+		long time_in(String str, int typmod);
+
+		String time_out(long t);
+
+		long timestamp_in(String str, int typmod);
+
+		String timestamp_out(long t);
+
+		long timestamptz_in(String str, int typmod);
+
+		String timestamptz_out(long t);
 
 	}
 
-	@SuppressWarnings("unused")
-	public static int geo_get_srid(Pointer g) {
-		return MeosLibrary.meos.geo_get_srid(g);
-	}
-	
 	@SuppressWarnings("unused")
 	public static void meos_error(int errlevel, int errcode, String format, Pointer args) {
 		MeosLibrary.meos.meos_error(errlevel, errcode, format, args);
@@ -3061,8 +4427,8 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static void meos_initialize(String tz_str, error_handler_fn err_handler) {
-		MeosLibrary.meos.meos_initialize(tz_str, err_handler);
+	public static void meos_initialize() {
+		MeosLibrary.meos.meos_initialize();
 	}
 	
 	@SuppressWarnings("unused")
@@ -3104,10 +4470,21 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
+	public static LocalDateTime date_to_timestamp(int dateVal) {
+		var result = MeosLibrary.meos.date_to_timestamp(dateVal);
+		return LocalDateTime.ofEpochSecond(result, 0, ZoneOffset.UTC);
+	}
+	
+	@SuppressWarnings("unused")
 	public static OffsetDateTime date_to_timestamptz(int d) {
 		var result = MeosLibrary.meos.date_to_timestamptz(d);
 		Instant instant = Instant.ofEpochSecond(result);
 		return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double float_round(double d, int maxdd) {
+		return MeosLibrary.meos.float_round(d, maxdd);
 	}
 	
 	@SuppressWarnings("unused")
@@ -3138,71 +4515,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static Pointer mult_interval_double(Pointer interv, double factor) {
 		return MeosLibrary.meos.mult_interval_double(interv, factor);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int pg_date_in(String str) {
-		return MeosLibrary.meos.pg_date_in(str);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String pg_date_out(int d) {
-		return MeosLibrary.meos.pg_date_out(d);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int pg_interval_cmp(Pointer interv1, Pointer interv2) {
-		return MeosLibrary.meos.pg_interval_cmp(interv1, interv2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer pg_interval_in(String str, int typmod) {
-		return MeosLibrary.meos.pg_interval_in(str, typmod);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer pg_interval_make(int years, int months, int weeks, int days, int hours, int mins, double secs) {
-		return MeosLibrary.meos.pg_interval_make(years, months, weeks, days, hours, mins, secs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String pg_interval_out(Pointer interv) {
-		return MeosLibrary.meos.pg_interval_out(interv);
-	}
-	
-	@SuppressWarnings("unused")
-	public static long pg_time_in(String str, int typmod) {
-		return MeosLibrary.meos.pg_time_in(str, typmod);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String pg_time_out(long t) {
-		return MeosLibrary.meos.pg_time_out(t);
-	}
-	
-	@SuppressWarnings("unused")
-	public static LocalDateTime pg_timestamp_in(String str, int typmod) {
-		var result = MeosLibrary.meos.pg_timestamp_in(str, typmod);
-		return LocalDateTime.ofEpochSecond(result, 0, ZoneOffset.UTC);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String pg_timestamp_out(LocalDateTime t) {
-		var t_new = t.toEpochSecond(ZoneOffset.UTC);
-		return MeosLibrary.meos.pg_timestamp_out(t_new);
-	}
-	
-	@SuppressWarnings("unused")
-	public static OffsetDateTime pg_timestamptz_in(String str, int typmod) {
-		var result = MeosLibrary.meos.pg_timestamptz_in(str, typmod);
-		Instant instant = Instant.ofEpochSecond(result);
-		return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String pg_timestamptz_out(OffsetDateTime t) {
-		var t_new = t.toEpochSecond();
-		return MeosLibrary.meos.pg_timestamptz_out(t_new);
 	}
 	
 	@SuppressWarnings("unused")
@@ -3246,84 +4558,15 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
+	public static int timestamp_to_date(LocalDateTime t) {
+		var t_new = t.toEpochSecond(ZoneOffset.UTC);
+		return MeosLibrary.meos.timestamp_to_date(t_new);
+	}
+	
+	@SuppressWarnings("unused")
 	public static int timestamptz_to_date(OffsetDateTime t) {
 		var t_new = t.toEpochSecond();
 		return MeosLibrary.meos.timestamptz_to_date(t_new);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geo_as_ewkb(Pointer gs, String endian) {
-		return MeosLibrary.meos.geo_as_ewkb(gs, endian);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String geo_as_ewkt(Pointer gs, int precision) {
-		return MeosLibrary.meos.geo_as_ewkt(gs, precision);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String geo_as_geojson(Pointer gs, int option, int precision, String srs) {
-		return MeosLibrary.meos.geo_as_geojson(gs, option, precision, srs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String geo_as_hexewkb(Pointer gs, String endian) {
-		return MeosLibrary.meos.geo_as_hexewkb(gs, endian);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String geo_as_text(Pointer gs, int precision) {
-		return MeosLibrary.meos.geo_as_text(gs, precision);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geo_from_ewkb(Pointer bytea_wkb, int srid) {
-		return MeosLibrary.meos.geo_from_ewkb(bytea_wkb, srid);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geo_from_geojson(String geojson) {
-		return MeosLibrary.meos.geo_from_geojson(geojson);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String geo_out(Pointer gs) {
-		return MeosLibrary.meos.geo_out(gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean geo_same(Pointer gs1, Pointer gs2) {
-		return MeosLibrary.meos.geo_same(gs1, gs2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geography_from_hexewkb(String wkt) {
-		return MeosLibrary.meos.geography_from_hexewkb(wkt);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geography_from_text(String wkt, int srid) {
-		return MeosLibrary.meos.geography_from_text(wkt, srid);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geometry_from_hexewkb(String wkt) {
-		return MeosLibrary.meos.geometry_from_hexewkb(wkt);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geometry_from_text(String wkt, int srid) {
-		return MeosLibrary.meos.geometry_from_text(wkt, srid);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer pgis_geography_in(String str, int typmod) {
-		return MeosLibrary.meos.pgis_geography_in(str, typmod);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer pgis_geometry_in(String str, int typmod) {
-		return MeosLibrary.meos.pgis_geometry_in(str, typmod);
 	}
 	
 	@SuppressWarnings("unused")
@@ -3417,31 +4660,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer geogset_in(String str) {
-		return MeosLibrary.meos.geogset_in(str);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geomset_in(String str) {
-		return MeosLibrary.meos.geomset_in(str);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String geoset_as_ewkt(Pointer set, int maxdd) {
-		return MeosLibrary.meos.geoset_as_ewkt(set, maxdd);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String geoset_as_text(Pointer set, int maxdd) {
-		return MeosLibrary.meos.geoset_as_text(set, maxdd);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String geoset_out(Pointer set, int maxdd) {
-		return MeosLibrary.meos.geoset_out(set, maxdd);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer intset_in(String str) {
 		return MeosLibrary.meos.intset_in(str);
 	}
@@ -3496,6 +4714,11 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
+	public static Pointer set_round(Pointer s, int maxdd) {
+		return MeosLibrary.meos.set_round(s, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
 	public static String span_as_hexwkb(Pointer s, byte variant) {
 		Runtime runtime = Runtime.getSystemRuntime();
 		Pointer size_out = Memory.allocateDirect(runtime, Long.BYTES);
@@ -3541,6 +4764,16 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static Pointer spanset_from_wkb(Pointer wkb, long size) {
 		return MeosLibrary.meos.spanset_from_wkb(wkb, size);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String spatialset_as_ewkt(Pointer set, int maxdd) {
+		return MeosLibrary.meos.spatialset_as_ewkt(set, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String spatialset_as_text(Pointer set, int maxdd) {
+		return MeosLibrary.meos.spatialset_as_text(set, maxdd);
 	}
 	
 	@SuppressWarnings("unused")
@@ -3614,11 +4847,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer geoset_make(Pointer values, int count) {
-		return MeosLibrary.meos.geoset_make(values, count);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer intset_make(Pointer values, int count) {
 		return MeosLibrary.meos.intset_make(values, count);
 	}
@@ -3644,8 +4872,8 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer spanset_make(Pointer spans, int count, boolean normalize, boolean order) {
-		return MeosLibrary.meos.spanset_make(spans, count, normalize, order);
+	public static Pointer spanset_make(Pointer spans, int count) {
+		return MeosLibrary.meos.spanset_make(spans, count);
 	}
 	
 	@SuppressWarnings("unused")
@@ -3666,161 +4894,156 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer bigint_to_set(long i) {
-		return MeosLibrary.meos.bigint_to_set(i);
+	public static Pointer bigint_set(long i) {
+		return MeosLibrary.meos.bigint_set(i);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer bigint_to_span(int i) {
-		return MeosLibrary.meos.bigint_to_span(i);
+	public static Pointer bigint_span(int i) {
+		return MeosLibrary.meos.bigint_span(i);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer bigint_to_spanset(int i) {
-		return MeosLibrary.meos.bigint_to_spanset(i);
+	public static Pointer bigint_spanset(int i) {
+		return MeosLibrary.meos.bigint_spanset(i);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer date_to_set(int d) {
-		return MeosLibrary.meos.date_to_set(d);
+	public static Pointer date_set(int d) {
+		return MeosLibrary.meos.date_set(d);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer date_to_span(int d) {
-		return MeosLibrary.meos.date_to_span(d);
+	public static Pointer date_span(int d) {
+		return MeosLibrary.meos.date_span(d);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer date_to_spanset(int d) {
-		return MeosLibrary.meos.date_to_spanset(d);
+	public static Pointer date_spanset(int d) {
+		return MeosLibrary.meos.date_spanset(d);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer dateset_to_tstzset(Pointer s) {
-		return MeosLibrary.meos.dateset_to_tstzset(s);
+	public static Pointer dateset_tstzset(Pointer s) {
+		return MeosLibrary.meos.dateset_tstzset(s);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer datespan_to_tstzspan(Pointer s) {
-		return MeosLibrary.meos.datespan_to_tstzspan(s);
+	public static Pointer datespan_tstzspan(Pointer s) {
+		return MeosLibrary.meos.datespan_tstzspan(s);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer datespanset_to_tstzspanset(Pointer ss) {
-		return MeosLibrary.meos.datespanset_to_tstzspanset(ss);
+	public static Pointer datespanset_tstzspanset(Pointer ss) {
+		return MeosLibrary.meos.datespanset_tstzspanset(ss);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer float_to_set(double d) {
-		return MeosLibrary.meos.float_to_set(d);
+	public static Pointer float_set(double d) {
+		return MeosLibrary.meos.float_set(d);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer float_to_span(double d) {
-		return MeosLibrary.meos.float_to_span(d);
+	public static Pointer float_span(double d) {
+		return MeosLibrary.meos.float_span(d);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer float_to_spanset(double d) {
-		return MeosLibrary.meos.float_to_spanset(d);
+	public static Pointer float_spanset(double d) {
+		return MeosLibrary.meos.float_spanset(d);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer floatset_to_intset(Pointer s) {
-		return MeosLibrary.meos.floatset_to_intset(s);
+	public static Pointer floatset_intset(Pointer s) {
+		return MeosLibrary.meos.floatset_intset(s);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer floatspan_to_intspan(Pointer s) {
-		return MeosLibrary.meos.floatspan_to_intspan(s);
+	public static Pointer floatspan_intspan(Pointer s) {
+		return MeosLibrary.meos.floatspan_intspan(s);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer floatspanset_to_intspanset(Pointer ss) {
-		return MeosLibrary.meos.floatspanset_to_intspanset(ss);
+	public static Pointer floatspanset_intspanset(Pointer ss) {
+		return MeosLibrary.meos.floatspanset_intspanset(ss);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer geo_to_set(Pointer gs) {
-		return MeosLibrary.meos.geo_to_set(gs);
+	public static Pointer int_set(int i) {
+		return MeosLibrary.meos.int_set(i);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer int_to_set(int i) {
-		return MeosLibrary.meos.int_to_set(i);
+	public static Pointer int_span(int i) {
+		return MeosLibrary.meos.int_span(i);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer int_to_span(int i) {
-		return MeosLibrary.meos.int_to_span(i);
+	public static Pointer int_spanset(int i) {
+		return MeosLibrary.meos.int_spanset(i);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer int_to_spanset(int i) {
-		return MeosLibrary.meos.int_to_spanset(i);
+	public static Pointer intset_floatset(Pointer s) {
+		return MeosLibrary.meos.intset_floatset(s);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer intset_to_floatset(Pointer s) {
-		return MeosLibrary.meos.intset_to_floatset(s);
+	public static Pointer intspan_floatspan(Pointer s) {
+		return MeosLibrary.meos.intspan_floatspan(s);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer intspan_to_floatspan(Pointer s) {
-		return MeosLibrary.meos.intspan_to_floatspan(s);
+	public static Pointer intspanset_floatspanset(Pointer ss) {
+		return MeosLibrary.meos.intspanset_floatspanset(ss);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer intspanset_to_floatspanset(Pointer ss) {
-		return MeosLibrary.meos.intspanset_to_floatspanset(ss);
+	public static Pointer set_spanset(Pointer s) {
+		return MeosLibrary.meos.set_spanset(s);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer set_to_spanset(Pointer s) {
-		return MeosLibrary.meos.set_to_spanset(s);
+	public static Pointer span_spanset(Pointer s) {
+		return MeosLibrary.meos.span_spanset(s);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer span_to_spanset(Pointer s) {
-		return MeosLibrary.meos.span_to_spanset(s);
+	public static Pointer text_set(Pointer txt) {
+		return MeosLibrary.meos.text_set(txt);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer text_to_set(Pointer txt) {
-		return MeosLibrary.meos.text_to_set(txt);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer timestamptz_to_set(OffsetDateTime t) {
+	public static Pointer timestamptz_set(OffsetDateTime t) {
 		var t_new = t.toEpochSecond();
-		return MeosLibrary.meos.timestamptz_to_set(t_new);
+		return MeosLibrary.meos.timestamptz_set(t_new);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer timestamptz_to_span(OffsetDateTime t) {
+	public static Pointer timestamptz_span(OffsetDateTime t) {
 		var t_new = t.toEpochSecond();
-		return MeosLibrary.meos.timestamptz_to_span(t_new);
+		return MeosLibrary.meos.timestamptz_span(t_new);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer timestamptz_to_spanset(OffsetDateTime t) {
+	public static Pointer timestamptz_spanset(OffsetDateTime t) {
 		var t_new = t.toEpochSecond();
-		return MeosLibrary.meos.timestamptz_to_spanset(t_new);
+		return MeosLibrary.meos.timestamptz_spanset(t_new);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tstzset_to_dateset(Pointer s) {
-		return MeosLibrary.meos.tstzset_to_dateset(s);
+	public static Pointer tstzset_dateset(Pointer s) {
+		return MeosLibrary.meos.tstzset_dateset(s);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tstzspan_to_datespan(Pointer s) {
-		return MeosLibrary.meos.tstzspan_to_datespan(s);
+	public static Pointer tstzspan_datespan(Pointer s) {
+		return MeosLibrary.meos.tstzspan_datespan(s);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tstzspanset_to_datespanset(Pointer ss) {
-		return MeosLibrary.meos.tstzspanset_to_datespanset(ss);
+	public static Pointer tstzspanset_datespanset(Pointer ss) {
+		return MeosLibrary.meos.tstzspanset_datespanset(ss);
 	}
 	
 	@SuppressWarnings("unused")
@@ -4009,36 +5232,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer geoset_end_value(Pointer s) {
-		return MeosLibrary.meos.geoset_end_value(s);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int geoset_srid(Pointer s) {
-		return MeosLibrary.meos.geoset_srid(s);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geoset_start_value(Pointer s) {
-		return MeosLibrary.meos.geoset_start_value(s);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geoset_value_n(Pointer s, int n) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.geoset_value_n(s, n, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geoset_values(Pointer s) {
-		return MeosLibrary.meos.geoset_values(s);
-	}
-	
-	@SuppressWarnings("unused")
 	public static int intset_end_value(Pointer s) {
 		return MeosLibrary.meos.intset_end_value(s);
 	}
@@ -4109,8 +5302,8 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer set_to_span(Pointer s) {
-		return MeosLibrary.meos.set_to_span(s);
+	public static Pointer set_span(Pointer s) {
+		return MeosLibrary.meos.set_span(s);
 	}
 	
 	@SuppressWarnings("unused")
@@ -4169,8 +5362,8 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer spanset_spans(Pointer ss) {
-		return MeosLibrary.meos.spanset_spans(ss);
+	public static Pointer spanset_spanarr(Pointer ss) {
+		return MeosLibrary.meos.spanset_spanarr(ss);
 	}
 	
 	@SuppressWarnings("unused")
@@ -4360,11 +5553,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer floatset_round(Pointer s, int maxdd) {
-		return MeosLibrary.meos.floatset_round(s, maxdd);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer floatset_shift_scale(Pointer s, double shift, double width, boolean hasshift, boolean haswidth) {
 		return MeosLibrary.meos.floatset_shift_scale(s, shift, width, hasshift, haswidth);
 	}
@@ -4377,6 +5565,16 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static Pointer floatspan_floor(Pointer s) {
 		return MeosLibrary.meos.floatspan_floor(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer floatspan_degrees(Pointer s, boolean normalize) {
+		return MeosLibrary.meos.floatspan_degrees(s, normalize);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer floatspan_radians(Pointer s) {
+		return MeosLibrary.meos.floatspan_radians(s);
 	}
 	
 	@SuppressWarnings("unused")
@@ -4400,6 +5598,16 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
+	public static Pointer floatspanset_degrees(Pointer ss, boolean normalize) {
+		return MeosLibrary.meos.floatspanset_degrees(ss, normalize);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer floatspanset_radians(Pointer ss) {
+		return MeosLibrary.meos.floatspanset_radians(ss);
+	}
+	
+	@SuppressWarnings("unused")
 	public static Pointer floatspanset_round(Pointer ss, int maxdd) {
 		return MeosLibrary.meos.floatspanset_round(ss, maxdd);
 	}
@@ -4407,36 +5615,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static Pointer floatspanset_shift_scale(Pointer ss, double shift, double width, boolean hasshift, boolean haswidth) {
 		return MeosLibrary.meos.floatspanset_shift_scale(ss, shift, width, hasshift, haswidth);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geoset_round(Pointer s, int maxdd) {
-		return MeosLibrary.meos.geoset_round(s, maxdd);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geoset_set_srid(Pointer s, int srid) {
-		return MeosLibrary.meos.geoset_set_srid(s, srid);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geoset_transform(Pointer s, int srid) {
-		return MeosLibrary.meos.geoset_transform(s, srid);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geoset_transform_pipeline(Pointer s, String pipelinestr, int srid, boolean is_forward) {
-		return MeosLibrary.meos.geoset_transform_pipeline(s, pipelinestr, srid, is_forward);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer point_transform(Pointer gs, int srid) {
-		return MeosLibrary.meos.point_transform(gs, srid);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer point_transform_pipeline(Pointer gs, String pipelinestr, int srid, boolean is_forward) {
-		return MeosLibrary.meos.point_transform_pipeline(gs, pipelinestr, srid, is_forward);
 	}
 	
 	@SuppressWarnings("unused")
@@ -4452,6 +5630,36 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static Pointer intspanset_shift_scale(Pointer ss, int shift, int width, boolean hasshift, boolean haswidth) {
 		return MeosLibrary.meos.intspanset_shift_scale(ss, shift, width, hasshift, haswidth);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer set_spans(Pointer s) {
+		return MeosLibrary.meos.set_spans(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer set_split_each_n_spans(Pointer s, int elem_count, Pointer count) {
+		return MeosLibrary.meos.set_split_each_n_spans(s, elem_count, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer set_split_n_spans(Pointer s, int span_count, Pointer count) {
+		return MeosLibrary.meos.set_split_n_spans(s, span_count, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spanset_spans(Pointer ss) {
+		return MeosLibrary.meos.spanset_spans(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spanset_split_each_n_spans(Pointer ss, int elem_count, Pointer count) {
+		return MeosLibrary.meos.spanset_split_each_n_spans(ss, elem_count, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spanset_split_n_spans(Pointer ss, int span_count, Pointer count) {
+		return MeosLibrary.meos.spanset_split_n_spans(ss, span_count, count);
 	}
 	
 	@SuppressWarnings("unused")
@@ -4744,11 +5952,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean contained_geo_set(Pointer gs, Pointer s) {
-		return MeosLibrary.meos.contained_geo_set(gs, s);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean contained_int_set(int i, Pointer s) {
 		return MeosLibrary.meos.contained_int_set(i, s);
 	}
@@ -4824,11 +6027,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static boolean contains_set_float(Pointer s, double d) {
 		return MeosLibrary.meos.contains_set_float(s, d);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean contains_set_geo(Pointer s, Pointer gs) {
-		return MeosLibrary.meos.contains_set_geo(s, gs);
 	}
 	
 	@SuppressWarnings("unused")
@@ -5729,11 +6927,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer intersection_geo_set(Pointer gs, Pointer s) {
-		return MeosLibrary.meos.intersection_geo_set(gs, s);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer intersection_int_set(int i, Pointer s) {
 		return MeosLibrary.meos.intersection_int_set(i, s);
 	}
@@ -5751,11 +6944,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static Pointer intersection_set_float(Pointer s, double d) {
 		return MeosLibrary.meos.intersection_set_float(s, d);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer intersection_set_geo(Pointer s, Pointer gs) {
-		return MeosLibrary.meos.intersection_set_geo(s, gs);
 	}
 	
 	@SuppressWarnings("unused")
@@ -5908,11 +7096,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer minus_geo_set(Pointer gs, Pointer s) {
-		return MeosLibrary.meos.minus_geo_set(gs, s);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer minus_int_set(int i, Pointer s) {
 		return MeosLibrary.meos.minus_int_set(i, s);
 	}
@@ -5940,11 +7123,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static Pointer minus_set_float(Pointer s, double d) {
 		return MeosLibrary.meos.minus_set_float(s, d);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer minus_set_geo(Pointer s, Pointer gs) {
-		return MeosLibrary.meos.minus_set_geo(s, gs);
 	}
 	
 	@SuppressWarnings("unused")
@@ -6109,11 +7287,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer union_geo_set(Pointer gs, Pointer s) {
-		return MeosLibrary.meos.union_geo_set(gs, s);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer union_int_set(int i, Pointer s) {
 		return MeosLibrary.meos.union_int_set(i, s);
 	}
@@ -6141,11 +7314,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static Pointer union_set_float(Pointer s, double d) {
 		return MeosLibrary.meos.union_set_float(s, d);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer union_set_geo(Pointer s, Pointer gs) {
-		return MeosLibrary.meos.union_set_geo(s, gs);
 	}
 	
 	@SuppressWarnings("unused")
@@ -6560,16 +7728,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer stbox_from_wkb(Pointer wkb, long size) {
-		return MeosLibrary.meos.stbox_from_wkb(wkb, size);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_from_hexwkb(String hexwkb) {
-		return MeosLibrary.meos.stbox_from_hexwkb(hexwkb);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer tbox_as_wkb(Pointer box, byte variant) {
 		Runtime runtime = Runtime.getSystemRuntime();
 		Pointer size_out = Memory.allocateDirect(runtime, Long.BYTES);
@@ -6582,28 +7740,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer stbox_as_wkb(Pointer box, byte variant) {
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer size_out = Memory.allocateDirect(runtime, Long.BYTES);
-		return MeosLibrary.meos.stbox_as_wkb(box, variant, size_out);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String stbox_as_hexwkb(Pointer box, byte variant, Pointer size) {
-		return MeosLibrary.meos.stbox_as_hexwkb(box, variant, size);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_in(String str) {
-		return MeosLibrary.meos.stbox_in(str);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String stbox_out(Pointer box, int maxdd) {
-		return MeosLibrary.meos.stbox_out(box, maxdd);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer float_tstzspan_to_tbox(double d, Pointer s) {
 		return MeosLibrary.meos.float_tstzspan_to_tbox(d, s);
 	}
@@ -6612,17 +7748,6 @@ public class functions {
 	public static Pointer float_timestamptz_to_tbox(double d, OffsetDateTime t) {
 		var t_new = t.toEpochSecond();
 		return MeosLibrary.meos.float_timestamptz_to_tbox(d, t_new);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geo_tstzspan_to_stbox(Pointer gs, Pointer s) {
-		return MeosLibrary.meos.geo_tstzspan_to_stbox(gs, s);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geo_timestamptz_to_stbox(Pointer gs, OffsetDateTime t) {
-		var t_new = t.toEpochSecond();
-		return MeosLibrary.meos.geo_timestamptz_to_stbox(gs, t_new);
 	}
 	
 	@SuppressWarnings("unused")
@@ -6648,16 +7773,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer stbox_copy(Pointer box) {
-		return MeosLibrary.meos.stbox_copy(box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_make(boolean hasx, boolean hasz, boolean geodetic, int srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, Pointer s) {
-		return MeosLibrary.meos.stbox_make(hasx, hasz, geodetic, srid, xmin, xmax, ymin, ymax, zmin, zmax, s);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer tbox_copy(Pointer box) {
 		return MeosLibrary.meos.tbox_copy(box);
 	}
@@ -6668,235 +7783,54 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer float_to_tbox(double d) {
-		return MeosLibrary.meos.float_to_tbox(d);
+	public static Pointer float_tbox(double d) {
+		return MeosLibrary.meos.float_tbox(d);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer geo_to_stbox(Pointer gs) {
-		return MeosLibrary.meos.geo_to_stbox(gs);
+	public static Pointer int_tbox(int i) {
+		return MeosLibrary.meos.int_tbox(i);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer int_to_tbox(int i) {
-		return MeosLibrary.meos.int_to_tbox(i);
+	public static Pointer set_tbox(Pointer s) {
+		return MeosLibrary.meos.set_tbox(s);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer set_to_tbox(Pointer s) {
-		return MeosLibrary.meos.set_to_tbox(s);
+	public static Pointer span_tbox(Pointer s) {
+		return MeosLibrary.meos.span_tbox(s);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer span_to_tbox(Pointer s) {
-		return MeosLibrary.meos.span_to_tbox(s);
+	public static Pointer spanset_tbox(Pointer ss) {
+		return MeosLibrary.meos.spanset_tbox(ss);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer spanset_to_tbox(Pointer ss) {
-		return MeosLibrary.meos.spanset_to_tbox(ss);
+	public static Pointer tbox_intspan(Pointer box) {
+		return MeosLibrary.meos.tbox_intspan(box);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer spatialset_to_stbox(Pointer s) {
-		return MeosLibrary.meos.spatialset_to_stbox(s);
+	public static Pointer tbox_floatspan(Pointer box) {
+		return MeosLibrary.meos.tbox_floatspan(box);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer stbox_to_gbox(Pointer box) {
-		return MeosLibrary.meos.stbox_to_gbox(box);
+	public static Pointer tbox_tstzspan(Pointer box) {
+		return MeosLibrary.meos.tbox_tstzspan(box);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer stbox_to_box3d(Pointer box) {
-		return MeosLibrary.meos.stbox_to_box3d(box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_to_geo(Pointer box) {
-		return MeosLibrary.meos.stbox_to_geo(box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_to_tstzspan(Pointer box) {
-		return MeosLibrary.meos.stbox_to_tstzspan(box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tbox_to_intspan(Pointer box) {
-		return MeosLibrary.meos.tbox_to_intspan(box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tbox_to_floatspan(Pointer box) {
-		return MeosLibrary.meos.tbox_to_floatspan(box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tbox_to_tstzspan(Pointer box) {
-		return MeosLibrary.meos.tbox_to_tstzspan(box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer timestamptz_to_stbox(OffsetDateTime t) {
+	public static Pointer timestamptz_tbox(OffsetDateTime t) {
 		var t_new = t.toEpochSecond();
-		return MeosLibrary.meos.timestamptz_to_stbox(t_new);
+		return MeosLibrary.meos.timestamptz_tbox(t_new);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer timestamptz_to_tbox(OffsetDateTime t) {
-		var t_new = t.toEpochSecond();
-		return MeosLibrary.meos.timestamptz_to_tbox(t_new);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tstzset_to_stbox(Pointer s) {
-		return MeosLibrary.meos.tstzset_to_stbox(s);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tstzspan_to_stbox(Pointer s) {
-		return MeosLibrary.meos.tstzspan_to_stbox(s);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tstzspanset_to_stbox(Pointer ss) {
-		return MeosLibrary.meos.tstzspanset_to_stbox(ss);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tnumber_to_tbox(Pointer temp) {
-		return MeosLibrary.meos.tnumber_to_tbox(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_to_stbox(Pointer temp) {
-		return MeosLibrary.meos.tpoint_to_stbox(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean stbox_hast(Pointer box) {
-		return MeosLibrary.meos.stbox_hast(box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean stbox_hasx(Pointer box) {
-		return MeosLibrary.meos.stbox_hasx(box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean stbox_hasz(Pointer box) {
-		return MeosLibrary.meos.stbox_hasz(box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean stbox_isgeodetic(Pointer box) {
-		return MeosLibrary.meos.stbox_isgeodetic(box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int stbox_srid(Pointer box) {
-		return MeosLibrary.meos.stbox_srid(box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_tmax(Pointer box) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.stbox_tmax(box, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_tmax_inc(Pointer box) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.stbox_tmax_inc(box, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_tmin(Pointer box) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.stbox_tmin(box, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_tmin_inc(Pointer box) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.stbox_tmin_inc(box, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_xmax(Pointer box) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.stbox_xmax(box, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_xmin(Pointer box) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.stbox_xmin(box, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_ymax(Pointer box) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.stbox_ymax(box, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_ymin(Pointer box) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.stbox_ymin(box, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_zmax(Pointer box) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.stbox_zmax(box, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_zmin(Pointer box) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.stbox_zmin(box, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
+	public static Pointer tnumber_tbox(Pointer temp) {
+		return MeosLibrary.meos.tnumber_tbox(temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -7030,51 +7964,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer stbox_expand_space(Pointer box, double d) {
-		return MeosLibrary.meos.stbox_expand_space(box, d);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_expand_time(Pointer box, Pointer interv) {
-		return MeosLibrary.meos.stbox_expand_time(box, interv);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_get_space(Pointer box) {
-		return MeosLibrary.meos.stbox_get_space(box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_quad_split(Pointer box, Pointer count) {
-		return MeosLibrary.meos.stbox_quad_split(box, count);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_round(Pointer box, int maxdd) {
-		return MeosLibrary.meos.stbox_round(box, maxdd);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_set_srid(Pointer box, int srid) {
-		return MeosLibrary.meos.stbox_set_srid(box, srid);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_shift_scale_time(Pointer box, Pointer shift, Pointer duration) {
-		return MeosLibrary.meos.stbox_shift_scale_time(box, shift, duration);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_transform(Pointer box, int srid) {
-		return MeosLibrary.meos.stbox_transform(box, srid);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_transform_pipeline(Pointer box, String pipelinestr, int srid, boolean is_forward) {
-		return MeosLibrary.meos.stbox_transform_pipeline(box, pipelinestr, srid, is_forward);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer tbox_expand_time(Pointer box, Pointer interv) {
 		return MeosLibrary.meos.tbox_expand_time(box, interv);
 	}
@@ -7120,21 +8009,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer union_stbox_stbox(Pointer box1, Pointer box2, boolean strict) {
-		return MeosLibrary.meos.union_stbox_stbox(box1, box2, strict);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer intersection_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.intersection_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean adjacent_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.adjacent_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean adjacent_tbox_tbox(Pointer box1, Pointer box2) {
 		return MeosLibrary.meos.adjacent_tbox_tbox(box1, box2);
 	}
@@ -7142,16 +8016,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static boolean contained_tbox_tbox(Pointer box1, Pointer box2) {
 		return MeosLibrary.meos.contained_tbox_tbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean contained_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.contained_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean contains_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.contains_stbox_stbox(box1, box2);
 	}
 	
 	@SuppressWarnings("unused")
@@ -7165,18 +8029,8 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean overlaps_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.overlaps_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean same_tbox_tbox(Pointer box1, Pointer box2) {
 		return MeosLibrary.meos.same_tbox_tbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean same_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.same_stbox_stbox(box1, box2);
 	}
 	
 	@SuppressWarnings("unused")
@@ -7220,86 +8074,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean left_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.left_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overleft_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.overleft_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean right_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.right_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overright_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.overright_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean below_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.below_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overbelow_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.overbelow_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean above_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.above_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overabove_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.overabove_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean front_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.front_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overfront_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.overfront_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean back_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.back_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overback_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.overback_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean before_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.before_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overbefore_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.overbefore_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean after_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.after_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overafter_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.overafter_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean tbox_eq(Pointer box1, Pointer box2) {
 		return MeosLibrary.meos.tbox_eq(box1, box2);
 	}
@@ -7335,41 +8109,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean stbox_eq(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.stbox_eq(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean stbox_ne(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.stbox_ne(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int stbox_cmp(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.stbox_cmp(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean stbox_lt(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.stbox_lt(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean stbox_le(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.stbox_le(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean stbox_ge(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.stbox_ge(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean stbox_gt(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.stbox_gt(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer tbool_in(String str) {
 		return MeosLibrary.meos.tbool_in(str);
 	}
@@ -7390,16 +8129,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tgeompoint_in(String str) {
-		return MeosLibrary.meos.tgeompoint_in(str);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tgeogpoint_in(String str) {
-		return MeosLibrary.meos.tgeogpoint_in(str);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer tbool_from_mfjson(String str) {
 		return MeosLibrary.meos.tbool_from_mfjson(str);
 	}
@@ -7417,16 +8146,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static Pointer ttext_from_mfjson(String str) {
 		return MeosLibrary.meos.ttext_from_mfjson(str);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tgeompoint_from_mfjson(String str) {
-		return MeosLibrary.meos.tgeompoint_from_mfjson(str);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tgeogpoint_from_mfjson(String str) {
-		return MeosLibrary.meos.tgeogpoint_from_mfjson(str);
 	}
 	
 	@SuppressWarnings("unused")
@@ -7457,21 +8176,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static String ttext_out(Pointer temp) {
 		return MeosLibrary.meos.ttext_out(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String tpoint_out(Pointer temp, int maxdd) {
-		return MeosLibrary.meos.tpoint_out(temp, maxdd);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String tpoint_as_text(Pointer temp, int maxdd) {
-		return MeosLibrary.meos.tpoint_as_text(temp, maxdd);
-	}
-	
-	@SuppressWarnings("unused")
-	public static String tpoint_as_ewkt(Pointer temp, int maxdd) {
-		return MeosLibrary.meos.tpoint_as_ewkt(temp, maxdd);
 	}
 	
 	@SuppressWarnings("unused")
@@ -7577,32 +8281,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tpoint_from_base_temp(Pointer gs, Pointer temp) {
-		return MeosLibrary.meos.tpoint_from_base_temp(gs, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpointinst_make(Pointer gs, OffsetDateTime t) {
-		var t_new = t.toEpochSecond();
-		return MeosLibrary.meos.tpointinst_make(gs, t_new);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpointseq_from_base_tstzspan(Pointer gs, Pointer s, int interp) {
-		return MeosLibrary.meos.tpointseq_from_base_tstzspan(gs, s, interp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpointseq_from_base_tstzset(Pointer gs, Pointer s) {
-		return MeosLibrary.meos.tpointseq_from_base_tstzset(gs, s);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpointseqset_from_base_tstzspanset(Pointer gs, Pointer ss, int interp) {
-		return MeosLibrary.meos.tpointseqset_from_base_tstzspanset(gs, ss, interp);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer tsequence_make(Pointer instants, int count, boolean lower_inc, boolean upper_inc, int interp, boolean normalize) {
 		return MeosLibrary.meos.tsequence_make(instants, count, lower_inc, upper_inc, interp, normalize);
 	}
@@ -7644,23 +8322,28 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer temporal_to_tstzspan(Pointer temp) {
-		return MeosLibrary.meos.temporal_to_tstzspan(temp);
+	public static Pointer temporal_tstzspan(Pointer temp) {
+		return MeosLibrary.meos.temporal_tstzspan(temp);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tfloat_to_tint(Pointer temp) {
-		return MeosLibrary.meos.tfloat_to_tint(temp);
+	public static Pointer tbool_tint(Pointer temp) {
+		return MeosLibrary.meos.tbool_tint(temp);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tint_to_tfloat(Pointer temp) {
-		return MeosLibrary.meos.tint_to_tfloat(temp);
+	public static Pointer tfloat_tint(Pointer temp) {
+		return MeosLibrary.meos.tfloat_tint(temp);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tnumber_to_span(Pointer temp) {
-		return MeosLibrary.meos.tnumber_to_span(temp);
+	public static Pointer tint_tfloat(Pointer temp) {
+		return MeosLibrary.meos.tint_tfloat(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumber_span(Pointer temp) {
+		return MeosLibrary.meos.tnumber_span(temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -7777,12 +8460,12 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static int temporal_lower_inc(Pointer temp) {
+	public static boolean temporal_lower_inc(Pointer temp) {
 		return MeosLibrary.meos.temporal_lower_inc(temp);
 	}
 	
 	@SuppressWarnings("unused")
-	public static int temporal_upper_inc(Pointer temp) {
+	public static boolean temporal_upper_inc(Pointer temp) {
 		return MeosLibrary.meos.temporal_upper_inc(temp);
 	}
 	
@@ -7931,37 +8614,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tpoint_end_value(Pointer temp) {
-		return MeosLibrary.meos.tpoint_end_value(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_start_value(Pointer temp) {
-		return MeosLibrary.meos.tpoint_start_value(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean tpoint_value_at_timestamptz(Pointer temp, OffsetDateTime t, boolean strict, Pointer value) {
-		var t_new = t.toEpochSecond();
-		return MeosLibrary.meos.tpoint_value_at_timestamptz(temp, t_new, strict, value);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_value_n(Pointer temp, int n) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.tpoint_value_n(temp, n, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_values(Pointer temp, Pointer count) {
-		return MeosLibrary.meos.tpoint_values(temp, count);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer ttext_end_value(Pointer temp) {
 		return MeosLibrary.meos.ttext_end_value(temp);
 	}
@@ -8003,8 +8655,33 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
+	public static int spheroid_init_from_srid(int srid, Pointer s) {
+		return MeosLibrary.meos.spheroid_init_from_srid(srid, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean ensure_srid_is_latlong(int srid) {
+		return MeosLibrary.meos.ensure_srid_is_latlong(srid);
+	}
+	
+	@SuppressWarnings("unused")
 	public static double float_degrees(double value, boolean normalize) {
 		return MeosLibrary.meos.float_degrees(value, normalize);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean srid_is_latlong(int srid) {
+		return MeosLibrary.meos.srid_is_latlong(srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temparr_round(Pointer temp, int count, int maxdd) {
+		return MeosLibrary.meos.temparr_round(temp, count, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_round(Pointer temp, int maxdd) {
+		return MeosLibrary.meos.temporal_round(temp, maxdd);
 	}
 	
 	@SuppressWarnings("unused")
@@ -8013,8 +8690,8 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer temporal_set_interp(Pointer temp, int interp) {
-		return MeosLibrary.meos.temporal_set_interp(temp, interp);
+	public static Pointer temporal_set_interp(Pointer temp, String interp_str) {
+		return MeosLibrary.meos.temporal_set_interp(temp, interp_str);
 	}
 	
 	@SuppressWarnings("unused")
@@ -8063,11 +8740,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tfloat_round(Pointer temp, int maxdd) {
-		return MeosLibrary.meos.tfloat_round(temp, maxdd);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer tfloat_scale_value(Pointer temp, double width) {
 		return MeosLibrary.meos.tfloat_scale_value(temp, width);
 	}
@@ -8080,11 +8752,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static Pointer tfloat_shift_value(Pointer temp, double shift) {
 		return MeosLibrary.meos.tfloat_shift_value(temp, shift);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tfloatarr_round(Pointer temp, int count, int maxdd) {
-		return MeosLibrary.meos.tfloatarr_round(temp, count, maxdd);
 	}
 	
 	@SuppressWarnings("unused")
@@ -8103,38 +8770,8 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tpoint_round(Pointer temp, int maxdd) {
-		return MeosLibrary.meos.tpoint_round(temp, maxdd);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_transform(Pointer temp, int srid) {
-		return MeosLibrary.meos.tpoint_transform(temp, srid);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_transform_pipeline(Pointer temp, String pipelinestr, int srid, boolean is_forward) {
-		return MeosLibrary.meos.tpoint_transform_pipeline(temp, pipelinestr, srid, is_forward);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_transform_pj(Pointer temp, int srid, Pointer pj) {
-		return MeosLibrary.meos.tpoint_transform_pj(temp, srid, pj);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer lwproj_transform(int srid_from, int srid_to) {
-		return MeosLibrary.meos.lwproj_transform(srid_from, srid_to);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpointarr_round(Pointer temp, int count, int maxdd) {
-		return MeosLibrary.meos.tpointarr_round(temp, count, maxdd);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer temporal_append_tinstant(Pointer temp, Pointer inst, double maxdist, Pointer maxt, boolean expand) {
-		return MeosLibrary.meos.temporal_append_tinstant(temp, inst, maxdist, maxt, expand);
+	public static Pointer temporal_append_tinstant(Pointer temp, Pointer inst, int interp, double maxdist, Pointer maxt, boolean expand) {
+		return MeosLibrary.meos.temporal_append_tinstant(temp, inst, interp, maxdist, maxt, expand);
 	}
 	
 	@SuppressWarnings("unused")
@@ -8316,36 +8953,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tpoint_at_geom_time(Pointer temp, Pointer gs, Pointer zspan, Pointer period) {
-		return MeosLibrary.meos.tpoint_at_geom_time(temp, gs, zspan, period);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_at_stbox(Pointer temp, Pointer box, boolean border_inc) {
-		return MeosLibrary.meos.tpoint_at_stbox(temp, box, border_inc);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_at_value(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.tpoint_at_value(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_minus_geom_time(Pointer temp, Pointer gs, Pointer zspan, Pointer period) {
-		return MeosLibrary.meos.tpoint_minus_geom_time(temp, gs, zspan, period);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_minus_stbox(Pointer temp, Pointer box, boolean border_inc) {
-		return MeosLibrary.meos.tpoint_minus_stbox(temp, box, border_inc);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_minus_value(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.tpoint_minus_value(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer ttext_at_value(Pointer temp, Pointer txt) {
 		return MeosLibrary.meos.ttext_at_value(temp, txt);
 	}
@@ -8406,11 +9013,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static int always_eq_point_tpoint(Pointer gs, Pointer temp) {
-		return MeosLibrary.meos.always_eq_point_tpoint(gs, temp);
-	}
-	
-	@SuppressWarnings("unused")
 	public static int always_eq_tbool_bool(Pointer temp, boolean b) {
 		return MeosLibrary.meos.always_eq_tbool_bool(temp, b);
 	}
@@ -8436,16 +9038,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static int always_eq_tpoint_point(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.always_eq_tpoint_point(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int always_eq_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.always_eq_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static int always_eq_ttext_text(Pointer temp, Pointer txt) {
 		return MeosLibrary.meos.always_eq_ttext_text(temp, txt);
 	}
@@ -8463,11 +9055,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static int always_ne_int_tint(int i, Pointer temp) {
 		return MeosLibrary.meos.always_ne_int_tint(i, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int always_ne_point_tpoint(Pointer gs, Pointer temp) {
-		return MeosLibrary.meos.always_ne_point_tpoint(gs, temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -8493,16 +9080,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static int always_ne_tint_int(Pointer temp, int i) {
 		return MeosLibrary.meos.always_ne_tint_int(temp, i);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int always_ne_tpoint_point(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.always_ne_tpoint_point(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int always_ne_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.always_ne_tpoint_tpoint(temp1, temp2);
 	}
 	
 	@SuppressWarnings("unused")
@@ -8666,11 +9243,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static int ever_eq_point_tpoint(Pointer gs, Pointer temp) {
-		return MeosLibrary.meos.ever_eq_point_tpoint(gs, temp);
-	}
-	
-	@SuppressWarnings("unused")
 	public static int ever_eq_tbool_bool(Pointer temp, boolean b) {
 		return MeosLibrary.meos.ever_eq_tbool_bool(temp, b);
 	}
@@ -8693,16 +9265,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static int ever_eq_tint_int(Pointer temp, int i) {
 		return MeosLibrary.meos.ever_eq_tint_int(temp, i);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int ever_eq_tpoint_point(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.ever_eq_tpoint_point(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int ever_eq_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.ever_eq_tpoint_tpoint(temp1, temp2);
 	}
 	
 	@SuppressWarnings("unused")
@@ -8866,11 +9428,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static int ever_ne_point_tpoint(Pointer gs, Pointer temp) {
-		return MeosLibrary.meos.ever_ne_point_tpoint(gs, temp);
-	}
-	
-	@SuppressWarnings("unused")
 	public static int ever_ne_tbool_bool(Pointer temp, boolean b) {
 		return MeosLibrary.meos.ever_ne_tbool_bool(temp, b);
 	}
@@ -8896,16 +9453,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static int ever_ne_tpoint_point(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.ever_ne_tpoint_point(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int ever_ne_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.ever_ne_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static int ever_ne_ttext_text(Pointer temp, Pointer txt) {
 		return MeosLibrary.meos.ever_ne_ttext_text(temp, txt);
 	}
@@ -8926,11 +9473,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer teq_point_tpoint(Pointer gs, Pointer temp) {
-		return MeosLibrary.meos.teq_point_tpoint(gs, temp);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer teq_tbool_bool(Pointer temp, boolean b) {
 		return MeosLibrary.meos.teq_tbool_bool(temp, b);
 	}
@@ -8948,11 +9490,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static Pointer teq_tfloat_float(Pointer temp, double d) {
 		return MeosLibrary.meos.teq_tfloat_float(temp, d);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer teq_tpoint_point(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.teq_tpoint_point(temp, gs);
 	}
 	
 	@SuppressWarnings("unused")
@@ -9121,11 +9658,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tne_point_tpoint(Pointer gs, Pointer temp) {
-		return MeosLibrary.meos.tne_point_tpoint(gs, temp);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer tne_tbool_bool(Pointer temp, boolean b) {
 		return MeosLibrary.meos.tne_tbool_bool(temp, b);
 	}
@@ -9146,11 +9678,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tne_tpoint_point(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.tne_tpoint_point(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer tne_tint_int(Pointer temp, int i) {
 		return MeosLibrary.meos.tne_tint_int(temp, i);
 	}
@@ -9161,13 +9688,38 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean adjacent_numspan_tnumber(Pointer s, Pointer temp) {
-		return MeosLibrary.meos.adjacent_numspan_tnumber(s, temp);
+	public static Pointer temporal_spans(Pointer temp, Pointer count) {
+		return MeosLibrary.meos.temporal_spans(temp, count);
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean adjacent_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.adjacent_stbox_tpoint(box, temp);
+	public static Pointer temporal_split_each_n_spans(Pointer temp, int elem_count, Pointer count) {
+		return MeosLibrary.meos.temporal_split_each_n_spans(temp, elem_count, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_split_n_spans(Pointer temp, int span_count, Pointer count) {
+		return MeosLibrary.meos.temporal_split_n_spans(temp, span_count, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumber_tboxes(Pointer temp, Pointer count) {
+		return MeosLibrary.meos.tnumber_tboxes(temp, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumber_split_each_n_tboxes(Pointer temp, int elem_count, Pointer count) {
+		return MeosLibrary.meos.tnumber_split_each_n_tboxes(temp, elem_count, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumber_split_n_tboxes(Pointer temp, int box_count, Pointer count) {
+		return MeosLibrary.meos.tnumber_split_n_tboxes(temp, box_count, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean adjacent_numspan_tnumber(Pointer s, Pointer temp) {
+		return MeosLibrary.meos.adjacent_numspan_tnumber(s, temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -9201,16 +9753,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean adjacent_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.adjacent_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean adjacent_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.adjacent_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean adjacent_tstzspan_temporal(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.adjacent_tstzspan_temporal(s, temp);
 	}
@@ -9218,11 +9760,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static boolean contained_numspan_tnumber(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.contained_numspan_tnumber(s, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean contained_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.contained_stbox_tpoint(box, temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -9256,16 +9793,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean contained_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.contained_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean contained_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.contained_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean contained_tstzspan_temporal(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.contained_tstzspan_temporal(s, temp);
 	}
@@ -9273,11 +9800,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static boolean contains_numspan_tnumber(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.contains_numspan_tnumber(s, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean contains_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.contains_stbox_tpoint(box, temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -9311,16 +9833,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean contains_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.contains_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean contains_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.contains_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean contains_tstzspan_temporal(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.contains_tstzspan_temporal(s, temp);
 	}
@@ -9328,11 +9840,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static boolean overlaps_numspan_tnumber(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.overlaps_numspan_tnumber(s, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overlaps_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.overlaps_stbox_tpoint(box, temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -9366,16 +9873,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean overlaps_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.overlaps_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overlaps_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.overlaps_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean overlaps_tstzspan_temporal(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.overlaps_tstzspan_temporal(s, temp);
 	}
@@ -9383,11 +9880,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static boolean same_numspan_tnumber(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.same_numspan_tnumber(s, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean same_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.same_stbox_tpoint(box, temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -9421,38 +9913,8 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean same_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.same_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean same_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.same_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean same_tstzspan_temporal(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.same_tstzspan_temporal(s, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean above_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.above_stbox_tpoint(box, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean above_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.above_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean above_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.above_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean after_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.after_stbox_tpoint(box, temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -9481,38 +9943,8 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean after_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.after_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean after_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.after_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean after_tstzspan_temporal(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.after_tstzspan_temporal(s, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean back_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.back_stbox_tpoint(box, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean back_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.back_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean back_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.back_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean before_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.before_stbox_tpoint(box, temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -9541,53 +9973,8 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean before_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.before_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean before_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.before_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean before_tstzspan_temporal(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.before_tstzspan_temporal(s, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean below_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.below_stbox_tpoint(box, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean below_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.below_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean below_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.below_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean front_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.front_stbox_tpoint(box, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean front_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.front_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean front_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.front_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean left_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.left_stbox_tpoint(box, temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -9616,36 +10003,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean left_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.left_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean left_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.left_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overabove_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.overabove_stbox_tpoint(box, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overabove_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.overabove_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overabove_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.overabove_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overafter_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.overafter_stbox_tpoint(box, temp);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean overafter_tbox_tnumber(Pointer box, Pointer temp) {
 		return MeosLibrary.meos.overafter_tbox_tnumber(box, temp);
 	}
@@ -9671,38 +10028,8 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean overafter_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.overafter_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overafter_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.overafter_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean overafter_tstzspan_temporal(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.overafter_tstzspan_temporal(s, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overback_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.overback_stbox_tpoint(box, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overback_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.overback_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overback_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.overback_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overbefore_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.overbefore_stbox_tpoint(box, temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -9731,58 +10058,13 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean overbefore_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.overbefore_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overbefore_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.overbefore_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean overbefore_tstzspan_temporal(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.overbefore_tstzspan_temporal(s, temp);
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean overbelow_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.overbelow_stbox_tpoint(box, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overbelow_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.overbelow_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overbelow_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.overbelow_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overfront_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.overfront_stbox_tpoint(box, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overfront_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.overfront_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overfront_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.overfront_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean overleft_numspan_tnumber(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.overleft_numspan_tnumber(s, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overleft_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.overleft_stbox_tpoint(box, temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -9806,23 +10088,8 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean overleft_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.overleft_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overleft_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.overleft_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean overright_numspan_tnumber(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.overright_numspan_tnumber(s, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overright_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.overright_stbox_tpoint(box, temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -9846,23 +10113,8 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static boolean overright_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.overright_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean overright_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.overright_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static boolean right_numspan_tnumber(Pointer s, Pointer temp) {
 		return MeosLibrary.meos.right_numspan_tnumber(s, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean right_stbox_tpoint(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.right_stbox_tpoint(box, temp);
 	}
 	
 	@SuppressWarnings("unused")
@@ -9883,16 +10135,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static boolean right_tnumber_tnumber(Pointer temp1, Pointer temp2) {
 		return MeosLibrary.meos.right_tnumber_tnumber(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean right_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.right_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean right_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.right_tpoint_tpoint(temp1, temp2);
 	}
 	
 	@SuppressWarnings("unused")
@@ -10041,6 +10283,21 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
+	public static Pointer tfloat_exp(Pointer temp) {
+		return MeosLibrary.meos.tfloat_exp(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloat_ln(Pointer temp) {
+		return MeosLibrary.meos.tfloat_ln(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloat_log10(Pointer temp) {
+		return MeosLibrary.meos.tfloat_log10(temp);
+	}
+	
+	@SuppressWarnings("unused")
 	public static Pointer tnumber_abs(Pointer temp) {
 		return MeosLibrary.meos.tnumber_abs(temp);
 	}
@@ -10101,26 +10358,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer distance_tpoint_point(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.distance_tpoint_point(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer distance_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.distance_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static double nad_stbox_geo(Pointer box, Pointer gs) {
-		return MeosLibrary.meos.nad_stbox_geo(box, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static double nad_stbox_stbox(Pointer box1, Pointer box2) {
-		return MeosLibrary.meos.nad_stbox_stbox(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
 	public static int nad_tint_int(Pointer temp, int i) {
 		return MeosLibrary.meos.nad_tint_int(temp, i);
 	}
@@ -10158,311 +10395,6 @@ public class functions {
 	@SuppressWarnings("unused")
 	public static double nad_tboxfloat_tboxfloat(Pointer box1, Pointer box2) {
 		return MeosLibrary.meos.nad_tboxfloat_tboxfloat(box1, box2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static double nad_tpoint_geo(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.nad_tpoint_geo(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static double nad_tpoint_stbox(Pointer temp, Pointer box) {
-		return MeosLibrary.meos.nad_tpoint_stbox(temp, box);
-	}
-	
-	@SuppressWarnings("unused")
-	public static double nad_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.nad_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer nai_tpoint_geo(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.nai_tpoint_geo(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer nai_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.nai_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer shortestline_tpoint_geo(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.shortestline_tpoint_geo(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer shortestline_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.shortestline_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer bearing_point_point(Pointer gs1, Pointer gs2) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.bearing_point_point(gs1, gs2, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer bearing_tpoint_point(Pointer temp, Pointer gs, boolean invert) {
-		return MeosLibrary.meos.bearing_tpoint_point(temp, gs, invert);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer bearing_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.bearing_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_angular_difference(Pointer temp) {
-		return MeosLibrary.meos.tpoint_angular_difference(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_azimuth(Pointer temp) {
-		return MeosLibrary.meos.tpoint_azimuth(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_convex_hull(Pointer temp) {
-		return MeosLibrary.meos.tpoint_convex_hull(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_cumulative_length(Pointer temp) {
-		return MeosLibrary.meos.tpoint_cumulative_length(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_direction(Pointer temp) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.tpoint_direction(temp, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_get_x(Pointer temp) {
-		return MeosLibrary.meos.tpoint_get_x(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_get_y(Pointer temp) {
-		return MeosLibrary.meos.tpoint_get_y(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_get_z(Pointer temp) {
-		return MeosLibrary.meos.tpoint_get_z(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean tpoint_is_simple(Pointer temp) {
-		return MeosLibrary.meos.tpoint_is_simple(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static double tpoint_length(Pointer temp) {
-		return MeosLibrary.meos.tpoint_length(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_speed(Pointer temp) {
-		return MeosLibrary.meos.tpoint_speed(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int tpoint_srid(Pointer temp) {
-		return MeosLibrary.meos.tpoint_srid(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_stboxes(Pointer temp, Pointer count) {
-		return MeosLibrary.meos.tpoint_stboxes(temp, count);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_trajectory(Pointer temp) {
-		return MeosLibrary.meos.tpoint_trajectory(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_twcentroid(Pointer temp) {
-		return MeosLibrary.meos.tpoint_twcentroid(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geo_expand_space(Pointer gs, double d) {
-		return MeosLibrary.meos.geo_expand_space(gs, d);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer geomeas_to_tpoint(Pointer gs) {
-		return MeosLibrary.meos.geomeas_to_tpoint(gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tgeogpoint_to_tgeompoint(Pointer temp) {
-		return MeosLibrary.meos.tgeogpoint_to_tgeompoint(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tgeompoint_to_tgeogpoint(Pointer temp) {
-		return MeosLibrary.meos.tgeompoint_to_tgeogpoint(temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean tpoint_AsMVTGeom(Pointer temp, Pointer bounds, int extent, int buffer, boolean clip_geom, Pointer gsarr, Pointer timesarr, Pointer count) {
-		return MeosLibrary.meos.tpoint_AsMVTGeom(temp, bounds, extent, buffer, clip_geom, gsarr, timesarr, count);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_expand_space(Pointer temp, double d) {
-		return MeosLibrary.meos.tpoint_expand_space(temp, d);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_make_simple(Pointer temp, Pointer count) {
-		return MeosLibrary.meos.tpoint_make_simple(temp, count);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_set_srid(Pointer temp, int srid) {
-		return MeosLibrary.meos.tpoint_set_srid(temp, srid);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_tfloat_to_geomeas(Pointer tpoint, Pointer measure, boolean segmentize) {
-		boolean out;
-		Runtime runtime = Runtime.getSystemRuntime();
-		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
-		out = MeosLibrary.meos.tpoint_tfloat_to_geomeas(tpoint, measure, segmentize, result);
-		Pointer new_result = result.getPointer(0);
-		return out ? new_result : null ;
-	}
-	
-	@SuppressWarnings("unused")
-	public static int acontains_geo_tpoint(Pointer gs, Pointer temp) {
-		return MeosLibrary.meos.acontains_geo_tpoint(gs, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int adisjoint_tpoint_geo(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.adisjoint_tpoint_geo(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int adisjoint_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.adisjoint_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int adwithin_tpoint_geo(Pointer temp, Pointer gs, double dist) {
-		return MeosLibrary.meos.adwithin_tpoint_geo(temp, gs, dist);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int adwithin_tpoint_tpoint(Pointer temp1, Pointer temp2, double dist) {
-		return MeosLibrary.meos.adwithin_tpoint_tpoint(temp1, temp2, dist);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int aintersects_tpoint_geo(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.aintersects_tpoint_geo(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int aintersects_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.aintersects_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int atouches_tpoint_geo(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.atouches_tpoint_geo(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int econtains_geo_tpoint(Pointer gs, Pointer temp) {
-		return MeosLibrary.meos.econtains_geo_tpoint(gs, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int edisjoint_tpoint_geo(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.edisjoint_tpoint_geo(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int edisjoint_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.edisjoint_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int edwithin_tpoint_geo(Pointer temp, Pointer gs, double dist) {
-		return MeosLibrary.meos.edwithin_tpoint_geo(temp, gs, dist);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int edwithin_tpoint_tpoint(Pointer temp1, Pointer temp2, double dist) {
-		return MeosLibrary.meos.edwithin_tpoint_tpoint(temp1, temp2, dist);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int eintersects_tpoint_geo(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.eintersects_tpoint_geo(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int eintersects_tpoint_tpoint(Pointer temp1, Pointer temp2) {
-		return MeosLibrary.meos.eintersects_tpoint_tpoint(temp1, temp2);
-	}
-	
-	@SuppressWarnings("unused")
-	public static int etouches_tpoint_geo(Pointer temp, Pointer gs) {
-		return MeosLibrary.meos.etouches_tpoint_geo(temp, gs);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tcontains_geo_tpoint(Pointer gs, Pointer temp, boolean restr, boolean atvalue) {
-		return MeosLibrary.meos.tcontains_geo_tpoint(gs, temp, restr, atvalue);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tdisjoint_tpoint_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue) {
-		return MeosLibrary.meos.tdisjoint_tpoint_geo(temp, gs, restr, atvalue);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tdisjoint_tpoint_tpoint (Pointer temp1, Pointer temp2, boolean restr, boolean atvalue) {
-		return MeosLibrary.meos.tdisjoint_tpoint_tpoint(temp1, temp2, restr, atvalue);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tdwithin_tpoint_geo(Pointer temp, Pointer gs, double dist, boolean restr, boolean atvalue) {
-		return MeosLibrary.meos.tdwithin_tpoint_geo(temp, gs, dist, restr, atvalue);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tdwithin_tpoint_tpoint(Pointer temp1, Pointer temp2, double dist, boolean restr, boolean atvalue) {
-		return MeosLibrary.meos.tdwithin_tpoint_tpoint(temp1, temp2, dist, restr, atvalue);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tintersects_tpoint_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue) {
-		return MeosLibrary.meos.tintersects_tpoint_geo(temp, gs, restr, atvalue);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tintersects_tpoint_tpoint (Pointer temp1, Pointer temp2, boolean restr, boolean atvalue) {
-		return MeosLibrary.meos.tintersects_tpoint_tpoint(temp1, temp2, restr, atvalue);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer ttouches_tpoint_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue) {
-		return MeosLibrary.meos.ttouches_tpoint_geo(temp, gs, restr, atvalue);
 	}
 	
 	@SuppressWarnings("unused")
@@ -10577,21 +10509,6 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tpoint_extent_transfn(Pointer box, Pointer temp) {
-		return MeosLibrary.meos.tpoint_extent_transfn(box, temp);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_tcentroid_finalfn(Pointer state) {
-		return MeosLibrary.meos.tpoint_tcentroid_finalfn(state);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_tcentroid_transfn(Pointer state, Pointer temp) {
-		return MeosLibrary.meos.tpoint_tcentroid_transfn(state, temp);
-	}
-	
-	@SuppressWarnings("unused")
 	public static Pointer tstzset_tcount_transfn(Pointer state, Pointer s) {
 		return MeosLibrary.meos.tstzset_tcount_transfn(state, s);
 	}
@@ -10674,115 +10591,5109 @@ public class functions {
 	}
 	
 	@SuppressWarnings("unused")
-	public static double float_bucket(double value, double size, double origin) {
-		return MeosLibrary.meos.float_bucket(value, size, origin);
+	public static long bigint_get_bin(long value, long vsize, long vorigin) {
+		return MeosLibrary.meos.bigint_get_bin(value, vsize, vorigin);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer floatspan_bucket_list(Pointer bounds, double size, double origin, Pointer count) {
-		return MeosLibrary.meos.floatspan_bucket_list(bounds, size, origin, count);
+	public static Pointer bigintspan_bins(Pointer s, long vsize, long vorigin, Pointer count) {
+		return MeosLibrary.meos.bigintspan_bins(s, vsize, vorigin, count);
 	}
 	
 	@SuppressWarnings("unused")
-	public static int int_bucket(int value, int size, int origin) {
-		return MeosLibrary.meos.int_bucket(value, size, origin);
+	public static Pointer bigintspanset_bins(Pointer ss, long vsize, long vorigin, Pointer count) {
+		return MeosLibrary.meos.bigintspanset_bins(ss, vsize, vorigin, count);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer intspan_bucket_list(Pointer bounds, int size, int origin, Pointer count) {
-		return MeosLibrary.meos.intspan_bucket_list(bounds, size, origin, count);
+	public static Pointer bigintspanset_value_spans(Pointer ss, long vsize, long vorigin, Pointer count) {
+		return MeosLibrary.meos.bigintspanset_value_spans(ss, vsize, vorigin, count);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer stbox_tile(Pointer point, OffsetDateTime t, double xsize, double ysize, double zsize, Pointer duration, Pointer sorigin, OffsetDateTime torigin, boolean hast) {
+	public static int date_get_bin(int d, Pointer duration, int torigin) {
+		return MeosLibrary.meos.date_get_bin(d, duration, torigin);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer datespan_bins(Pointer s, Pointer duration, int torigin, Pointer count) {
+		return MeosLibrary.meos.datespan_bins(s, duration, torigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer datespanset_bins(Pointer ss, Pointer duration, int torigin, Pointer count) {
+		return MeosLibrary.meos.datespanset_bins(ss, duration, torigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer datespanset_time_spans(Pointer ss, Pointer duration, int torigin, Pointer count) {
+		return MeosLibrary.meos.datespanset_time_spans(ss, duration, torigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double float_get_bin(double value, double vsize, double vorigin) {
+		return MeosLibrary.meos.float_get_bin(value, vsize, vorigin);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer floatspan_bins(Pointer s, double vsize, double vorigin, Pointer count) {
+		return MeosLibrary.meos.floatspan_bins(s, vsize, vorigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer floatspanset_value_spans(Pointer ss, double vsize, double vorigin, Pointer count) {
+		return MeosLibrary.meos.floatspanset_value_spans(ss, vsize, vorigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int int_get_bin(int value, int vsize, int vorigin) {
+		return MeosLibrary.meos.int_get_bin(value, vsize, vorigin);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer intspan_bins(Pointer s, int vsize, int vorigin, Pointer count) {
+		return MeosLibrary.meos.intspan_bins(s, vsize, vorigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer intspanset_bins(Pointer ss, int vsize, int vorigin, Pointer count) {
+		return MeosLibrary.meos.intspanset_bins(ss, vsize, vorigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer intspanset_value_spans(Pointer ss, int vsize, int vorigin, Pointer count) {
+		return MeosLibrary.meos.intspanset_value_spans(ss, vsize, vorigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static OffsetDateTime timestamptz_get_bin(OffsetDateTime t, Pointer duration, OffsetDateTime torigin) {
 		var t_new = t.toEpochSecond();
 		var torigin_new = torigin.toEpochSecond();
-		return MeosLibrary.meos.stbox_tile(point, t_new, xsize, ysize, zsize, duration, sorigin, torigin_new, hast);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer stbox_tile_list(Pointer bounds, double xsize, double ysize, double zsize, Pointer duration, Pointer sorigin, OffsetDateTime torigin, boolean border_inc, Pointer count) {
-		var torigin_new = torigin.toEpochSecond();
-		return MeosLibrary.meos.stbox_tile_list(bounds, xsize, ysize, zsize, duration, sorigin, torigin_new, border_inc, count);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer temporal_time_split(Pointer temp, Pointer duration, OffsetDateTime torigin, Pointer time_buckets, Pointer count) {
-		var torigin_new = torigin.toEpochSecond();
-		return MeosLibrary.meos.temporal_time_split(temp, duration, torigin_new, time_buckets, count);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tfloat_value_split(Pointer temp, double size, double origin, Pointer value_buckets, Pointer count) {
-		return MeosLibrary.meos.tfloat_value_split(temp, size, origin, value_buckets, count);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tfloat_value_time_split(Pointer temp, double size, Pointer duration, double vorigin, OffsetDateTime torigin, Pointer value_buckets, Pointer time_buckets, Pointer count) {
-		var torigin_new = torigin.toEpochSecond();
-		return MeosLibrary.meos.tfloat_value_time_split(temp, size, duration, vorigin, torigin_new, value_buckets, time_buckets, count);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tfloatbox_tile(double value, OffsetDateTime t, double vsize, Pointer duration, double vorigin, OffsetDateTime torigin) {
-		var t_new = t.toEpochSecond();
-		var torigin_new = torigin.toEpochSecond();
-		return MeosLibrary.meos.tfloatbox_tile(value, t_new, vsize, duration, vorigin, torigin_new);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tfloatbox_tile_list(Pointer box, double xsize, Pointer duration, double xorigin, OffsetDateTime torigin, Pointer count) {
-		var torigin_new = torigin.toEpochSecond();
-		return MeosLibrary.meos.tfloatbox_tile_list(box, xsize, duration, xorigin, torigin_new, count);
-	}
-	
-	@SuppressWarnings("unused")
-	public static OffsetDateTime timestamptz_bucket(OffsetDateTime timestamp, Pointer duration, OffsetDateTime origin) {
-		var timestamp_new = timestamp.toEpochSecond();
-		var origin_new = origin.toEpochSecond();
-		var result = MeosLibrary.meos.timestamptz_bucket(timestamp_new, duration, origin_new);
+		var result = MeosLibrary.meos.timestamptz_get_bin(t_new, duration, torigin_new);
 		Instant instant = Instant.ofEpochSecond(result);
 		return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tint_value_split(Pointer temp, int size, int origin, Pointer value_buckets, Pointer count) {
-		return MeosLibrary.meos.tint_value_split(temp, size, origin, value_buckets, count);
+	public static Pointer tstzspan_bins(Pointer s, Pointer duration, OffsetDateTime origin, Pointer count) {
+		var origin_new = origin.toEpochSecond();
+		return MeosLibrary.meos.tstzspan_bins(s, duration, origin_new, count);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tint_value_time_split(Pointer temp, int size, Pointer duration, int vorigin, OffsetDateTime torigin, Pointer value_buckets, Pointer time_buckets, Pointer count) {
+	public static Pointer tstzspanset_bins(Pointer ss, Pointer duration, OffsetDateTime torigin, Pointer count) {
 		var torigin_new = torigin.toEpochSecond();
-		return MeosLibrary.meos.tint_value_time_split(temp, size, duration, vorigin, torigin_new, value_buckets, time_buckets, count);
+		return MeosLibrary.meos.tstzspanset_bins(ss, duration, torigin_new, count);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tintbox_tile(int value, OffsetDateTime t, int vsize, Pointer duration, int vorigin, OffsetDateTime torigin) {
+	public static Pointer tstzspanset_time_spans(Pointer ss, Pointer duration, OffsetDateTime torigin, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tstzspanset_time_spans(ss, duration, torigin_new, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_time_spans(Pointer temp, Pointer duration, OffsetDateTime origin, Pointer count) {
+		var origin_new = origin.toEpochSecond();
+		return MeosLibrary.meos.temporal_time_spans(temp, duration, origin_new, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_time_split(Pointer temp, Pointer duration, OffsetDateTime torigin, Pointer time_bins, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.temporal_time_split(temp, duration, torigin_new, time_bins, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloat_value_spans(Pointer temp, double vsize, double vorigin, Pointer count) {
+		return MeosLibrary.meos.tfloat_value_spans(temp, vsize, vorigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloat_value_split(Pointer temp, double vsize, double vorigin, Pointer value_bins, Pointer count) {
+		return MeosLibrary.meos.tfloat_value_split(temp, vsize, vorigin, value_bins, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloat_value_time_split(Pointer temp, double vsize, Pointer duration, double vorigin, OffsetDateTime torigin, Pointer value_bins, Pointer time_bins, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tfloat_value_time_split(temp, vsize, duration, vorigin, torigin_new, value_bins, time_bins, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloatbox_get_time_tile(OffsetDateTime t, Pointer duration, OffsetDateTime torigin) {
 		var t_new = t.toEpochSecond();
 		var torigin_new = torigin.toEpochSecond();
-		return MeosLibrary.meos.tintbox_tile(value, t_new, vsize, duration, vorigin, torigin_new);
+		return MeosLibrary.meos.tfloatbox_get_time_tile(t_new, duration, torigin_new);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tintbox_tile_list(Pointer box, int xsize, Pointer duration, int xorigin, OffsetDateTime torigin, Pointer count) {
+	public static Pointer tfloatbox_get_value_tile(double value, double vsize, double vorigin) {
+		return MeosLibrary.meos.tfloatbox_get_value_tile(value, vsize, vorigin);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloatbox_get_value_time_tile(double value, OffsetDateTime t, double vsize, Pointer duration, double vorigin, OffsetDateTime torigin) {
+		var t_new = t.toEpochSecond();
 		var torigin_new = torigin.toEpochSecond();
-		return MeosLibrary.meos.tintbox_tile_list(box, xsize, duration, xorigin, torigin_new, count);
+		return MeosLibrary.meos.tfloatbox_get_value_time_tile(value, t_new, vsize, duration, vorigin, torigin_new);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tpoint_space_split(Pointer temp, float xsize, float ysize, float zsize, Pointer sorigin, boolean bitmatrix, boolean border_inc, Pointer space_buckets, Pointer count) {
-		return MeosLibrary.meos.tpoint_space_split(temp, xsize, ysize, zsize, sorigin, bitmatrix, border_inc, space_buckets, count);
-	}
-	
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_space_time_split(Pointer temp, float xsize, float ysize, float zsize, Pointer duration, Pointer sorigin, OffsetDateTime torigin, boolean bitmatrix, boolean border_inc, Pointer space_buckets, Pointer time_buckets, Pointer count) {
+	public static Pointer tfloatbox_time_tiles(Pointer box, Pointer duration, OffsetDateTime torigin, Pointer count) {
 		var torigin_new = torigin.toEpochSecond();
-		return MeosLibrary.meos.tpoint_space_time_split(temp, xsize, ysize, zsize, duration, sorigin, torigin_new, bitmatrix, border_inc, space_buckets, time_buckets, count);
+		return MeosLibrary.meos.tfloatbox_time_tiles(box, duration, torigin_new, count);
 	}
 	
 	@SuppressWarnings("unused")
-	public static Pointer tstzspan_bucket_list(Pointer bounds, Pointer duration, OffsetDateTime origin, Pointer count) {
-		var origin_new = origin.toEpochSecond();
-		return MeosLibrary.meos.tstzspan_bucket_list(bounds, duration, origin_new, count);
+	public static Pointer tfloatbox_value_tiles(Pointer box, double vsize, double vorigin, Pointer count) {
+		return MeosLibrary.meos.tfloatbox_value_tiles(box, vsize, vorigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloatbox_value_time_tiles(Pointer box, double vsize, Pointer duration, double vorigin, OffsetDateTime torigin, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tfloatbox_value_time_tiles(box, vsize, duration, vorigin, torigin_new, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tint_value_spans(Pointer temp, int vsize, int vorigin, Pointer count) {
+		return MeosLibrary.meos.tint_value_spans(temp, vsize, vorigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tint_value_split(Pointer temp, int vsize, int vorigin, Pointer value_bins, Pointer count) {
+		return MeosLibrary.meos.tint_value_split(temp, vsize, vorigin, value_bins, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tint_value_time_split(Pointer temp, int size, Pointer duration, int vorigin, OffsetDateTime torigin, Pointer value_bins, Pointer time_bins, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tint_value_time_split(temp, size, duration, vorigin, torigin_new, value_bins, time_bins, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintbox_get_time_tile(OffsetDateTime t, Pointer duration, OffsetDateTime torigin) {
+		var t_new = t.toEpochSecond();
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tintbox_get_time_tile(t_new, duration, torigin_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintbox_get_value_tile(int value, int vsize, int vorigin) {
+		return MeosLibrary.meos.tintbox_get_value_tile(value, vsize, vorigin);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintbox_get_value_time_tile(int value, OffsetDateTime t, int vsize, Pointer duration, int vorigin, OffsetDateTime torigin) {
+		var t_new = t.toEpochSecond();
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tintbox_get_value_time_tile(value, t_new, vsize, duration, vorigin, torigin_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintbox_time_tiles(Pointer box, Pointer duration, OffsetDateTime torigin, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tintbox_time_tiles(box, duration, torigin_new, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintbox_value_tiles(Pointer box, int xsize, int xorigin, Pointer count) {
+		return MeosLibrary.meos.tintbox_value_tiles(box, xsize, xorigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintbox_value_time_tiles(Pointer box, int xsize, Pointer duration, int xorigin, OffsetDateTime torigin, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tintbox_value_time_tiles(box, xsize, duration, xorigin, torigin_new, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_as_ewkb(Pointer gs, String endian, Pointer size) {
+		return MeosLibrary.meos.geo_as_ewkb(gs, endian, size);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String geo_as_ewkt(Pointer gs, int precision) {
+		return MeosLibrary.meos.geo_as_ewkt(gs, precision);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String geo_as_geojson(Pointer gs, int option, int precision, String srs) {
+		return MeosLibrary.meos.geo_as_geojson(gs, option, precision, srs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String geo_as_hexewkb(Pointer gs, String endian) {
+		return MeosLibrary.meos.geo_as_hexewkb(gs, endian);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String geo_as_text(Pointer gs, int precision) {
+		return MeosLibrary.meos.geo_as_text(gs, precision);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_collect_garray(Pointer gsarr, int count) {
+		return MeosLibrary.meos.geo_collect_garray(gsarr, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_copy(Pointer g) {
+		return MeosLibrary.meos.geo_copy(g);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int geo_equals(Pointer gs1, Pointer gs2) {
+		return MeosLibrary.meos.geo_equals(gs1, gs2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_from_ewkb(Pointer wkb, long wkb_size, int srid) {
+		return MeosLibrary.meos.geo_from_ewkb(wkb, wkb_size, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_from_geojson(String geojson) {
+		return MeosLibrary.meos.geo_from_geojson(geojson);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_from_text(String wkt, int srid) {
+		return MeosLibrary.meos.geo_from_text(wkt, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geo_is_empty(Pointer g) {
+		return MeosLibrary.meos.geo_is_empty(g);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_makeline_garray(Pointer gsarr, int count) {
+		return MeosLibrary.meos.geo_makeline_garray(gsarr, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String geo_out(Pointer gs) {
+		return MeosLibrary.meos.geo_out(gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_reverse(Pointer gs) {
+		return MeosLibrary.meos.geo_reverse(gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_round(Pointer gs, int maxdd) {
+		return MeosLibrary.meos.geo_round(gs, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geo_same(Pointer gs1, Pointer gs2) {
+		return MeosLibrary.meos.geo_same(gs1, gs2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer  geo_set_srid(Pointer gs, int srid) {
+		return MeosLibrary.meos.geo_set_srid(gs, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int geo_srid(Pointer gs) {
+		return MeosLibrary.meos.geo_srid(gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_transform(Pointer geom, int srid_to) {
+		return MeosLibrary.meos.geo_transform(geom, srid_to);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_transform_pipeline(Pointer gs, String pipeline, int srid_to, boolean is_forward) {
+		return MeosLibrary.meos.geo_transform_pipeline(gs, pipeline, srid_to, is_forward);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double geog_area(Pointer g, boolean use_spheroid) {
+		return MeosLibrary.meos.geog_area(g, use_spheroid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geog_centroid(Pointer g, boolean use_spheroid) {
+		return MeosLibrary.meos.geog_centroid(g, use_spheroid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double geog_distance(Pointer g1, Pointer g2) {
+		return MeosLibrary.meos.geog_distance(g1, g2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geog_dwithin(Pointer g1, Pointer g2, double tolerance, boolean use_spheroid) {
+		return MeosLibrary.meos.geog_dwithin(g1, g2, tolerance, use_spheroid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geog_from_binary(String wkb_bytea) {
+		return MeosLibrary.meos.geog_from_binary(wkb_bytea);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geog_from_geom(Pointer geom) {
+		return MeosLibrary.meos.geog_from_geom(geom);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geog_from_hexewkb(String wkt) {
+		return MeosLibrary.meos.geog_from_hexewkb(wkt);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geog_in(String str, int typmod) {
+		return MeosLibrary.meos.geog_in(str, typmod);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geog_intersects(Pointer gs1, Pointer gs2, boolean use_spheroid) {
+		return MeosLibrary.meos.geog_intersects(gs1, gs2, use_spheroid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double geog_length(Pointer g, boolean use_spheroid) {
+		return MeosLibrary.meos.geog_length(g, use_spheroid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double geog_perimeter(Pointer g, boolean use_spheroid) {
+		return MeosLibrary.meos.geog_perimeter(g, use_spheroid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_array_union(Pointer gsarr, int count) {
+		return MeosLibrary.meos.geom_array_union(gsarr, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_azimuth(Pointer gs1, Pointer gs2) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.geom_azimuth(gs1, gs2, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_boundary(Pointer gs) {
+		return MeosLibrary.meos.geom_boundary(gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_buffer(Pointer gs, double size, String params) {
+		return MeosLibrary.meos.geom_buffer(gs, size, params);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_centroid(Pointer gs) {
+		return MeosLibrary.meos.geom_centroid(gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geom_contains(Pointer gs1, Pointer gs2) {
+		return MeosLibrary.meos.geom_contains(gs1, gs2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_convex_hull(Pointer gs) {
+		return MeosLibrary.meos.geom_convex_hull(gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geom_covers(Pointer gs1, Pointer gs2) {
+		return MeosLibrary.meos.geom_covers(gs1, gs2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_difference2d(Pointer gs1, Pointer gs2) {
+		return MeosLibrary.meos.geom_difference2d(gs1, gs2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geom_disjoint2d(Pointer gs1, Pointer gs2) {
+		return MeosLibrary.meos.geom_disjoint2d(gs1, gs2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double geom_distance2d(Pointer gs1, Pointer gs2) {
+		return MeosLibrary.meos.geom_distance2d(gs1, gs2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double geom_distance3d(Pointer gs1, Pointer gs2) {
+		return MeosLibrary.meos.geom_distance3d(gs1, gs2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geom_dwithin2d(Pointer gs1, Pointer gs2, double tolerance) {
+		return MeosLibrary.meos.geom_dwithin2d(gs1, gs2, tolerance);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geom_dwithin3d(Pointer gs1, Pointer gs2, double tolerance) {
+		return MeosLibrary.meos.geom_dwithin3d(gs1, gs2, tolerance);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_from_geog(Pointer geog) {
+		return MeosLibrary.meos.geom_from_geog(geog);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_from_hexewkb(String wkt) {
+		return MeosLibrary.meos.geom_from_hexewkb(wkt);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_from_text(String wkt, int srid) {
+		return MeosLibrary.meos.geom_from_text(wkt, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_in(String str, int typmod) {
+		return MeosLibrary.meos.geom_in(str, typmod);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_intersection2d(Pointer gs1, Pointer gs2) {
+		return MeosLibrary.meos.geom_intersection2d(gs1, gs2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geom_intersects2d(Pointer gs1, Pointer gs2) {
+		return MeosLibrary.meos.geom_intersects2d(gs1, gs2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geom_intersects3d(Pointer gs1, Pointer gs2) {
+		return MeosLibrary.meos.geom_intersects3d(gs1, gs2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double geom_length(Pointer gs) {
+		return MeosLibrary.meos.geom_length(gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double geom_perimeter(Pointer gs) {
+		return MeosLibrary.meos.geom_perimeter(gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geom_relate_pattern(Pointer gs1, Pointer gs2, String patt) {
+		return MeosLibrary.meos.geom_relate_pattern(gs1, gs2, patt);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_shortestline2d(Pointer gs1, Pointer s2) {
+		return MeosLibrary.meos.geom_shortestline2d(gs1, s2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_shortestline3d(Pointer gs1, Pointer s2) {
+		return MeosLibrary.meos.geom_shortestline3d(gs1, s2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geom_touches(Pointer gs1, Pointer gs2) {
+		return MeosLibrary.meos.geom_touches(gs1, gs2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geom_unary_union(Pointer gs, double prec) {
+		return MeosLibrary.meos.geom_unary_union(gs, prec);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer line_interpolate_point(Pointer gs, double distance_fraction, boolean repeat) {
+		return MeosLibrary.meos.line_interpolate_point(gs, distance_fraction, repeat);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int line_numpoints(Pointer gs) {
+		return MeosLibrary.meos.line_numpoints(gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double line_locate_point(Pointer gs1, Pointer gs2) {
+		return MeosLibrary.meos.line_locate_point(gs1, gs2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer line_point_n(Pointer geom, int n) {
+		return MeosLibrary.meos.line_point_n(geom, n);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer line_substring(Pointer gs, double from, double to) {
+		return MeosLibrary.meos.line_substring(gs, from, to);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_stboxes(Pointer gs, Pointer count) {
+		return MeosLibrary.meos.geo_stboxes(gs, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_split_n_stboxes(Pointer gs, int box_count, Pointer count) {
+		return MeosLibrary.meos.geo_split_n_stboxes(gs, box_count, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contained_geo_set(Pointer gs, Pointer s) {
+		return MeosLibrary.meos.contained_geo_set(gs, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contains_set_geo(Pointer s, Pointer gs) {
+		return MeosLibrary.meos.contains_set_geo(s, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_set(Pointer gs) {
+		return MeosLibrary.meos.geo_set(gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geoset_end_value(Pointer s) {
+		return MeosLibrary.meos.geoset_end_value(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geoset_make(Pointer values, int count) {
+		return MeosLibrary.meos.geoset_make(values, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geoset_start_value(Pointer s) {
+		return MeosLibrary.meos.geoset_start_value(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geoset_value_n(Pointer s, int n) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.geoset_value_n(s, n, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geoset_values(Pointer s) {
+		return MeosLibrary.meos.geoset_values(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer intersection_geo_set(Pointer gs, Pointer s) {
+		return MeosLibrary.meos.intersection_geo_set(gs, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer intersection_set_geo(Pointer s, Pointer gs) {
+		return MeosLibrary.meos.intersection_set_geo(s, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer minus_geo_set(Pointer gs, Pointer s) {
+		return MeosLibrary.meos.minus_geo_set(gs, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer minus_set_geo(Pointer s, Pointer gs) {
+		return MeosLibrary.meos.minus_set_geo(s, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int spatialset_srid(Pointer s) {
+		return MeosLibrary.meos.spatialset_srid(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spatialset_set_srid(Pointer s, int srid) {
+		return MeosLibrary.meos.spatialset_set_srid(s, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spatialset_transform(Pointer s, int srid) {
+		return MeosLibrary.meos.spatialset_transform(s, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spatialset_transform_pipeline(Pointer s, String pipelinestr, int srid, boolean is_forward) {
+		return MeosLibrary.meos.spatialset_transform_pipeline(s, pipelinestr, srid, is_forward);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer union_geo_set(Pointer gs, Pointer s) {
+		return MeosLibrary.meos.union_geo_set(gs, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer union_set_geo(Pointer s, Pointer gs) {
+		return MeosLibrary.meos.union_set_geo(s, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_from_wkb(Pointer wkb, long size) {
+		return MeosLibrary.meos.stbox_from_wkb(wkb, size);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_from_hexwkb(String hexwkb) {
+		return MeosLibrary.meos.stbox_from_hexwkb(hexwkb);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_as_wkb(Pointer box, byte variant) {
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer size_out = Memory.allocateDirect(runtime, Long.BYTES);
+		return MeosLibrary.meos.stbox_as_wkb(box, variant, size_out);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String stbox_as_hexwkb(Pointer box, byte variant, Pointer size) {
+		return MeosLibrary.meos.stbox_as_hexwkb(box, variant, size);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_in(String str) {
+		return MeosLibrary.meos.stbox_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String stbox_out(Pointer box, int maxdd) {
+		return MeosLibrary.meos.stbox_out(box, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_tstzspan_to_stbox(Pointer gs, Pointer s) {
+		return MeosLibrary.meos.geo_tstzspan_to_stbox(gs, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_timestamptz_to_stbox(Pointer gs, OffsetDateTime t) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.geo_timestamptz_to_stbox(gs, t_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_copy(Pointer box) {
+		return MeosLibrary.meos.stbox_copy(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_make(boolean hasx, boolean hasz, boolean geodetic, int srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, Pointer s) {
+		return MeosLibrary.meos.stbox_make(hasx, hasz, geodetic, srid, xmin, xmax, ymin, ymax, zmin, zmax, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_stbox(Pointer gs) {
+		return MeosLibrary.meos.geo_stbox(gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_geo(Pointer box) {
+		return MeosLibrary.meos.stbox_geo(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spatialset_stbox(Pointer s) {
+		return MeosLibrary.meos.spatialset_stbox(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_gbox(Pointer box) {
+		return MeosLibrary.meos.stbox_gbox(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_box3d(Pointer box) {
+		return MeosLibrary.meos.stbox_box3d(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_tstzspan(Pointer box) {
+		return MeosLibrary.meos.stbox_tstzspan(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer timestamptz_stbox(OffsetDateTime t) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.timestamptz_stbox(t_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tstzset_stbox(Pointer s) {
+		return MeosLibrary.meos.tstzset_stbox(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tstzspan_stbox(Pointer s) {
+		return MeosLibrary.meos.tstzspan_stbox(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tstzspanset_stbox(Pointer ss) {
+		return MeosLibrary.meos.tstzspanset_stbox(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tspatial_stbox(Pointer temp) {
+		return MeosLibrary.meos.tspatial_stbox(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double stbox_area(Pointer box, boolean spheroid) {
+		return MeosLibrary.meos.stbox_area(box, spheroid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean stbox_hast(Pointer box) {
+		return MeosLibrary.meos.stbox_hast(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean stbox_hasx(Pointer box) {
+		return MeosLibrary.meos.stbox_hasx(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean stbox_hasz(Pointer box) {
+		return MeosLibrary.meos.stbox_hasz(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean stbox_isgeodetic(Pointer box) {
+		return MeosLibrary.meos.stbox_isgeodetic(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double stbox_perimeter(Pointer box, boolean spheroid) {
+		return MeosLibrary.meos.stbox_perimeter(box, spheroid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int stbox_srid(Pointer box) {
+		return MeosLibrary.meos.stbox_srid(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_tmax(Pointer box) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.stbox_tmax(box, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_tmax_inc(Pointer box) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.stbox_tmax_inc(box, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_tmin(Pointer box) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.stbox_tmin(box, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_tmin_inc(Pointer box) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.stbox_tmin_inc(box, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static double stbox_volume(Pointer box) {
+		return MeosLibrary.meos.stbox_volume(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_xmax(Pointer box) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.stbox_xmax(box, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_xmin(Pointer box) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.stbox_xmin(box, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_ymax(Pointer box) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.stbox_ymax(box, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_ymin(Pointer box) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.stbox_ymin(box, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_zmax(Pointer box) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.stbox_zmax(box, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_zmin(Pointer box) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.stbox_zmin(box, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_expand_space(Pointer box, double d) {
+		return MeosLibrary.meos.stbox_expand_space(box, d);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_expand_time(Pointer box, Pointer interv) {
+		return MeosLibrary.meos.stbox_expand_time(box, interv);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_get_space(Pointer box) {
+		return MeosLibrary.meos.stbox_get_space(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_quad_split(Pointer box, Pointer count) {
+		return MeosLibrary.meos.stbox_quad_split(box, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_round(Pointer box, int maxdd) {
+		return MeosLibrary.meos.stbox_round(box, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_set_srid(Pointer box, int srid) {
+		return MeosLibrary.meos.stbox_set_srid(box, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_shift_scale_time(Pointer box, Pointer shift, Pointer duration) {
+		return MeosLibrary.meos.stbox_shift_scale_time(box, shift, duration);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_transform(Pointer box, int srid) {
+		return MeosLibrary.meos.stbox_transform(box, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_transform_pipeline(Pointer box, String pipelinestr, int srid, boolean is_forward) {
+		return MeosLibrary.meos.stbox_transform_pipeline(box, pipelinestr, srid, is_forward);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stboxarr_round(Pointer boxarr, int count, int maxdd) {
+		return MeosLibrary.meos.stboxarr_round(boxarr, count, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer union_stbox_stbox(Pointer box1, Pointer box2, boolean strict) {
+		return MeosLibrary.meos.union_stbox_stbox(box1, box2, strict);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer intersection_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.intersection_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean adjacent_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.adjacent_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contained_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.contained_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contains_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.contains_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overlaps_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.overlaps_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean same_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.same_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean left_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.left_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overleft_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.overleft_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean right_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.right_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overright_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.overright_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean below_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.below_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overbelow_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.overbelow_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean above_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.above_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overabove_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.overabove_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean front_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.front_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overfront_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.overfront_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean back_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.back_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overback_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.overback_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean before_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.before_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overbefore_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.overbefore_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean after_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.after_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overafter_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.overafter_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean stbox_eq(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.stbox_eq(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean stbox_ne(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.stbox_ne(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int stbox_cmp(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.stbox_cmp(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean stbox_lt(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.stbox_lt(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean stbox_le(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.stbox_le(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean stbox_ge(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.stbox_ge(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean stbox_gt(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.stbox_gt(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer rtree_create_stbox() {
+		return MeosLibrary.meos.rtree_create_stbox();
+	}
+	
+	@SuppressWarnings("unused")
+	public static void rtree_insert(Pointer rtree, Pointer box, long id) {
+		MeosLibrary.meos.rtree_insert(rtree, box, id);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer rtree_search(Pointer rtree,Pointer query, Pointer count) {
+		return MeosLibrary.meos.rtree_search(rtree, query, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void rtree_free(Pointer rtree) {
+		MeosLibrary.meos.rtree_free(rtree);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tgeo_out(Pointer temp, int maxdd) {
+		return MeosLibrary.meos.tgeo_out(temp, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tspatial_as_text(Pointer temp, int maxdd) {
+		return MeosLibrary.meos.tspatial_as_text(temp, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tspatial_as_ewkt(Pointer temp, int maxdd) {
+		return MeosLibrary.meos.tspatial_as_ewkt(temp, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeogpoint_in(String str) {
+		return MeosLibrary.meos.tgeogpoint_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeogpoint_from_mfjson(String str) {
+		return MeosLibrary.meos.tgeogpoint_from_mfjson(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeography_in(String str) {
+		return MeosLibrary.meos.tgeography_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeometry_in(String str) {
+		return MeosLibrary.meos.tgeometry_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeompoint_in(String str) {
+		return MeosLibrary.meos.tgeompoint_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeompoint_from_mfjson(String str) {
+		return MeosLibrary.meos.tgeompoint_from_mfjson(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geogset_in(String str) {
+		return MeosLibrary.meos.geogset_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geomset_in(String str) {
+		return MeosLibrary.meos.geomset_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_from_base_temp(Pointer gs, Pointer temp) {
+		return MeosLibrary.meos.tgeo_from_base_temp(gs, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeoinst_make(Pointer gs, OffsetDateTime t) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.tgeoinst_make(gs, t_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeoseq_from_base_tstzset(Pointer gs, Pointer s) {
+		return MeosLibrary.meos.tgeoseq_from_base_tstzset(gs, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeoseqset_from_base_tstzspanset(Pointer gs, Pointer ss, int interp) {
+		return MeosLibrary.meos.tgeoseqset_from_base_tstzspanset(gs, ss, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_from_base_temp(Pointer gs, Pointer temp) {
+		return MeosLibrary.meos.tpoint_from_base_temp(gs, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointinst_make(Pointer gs, OffsetDateTime t) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.tpointinst_make(gs, t_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseq_from_base_tstzspan(Pointer gs, Pointer s, int interp) {
+		return MeosLibrary.meos.tpointseq_from_base_tstzspan(gs, s, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseq_from_base_tstzset(Pointer gs, Pointer s) {
+		return MeosLibrary.meos.tpointseq_from_base_tstzset(gs, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseqset_from_base_tstzspanset(Pointer gs, Pointer ss, int interp) {
+		return MeosLibrary.meos.tpointseqset_from_base_tstzspanset(gs, ss, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_end_value(Pointer temp) {
+		return MeosLibrary.meos.tgeo_end_value(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_start_value(Pointer temp) {
+		return MeosLibrary.meos.tgeo_start_value(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean tgeo_value_at_timestamptz(Pointer temp, OffsetDateTime t, boolean strict, Pointer value) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.tgeo_value_at_timestamptz(temp, t_new, strict, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_value_n(Pointer temp, int n) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.tgeo_value_n(temp, n, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_values(Pointer temp, Pointer count) {
+		return MeosLibrary.meos.tgeo_values(temp, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_traversed_area(Pointer temp) {
+		return MeosLibrary.meos.tgeo_traversed_area(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_centroid(Pointer temp) {
+		return MeosLibrary.meos.tgeo_centroid(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int tspatial_srid(Pointer temp) {
+		return MeosLibrary.meos.tspatial_srid(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tspatial_set_srid(Pointer temp, int srid) {
+		return MeosLibrary.meos.tspatial_set_srid(temp, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tspatial_transform(Pointer temp, int srid) {
+		return MeosLibrary.meos.tspatial_transform(temp, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tspatial_transform_pipeline(Pointer temp, String pipelinestr, int srid, boolean is_forward) {
+		return MeosLibrary.meos.tspatial_transform_pipeline(temp, pipelinestr, srid, is_forward);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_at_geom(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.tgeo_at_geom(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_at_stbox(Pointer temp, Pointer box, boolean border_inc) {
+		return MeosLibrary.meos.tgeo_at_stbox(temp, box, border_inc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_minus_geom(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.tgeo_minus_geom(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_minus_stbox(Pointer temp, Pointer box, boolean border_inc) {
+		return MeosLibrary.meos.tgeo_minus_stbox(temp, box, border_inc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_at_geom(Pointer temp, Pointer gs, Pointer zspan) {
+		return MeosLibrary.meos.tpoint_at_geom(temp, gs, zspan);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_at_stbox(Pointer temp, Pointer box, boolean border_inc) {
+		return MeosLibrary.meos.tpoint_at_stbox(temp, box, border_inc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_at_value(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.tpoint_at_value(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_minus_geom(Pointer temp, Pointer gs, Pointer zspan) {
+		return MeosLibrary.meos.tpoint_minus_geom(temp, gs, zspan);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_minus_stbox(Pointer temp, Pointer box, boolean border_inc) {
+		return MeosLibrary.meos.tpoint_minus_stbox(temp, box, border_inc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_minus_value(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.tpoint_minus_value(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_eq_geo_tgeo(Pointer gs, Pointer temp) {
+		return MeosLibrary.meos.always_eq_geo_tgeo(gs, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_eq_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.always_eq_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_eq_tgeo_tgeo(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.always_eq_tgeo_tgeo(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_ne_geo_tgeo(Pointer gs, Pointer temp) {
+		return MeosLibrary.meos.always_ne_geo_tgeo(gs, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_ne_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.always_ne_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_ne_tgeo_tgeo(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.always_ne_tgeo_tgeo(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_eq_geo_tgeo(Pointer gs, Pointer temp) {
+		return MeosLibrary.meos.ever_eq_geo_tgeo(gs, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_eq_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.ever_eq_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_eq_tgeo_tgeo(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.ever_eq_tgeo_tgeo(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_ne_geo_tgeo(Pointer gs, Pointer temp) {
+		return MeosLibrary.meos.ever_ne_geo_tgeo(gs, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_ne_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.ever_ne_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_ne_tgeo_tgeo(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.ever_ne_tgeo_tgeo(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer teq_geo_tgeo(Pointer gs, Pointer temp) {
+		return MeosLibrary.meos.teq_geo_tgeo(gs, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer teq_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.teq_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tne_geo_tgeo(Pointer gs, Pointer temp) {
+		return MeosLibrary.meos.tne_geo_tgeo(gs, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tne_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.tne_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_split_each_n_stboxes(Pointer gs, int elem_count, Pointer count) {
+		return MeosLibrary.meos.geo_split_each_n_stboxes(gs, elem_count, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_stboxes(Pointer temp, Pointer count) {
+		return MeosLibrary.meos.tgeo_stboxes(temp, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_space_boxes(Pointer temp, double xsize, double ysize, double zsize, Pointer sorigin, boolean bitmatrix, boolean border_inc, Pointer count) {
+		return MeosLibrary.meos.tgeo_space_boxes(temp, xsize, ysize, zsize, sorigin, bitmatrix, border_inc, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_space_time_boxes(Pointer temp, double xsize, double ysize, double zsize, Pointer duration, Pointer sorigin, OffsetDateTime torigin, boolean bitmatrix, boolean border_inc, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tgeo_space_time_boxes(temp, xsize, ysize, zsize, duration, sorigin, torigin_new, bitmatrix, border_inc, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_split_each_n_stboxes(Pointer temp, int elem_count, Pointer count) {
+		return MeosLibrary.meos.tgeo_split_each_n_stboxes(temp, elem_count, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_split_n_stboxes(Pointer temp, int box_count, Pointer count) {
+		return MeosLibrary.meos.tgeo_split_n_stboxes(temp, box_count, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean adjacent_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.adjacent_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean adjacent_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.adjacent_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean adjacent_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.adjacent_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contained_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.contained_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contained_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.contained_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contained_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.contained_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contains_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.contains_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contains_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.contains_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contains_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.contains_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overlaps_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.overlaps_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overlaps_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.overlaps_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overlaps_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.overlaps_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean same_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.same_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean same_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.same_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean same_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.same_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean above_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.above_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean above_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.above_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean above_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.above_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean after_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.after_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean after_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.after_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean after_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.after_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean back_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.back_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean back_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.back_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean back_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.back_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean before_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.before_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean before_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.before_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean before_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.before_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean below_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.below_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean below_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.below_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean below_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.below_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean front_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.front_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean front_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.front_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean front_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.front_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean left_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.left_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean left_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.left_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean left_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.left_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overabove_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.overabove_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overabove_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.overabove_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overabove_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.overabove_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overafter_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.overafter_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overafter_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.overafter_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overafter_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.overafter_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overback_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.overback_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overback_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.overback_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overback_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.overback_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overbefore_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.overbefore_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overbefore_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.overbefore_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overbefore_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.overbefore_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overbelow_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.overbelow_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overbelow_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.overbelow_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overbelow_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.overbelow_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overfront_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.overfront_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overfront_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.overfront_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overfront_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.overfront_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overleft_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.overleft_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overleft_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.overleft_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overleft_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.overleft_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overright_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.overright_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overright_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.overright_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overright_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.overright_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean right_stbox_tspatial(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.right_stbox_tspatial(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean right_tspatial_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.right_tspatial_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean right_tspatial_tspatial(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.right_tspatial_tspatial(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer bearing_point_point(Pointer gs1, Pointer gs2) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.bearing_point_point(gs1, gs2, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer bearing_tpoint_point(Pointer temp, Pointer gs, boolean invert) {
+		return MeosLibrary.meos.bearing_tpoint_point(temp, gs, invert);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer bearing_tpoint_tpoint(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.bearing_tpoint_tpoint(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_gboxes(Pointer gs, Pointer count) {
+		return MeosLibrary.meos.geo_gboxes(gs, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_angular_difference(Pointer temp) {
+		return MeosLibrary.meos.tpoint_angular_difference(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_azimuth(Pointer temp) {
+		return MeosLibrary.meos.tpoint_azimuth(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_convex_hull(Pointer temp) {
+		return MeosLibrary.meos.tgeo_convex_hull(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_cumulative_length(Pointer temp) {
+		return MeosLibrary.meos.tpoint_cumulative_length(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_direction(Pointer temp) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.tpoint_direction(temp, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_get_x(Pointer temp) {
+		return MeosLibrary.meos.tpoint_get_x(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_get_y(Pointer temp) {
+		return MeosLibrary.meos.tpoint_get_y(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_get_z(Pointer temp) {
+		return MeosLibrary.meos.tpoint_get_z(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean tpoint_is_simple(Pointer temp) {
+		return MeosLibrary.meos.tpoint_is_simple(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double tpoint_length(Pointer temp) {
+		return MeosLibrary.meos.tpoint_length(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_speed(Pointer temp) {
+		return MeosLibrary.meos.tpoint_speed(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_trajectory(Pointer temp) {
+		return MeosLibrary.meos.tpoint_trajectory(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_twcentroid(Pointer temp) {
+		return MeosLibrary.meos.tpoint_twcentroid(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geo_expand_space(Pointer gs, double d) {
+		return MeosLibrary.meos.geo_expand_space(gs, d);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer geomeas_tpoint(Pointer gs) {
+		return MeosLibrary.meos.geomeas_tpoint(gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeogpoint_tgeography(Pointer temp) {
+		return MeosLibrary.meos.tgeogpoint_tgeography(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeography_tgeometry(Pointer temp) {
+		return MeosLibrary.meos.tgeography_tgeometry(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeography_tgeogpoint(Pointer temp) {
+		return MeosLibrary.meos.tgeography_tgeogpoint(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeometry_tgeography(Pointer temp) {
+		return MeosLibrary.meos.tgeometry_tgeography(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeometry_tgeompoint(Pointer temp) {
+		return MeosLibrary.meos.tgeometry_tgeompoint(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeompoint_tgeometry(Pointer temp) {
+		return MeosLibrary.meos.tgeompoint_tgeometry(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_affine(Pointer temp, Pointer a) {
+		return MeosLibrary.meos.tgeo_affine(temp, a);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean tpoint_AsMVTGeom(Pointer temp, Pointer bounds, int extent, int buffer, boolean clip_geom, Pointer gsarr, Pointer timesarr, Pointer count) {
+		return MeosLibrary.meos.tpoint_AsMVTGeom(temp, bounds, extent, buffer, clip_geom, gsarr, timesarr, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tspatial_expand_space(Pointer temp, double d) {
+		return MeosLibrary.meos.tspatial_expand_space(temp, d);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_make_simple(Pointer temp, Pointer count) {
+		return MeosLibrary.meos.tpoint_make_simple(temp, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_scale(Pointer temp, Pointer scale, Pointer sorigin) {
+		return MeosLibrary.meos.tgeo_scale(temp, scale, sorigin);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_tfloat_to_geomeas(Pointer tpoint, Pointer measure, boolean segmentize) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.tpoint_tfloat_to_geomeas(tpoint, measure, segmentize, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static int acontains_geo_tgeo(Pointer gs, Pointer temp) {
+		return MeosLibrary.meos.acontains_geo_tgeo(gs, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int adisjoint_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.adisjoint_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int adisjoint_tgeo_tgeo(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.adisjoint_tgeo_tgeo(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int adwithin_tgeo_geo(Pointer temp, Pointer gs, double dist) {
+		return MeosLibrary.meos.adwithin_tgeo_geo(temp, gs, dist);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int adwithin_tgeo_tgeo(Pointer temp1, Pointer temp2, double dist) {
+		return MeosLibrary.meos.adwithin_tgeo_tgeo(temp1, temp2, dist);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int aintersects_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.aintersects_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int aintersects_tgeo_tgeo(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.aintersects_tgeo_tgeo(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int atouches_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.atouches_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int econtains_geo_tgeo(Pointer gs, Pointer temp) {
+		return MeosLibrary.meos.econtains_geo_tgeo(gs, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int edisjoint_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.edisjoint_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int edisjoint_tgeo_tgeo(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.edisjoint_tgeo_tgeo(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int edwithin_tgeo_geo(Pointer temp, Pointer gs, double dist) {
+		return MeosLibrary.meos.edwithin_tgeo_geo(temp, gs, dist);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int edwithin_tgeo_tgeo(Pointer temp1, Pointer temp2, double dist) {
+		return MeosLibrary.meos.edwithin_tgeo_tgeo(temp1, temp2, dist);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int eintersects_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.eintersects_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int eintersects_tgeo_tgeo(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.eintersects_tgeo_tgeo(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int etouches_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.etouches_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tcontains_geo_tgeo(Pointer gs, Pointer temp, boolean restr, boolean atvalue) {
+		return MeosLibrary.meos.tcontains_geo_tgeo(gs, temp, restr, atvalue);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tdisjoint_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue) {
+		return MeosLibrary.meos.tdisjoint_tgeo_geo(temp, gs, restr, atvalue);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tdisjoint_tgeo_tgeo (Pointer temp1, Pointer temp2, boolean restr, boolean atvalue) {
+		return MeosLibrary.meos.tdisjoint_tgeo_tgeo(temp1, temp2, restr, atvalue);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tdwithin_tgeo_geo(Pointer temp, Pointer gs, double dist, boolean restr, boolean atvalue) {
+		return MeosLibrary.meos.tdwithin_tgeo_geo(temp, gs, dist, restr, atvalue);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tdwithin_tgeo_tgeo(Pointer temp1, Pointer temp2, double dist, boolean restr, boolean atvalue) {
+		return MeosLibrary.meos.tdwithin_tgeo_tgeo(temp1, temp2, dist, restr, atvalue);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintersects_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue) {
+		return MeosLibrary.meos.tintersects_tgeo_geo(temp, gs, restr, atvalue);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintersects_tgeo_tgeo (Pointer temp1, Pointer temp2, boolean restr, boolean atvalue) {
+		return MeosLibrary.meos.tintersects_tgeo_tgeo(temp1, temp2, restr, atvalue);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer ttouches_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue) {
+		return MeosLibrary.meos.ttouches_tgeo_geo(temp, gs, restr, atvalue);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double nad_stbox_geo(Pointer box, Pointer gs) {
+		return MeosLibrary.meos.nad_stbox_geo(box, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double nad_stbox_stbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.nad_stbox_stbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double nad_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.nad_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double nad_tgeo_stbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.nad_tgeo_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double nad_tgeo_tgeo(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.nad_tgeo_tgeo(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer nai_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.nai_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer nai_tgeo_tgeo(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.nai_tgeo_tgeo(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer shortestline_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.shortestline_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer shortestline_tgeo_tgeo(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.shortestline_tgeo_tgeo(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer distance_tgeo_geo(Pointer temp, Pointer gs) {
+		return MeosLibrary.meos.distance_tgeo_geo(temp, gs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer distance_tgeo_tgeo(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.distance_tgeo_tgeo(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_tcentroid_finalfn(Pointer state) {
+		return MeosLibrary.meos.tpoint_tcentroid_finalfn(state);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_tcentroid_transfn(Pointer state, Pointer temp) {
+		return MeosLibrary.meos.tpoint_tcentroid_transfn(state, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tspatial_extent_transfn(Pointer box, Pointer temp) {
+		return MeosLibrary.meos.tspatial_extent_transfn(box, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_get_space_tile(Pointer point, double xsize, double ysize, double zsize, Pointer sorigin) {
+		return MeosLibrary.meos.stbox_get_space_tile(point, xsize, ysize, zsize, sorigin);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_get_space_time_tile(Pointer point, OffsetDateTime t, double xsize, double ysize, double zsize, Pointer duration, Pointer sorigin, OffsetDateTime torigin) {
+		var t_new = t.toEpochSecond();
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.stbox_get_space_time_tile(point, t_new, xsize, ysize, zsize, duration, sorigin, torigin_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_get_time_tile(OffsetDateTime t, Pointer duration, OffsetDateTime torigin) {
+		var t_new = t.toEpochSecond();
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.stbox_get_time_tile(t_new, duration, torigin_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_space_tiles(Pointer bounds, double xsize, double ysize, double zsize, Pointer sorigin, boolean border_inc, Pointer count) {
+		return MeosLibrary.meos.stbox_space_tiles(bounds, xsize, ysize, zsize, sorigin, border_inc, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_space_time_tiles(Pointer bounds, double xsize, double ysize, double zsize, Pointer duration, Pointer sorigin, OffsetDateTime torigin, boolean border_inc, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.stbox_space_time_tiles(bounds, xsize, ysize, zsize, duration, sorigin, torigin_new, border_inc, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer stbox_time_tiles(Pointer bounds, Pointer duration, OffsetDateTime torigin, boolean border_inc, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.stbox_time_tiles(bounds, duration, torigin_new, border_inc, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_space_split(Pointer temp, double xsize, double ysize, double zsize, Pointer sorigin, boolean bitmatrix, boolean border_inc, Pointer space_bins, Pointer count) {
+		return MeosLibrary.meos.tpoint_space_split(temp, xsize, ysize, zsize, sorigin, bitmatrix, border_inc, space_bins, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_space_time_split(Pointer temp, double xsize, double ysize, double zsize, Pointer duration, Pointer sorigin, OffsetDateTime torigin, boolean bitmatrix, boolean border_inc, Pointer space_bins, Pointer time_bins, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tgeo_space_time_split(temp, xsize, ysize, zsize, duration, sorigin, torigin_new, bitmatrix, border_inc, space_bins, time_bins, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_time_split(Pointer temp, Pointer duration, OffsetDateTime torigin, boolean border_inc, Pointer time_bins, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tgeo_time_split(temp, duration, torigin_new, border_inc, time_bins, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int int4_in(String str) {
+		return MeosLibrary.meos.int4_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String int4_out(int val) {
+		return MeosLibrary.meos.int4_out(val);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long int8_in(String str) {
+		return MeosLibrary.meos.int8_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String int8_out(long val) {
+		return MeosLibrary.meos.int8_out(val);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String float8_out(double num, int maxdd) {
+		return MeosLibrary.meos.float8_out(num, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double pg_dsin(double arg1) {
+		return MeosLibrary.meos.pg_dsin(arg1);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double pg_dcos(double arg1) {
+		return MeosLibrary.meos.pg_dcos(arg1);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double pg_datan(double arg1) {
+		return MeosLibrary.meos.pg_datan(arg1);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double pg_datan2(double arg1, double arg2) {
+		return MeosLibrary.meos.pg_datan2(arg1, arg2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int pg_date_in(String str) {
+		return MeosLibrary.meos.pg_date_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String pg_date_out(int d) {
+		return MeosLibrary.meos.pg_date_out(d);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int pg_interval_cmp(Pointer interv1, Pointer interv2) {
+		return MeosLibrary.meos.pg_interval_cmp(interv1, interv2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer pg_interval_in(String str, int prec) {
+		return MeosLibrary.meos.pg_interval_in(str, prec);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer pg_interval_justify_hours(Pointer span) {
+		return MeosLibrary.meos.pg_interval_justify_hours(span);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String pg_interval_out(Pointer interv) {
+		return MeosLibrary.meos.pg_interval_out(interv);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long pg_time_in(String str, int typmod) {
+		return MeosLibrary.meos.pg_time_in(str, typmod);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String pg_time_out(long t) {
+		return MeosLibrary.meos.pg_time_out(t);
+	}
+	
+	@SuppressWarnings("unused")
+	public static LocalDateTime pg_timestamp_in(String str, int typmod) {
+		var result = MeosLibrary.meos.pg_timestamp_in(str, typmod);
+		return LocalDateTime.ofEpochSecond(result, 0, ZoneOffset.UTC);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String pg_timestamp_out(LocalDateTime t) {
+		var t_new = t.toEpochSecond(ZoneOffset.UTC);
+		return MeosLibrary.meos.pg_timestamp_out(t_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static OffsetDateTime pg_timestamptz_in(String str, int prec) {
+		var result = MeosLibrary.meos.pg_timestamptz_in(str, prec);
+		Instant instant = Instant.ofEpochSecond(result);
+		return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String pg_timestamptz_out(OffsetDateTime t) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.pg_timestamptz_out(t_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int hash_bytes_uint32(int k) {
+		return MeosLibrary.meos.hash_bytes_uint32(k);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int pg_hashint8(long val) {
+		return MeosLibrary.meos.pg_hashint8(val);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int pg_hashfloat8(double key) {
+		return MeosLibrary.meos.pg_hashfloat8(key);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long hash_bytes_uint32_extended(int k, long seed) {
+		return MeosLibrary.meos.hash_bytes_uint32_extended(k, seed);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long pg_hashint8extended(long val, long seed) {
+		return MeosLibrary.meos.pg_hashint8extended(val, seed);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long pg_hashfloat8extended(double key, long seed) {
+		return MeosLibrary.meos.pg_hashfloat8extended(key, seed);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int pg_hashtext(Pointer key) {
+		return MeosLibrary.meos.pg_hashtext(key);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long pg_hashtextextended(Pointer key, long seed) {
+		return MeosLibrary.meos.pg_hashtextextended(key, seed);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer gsl_get_generation_rng() {
+		return MeosLibrary.meos.gsl_get_generation_rng();
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer gsl_get_aggregation_rng() {
+		return MeosLibrary.meos.gsl_get_aggregation_rng();
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer proj_get_context() {
+		return MeosLibrary.meos.proj_get_context();
+	}
+	
+	@SuppressWarnings("unused")
+	public static long datum_floor(long d) {
+		return MeosLibrary.meos.datum_floor(d);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long datum_ceil(long d) {
+		return MeosLibrary.meos.datum_ceil(d);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long datum_degrees(long d, long normalize) {
+		return MeosLibrary.meos.datum_degrees(d, normalize);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long datum_radians(long d) {
+		return MeosLibrary.meos.datum_radians(d);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int datum_hash(long d, meosType basetype) {
+		return MeosLibrary.meos.datum_hash(d, basetype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long datum_hash_extended(long d, meosType basetype, long seed) {
+		return MeosLibrary.meos.datum_hash_extended(d, basetype, seed);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long datum_float_round(long value, long size) {
+		return MeosLibrary.meos.datum_float_round(value, size);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long datum_geo_round(long value, long size) {
+		return MeosLibrary.meos.datum_geo_round(value, size);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer point_round(Pointer gs, int maxdd) {
+		return MeosLibrary.meos.point_round(gs, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void floatspan_round_set(Pointer s, int maxdd) {
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer SET_BBOX_PTR(Pointer s) {
+		return MeosLibrary.meos.SET_BBOX_PTR(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer SET_OFFSETS_PTR(Pointer s) {
+		return MeosLibrary.meos.SET_OFFSETS_PTR(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long SET_VAL_N(Pointer s, int index) {
+		return MeosLibrary.meos.SET_VAL_N(s, index);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer SPANSET_SP_N(Pointer ss, int index) {
+		return MeosLibrary.meos.SPANSET_SP_N(ss, index);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer TSEQUENCE_OFFSETS_PTR(Pointer seq) {
+		return MeosLibrary.meos.TSEQUENCE_OFFSETS_PTR(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer TSEQUENCE_INST_N(Pointer seq, int index) {
+		return MeosLibrary.meos.TSEQUENCE_INST_N(seq, index);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer TSEQUENCESET_OFFSETS_PTR(Pointer ss) {
+		return MeosLibrary.meos.TSEQUENCESET_OFFSETS_PTR(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer TSEQUENCESET_SEQ_N(Pointer ss, int index) {
+		return MeosLibrary.meos.TSEQUENCESET_SEQ_N(ss, index);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer set_in(String str, meosType basetype) {
+		return MeosLibrary.meos.set_in(str, basetype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String set_out(Pointer s, int maxdd) {
+		return MeosLibrary.meos.set_out(s, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer span_in(String str, meosType spantype) {
+		return MeosLibrary.meos.span_in(str, spantype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String span_out(Pointer s, int maxdd) {
+		return MeosLibrary.meos.span_out(s, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spanset_in(String str, meosType spantype) {
+		return MeosLibrary.meos.spanset_in(str, spantype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String spanset_out(Pointer ss, int maxdd) {
+		return MeosLibrary.meos.spanset_out(ss, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer set_make(Pointer values, int count, meosType basetype, boolean order) {
+		return MeosLibrary.meos.set_make(values, count, basetype, order);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer set_make_exp(Pointer values, int count, int maxcount, meosType basetype, boolean order) {
+		return MeosLibrary.meos.set_make_exp(values, count, maxcount, basetype, order);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer set_make_free(Pointer values, int count, meosType basetype, boolean order) {
+		return MeosLibrary.meos.set_make_free(values, count, basetype, order);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer span_make(long lower, long upper, boolean lower_inc, boolean upper_inc, meosType basetype) {
+		return MeosLibrary.meos.span_make(lower, upper, lower_inc, upper_inc, basetype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void span_set(long lower, long upper, boolean lower_inc, boolean upper_inc, meosType basetype, meosType spantype, Pointer s) {
+		MeosLibrary.meos.span_set(lower, upper, lower_inc, upper_inc, basetype, spantype, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spanset_make_exp(Pointer spans, int count, int maxcount, boolean normalize, boolean order) {
+		return MeosLibrary.meos.spanset_make_exp(spans, count, maxcount, normalize, order);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spanset_make_free(Pointer spans, int count, boolean normalize, boolean order) {
+		return MeosLibrary.meos.spanset_make_free(spans, count, normalize, order);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void value_set_span(long value, meosType basetype, Pointer s) {
+		MeosLibrary.meos.value_set_span(value, basetype, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer value_set(long d, meosType basetype) {
+		return MeosLibrary.meos.value_set(d, basetype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer value_span(long d, meosType basetype) {
+		return MeosLibrary.meos.value_span(d, basetype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer value_spanset(long d, meosType basetype) {
+		return MeosLibrary.meos.value_spanset(d, basetype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long numspan_width(Pointer s) {
+		return MeosLibrary.meos.numspan_width(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long numspanset_width(Pointer ss, boolean boundspan) {
+		return MeosLibrary.meos.numspanset_width(ss, boundspan);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long set_end_value(Pointer s) {
+		return MeosLibrary.meos.set_end_value(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int set_mem_size(Pointer s) {
+		return MeosLibrary.meos.set_mem_size(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void set_set_subspan(Pointer s, int minidx, int maxidx) {
+	}
+	
+	@SuppressWarnings("unused")
+	public static void set_set_span(Pointer s) {
+	}
+	
+	@SuppressWarnings("unused")
+	public static long set_start_value(Pointer s) {
+		return MeosLibrary.meos.set_start_value(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer set_value_n(Pointer s, int n) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.set_value_n(s, n, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer set_vals(Pointer s) {
+		return MeosLibrary.meos.set_vals(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer set_values(Pointer s) {
+		return MeosLibrary.meos.set_values(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long spanset_lower(Pointer ss) {
+		return MeosLibrary.meos.spanset_lower(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int spanset_mem_size(Pointer ss) {
+		return MeosLibrary.meos.spanset_mem_size(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spanset_sps(Pointer ss) {
+		return MeosLibrary.meos.spanset_sps(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long spanset_upper(Pointer ss) {
+		return MeosLibrary.meos.spanset_upper(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void datespan_set_tstzspan(Pointer s1, Pointer s2) {
+		MeosLibrary.meos.datespan_set_tstzspan(s1, s2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void floatspan_set_intspan(Pointer s1, Pointer s2) {
+		MeosLibrary.meos.floatspan_set_intspan(s1, s2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void intspan_set_floatspan(Pointer s1, Pointer s2) {
+		MeosLibrary.meos.intspan_set_floatspan(s1, s2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer numset_shift_scale(Pointer s, long shift, long width, boolean hasshift, boolean haswidth) {
+		return MeosLibrary.meos.numset_shift_scale(s, shift, width, hasshift, haswidth);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer numspan_shift_scale(Pointer s, long shift, long width, boolean hasshift, boolean haswidth) {
+		return MeosLibrary.meos.numspan_shift_scale(s, shift, width, hasshift, haswidth);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer numspanset_shift_scale(Pointer ss, long shift, long width, boolean hasshift, boolean haswidth) {
+		return MeosLibrary.meos.numspanset_shift_scale(ss, shift, width, hasshift, haswidth);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer set_compact(Pointer s) {
+		return MeosLibrary.meos.set_compact(s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void span_expand(Pointer s1, Pointer s2) {
+		MeosLibrary.meos.span_expand(s1, s2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spanset_compact(Pointer ss) {
+		return MeosLibrary.meos.spanset_compact(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer textcat_textset_text_int(Pointer s, Pointer txt, boolean invert) {
+		return MeosLibrary.meos.textcat_textset_text_int(s, txt, invert);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tstzspan_set_datespan(Pointer s1, Pointer s2) {
+		MeosLibrary.meos.tstzspan_set_datespan(s1, s2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean adjacent_span_value(Pointer s, long value) {
+		return MeosLibrary.meos.adjacent_span_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean adjacent_spanset_value(Pointer ss, long value) {
+		return MeosLibrary.meos.adjacent_spanset_value(ss, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean adjacent_value_spanset(long value, Pointer ss) {
+		return MeosLibrary.meos.adjacent_value_spanset(value, ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contained_value_set(long value, Pointer s) {
+		return MeosLibrary.meos.contained_value_set(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contained_value_span(long value, Pointer s) {
+		return MeosLibrary.meos.contained_value_span(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contained_value_spanset(long value, Pointer ss) {
+		return MeosLibrary.meos.contained_value_spanset(value, ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contains_set_value(Pointer s, long value) {
+		return MeosLibrary.meos.contains_set_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contains_span_value(Pointer s, long value) {
+		return MeosLibrary.meos.contains_span_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean contains_spanset_value(Pointer ss, long value) {
+		return MeosLibrary.meos.contains_spanset_value(ss, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean ovadj_span_span(Pointer s1, Pointer s2) {
+		return MeosLibrary.meos.ovadj_span_span(s1, s2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean left_set_value(Pointer s, long value) {
+		return MeosLibrary.meos.left_set_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean left_span_value(Pointer s, long value) {
+		return MeosLibrary.meos.left_span_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean left_spanset_value(Pointer ss, long value) {
+		return MeosLibrary.meos.left_spanset_value(ss, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean left_value_set(long value, Pointer s) {
+		return MeosLibrary.meos.left_value_set(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean left_value_span(long value, Pointer s) {
+		return MeosLibrary.meos.left_value_span(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean left_value_spanset(long value, Pointer ss) {
+		return MeosLibrary.meos.left_value_spanset(value, ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean lfnadj_span_span(Pointer s1, Pointer s2) {
+		return MeosLibrary.meos.lfnadj_span_span(s1, s2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overleft_set_value(Pointer s, long value) {
+		return MeosLibrary.meos.overleft_set_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overleft_span_value(Pointer s, long value) {
+		return MeosLibrary.meos.overleft_span_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overleft_spanset_value(Pointer ss, long value) {
+		return MeosLibrary.meos.overleft_spanset_value(ss, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overleft_value_set(long value, Pointer s) {
+		return MeosLibrary.meos.overleft_value_set(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overleft_value_span(long value, Pointer s) {
+		return MeosLibrary.meos.overleft_value_span(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overleft_value_spanset(long value, Pointer ss) {
+		return MeosLibrary.meos.overleft_value_spanset(value, ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overright_set_value(Pointer s, long value) {
+		return MeosLibrary.meos.overright_set_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overright_span_value(Pointer s, long value) {
+		return MeosLibrary.meos.overright_span_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overright_spanset_value(Pointer ss, long value) {
+		return MeosLibrary.meos.overright_spanset_value(ss, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overright_value_set(long value, Pointer s) {
+		return MeosLibrary.meos.overright_value_set(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overright_value_span(long value, Pointer s) {
+		return MeosLibrary.meos.overright_value_span(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean overright_value_spanset(long value, Pointer ss) {
+		return MeosLibrary.meos.overright_value_spanset(value, ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean right_value_set(long value, Pointer s) {
+		return MeosLibrary.meos.right_value_set(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean right_set_value(Pointer s, long value) {
+		return MeosLibrary.meos.right_set_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean right_value_span(long value, Pointer s) {
+		return MeosLibrary.meos.right_value_span(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean right_value_spanset(long value, Pointer ss) {
+		return MeosLibrary.meos.right_value_spanset(value, ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean right_span_value(Pointer s, long value) {
+		return MeosLibrary.meos.right_span_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean right_spanset_value(Pointer ss, long value) {
+		return MeosLibrary.meos.right_spanset_value(ss, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void bbox_union_span_span(Pointer s1, Pointer s2) {
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer inter_span_span(Pointer s1, Pointer s2) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.inter_span_span(s1, s2, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer intersection_set_value(Pointer s, long value) {
+		return MeosLibrary.meos.intersection_set_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer intersection_span_value(Pointer s, long value) {
+		return MeosLibrary.meos.intersection_span_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer intersection_spanset_value(Pointer ss, long value) {
+		return MeosLibrary.meos.intersection_spanset_value(ss, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer intersection_value_set(long value, Pointer s) {
+		return MeosLibrary.meos.intersection_value_set(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer intersection_value_span(long value, Pointer s) {
+		return MeosLibrary.meos.intersection_value_span(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer intersection_value_spanset(long value, Pointer ss) {
+		return MeosLibrary.meos.intersection_value_spanset(value, ss);
+	}
+	/** 
+	@SuppressWarnings("unused")
+	public static int mi_span_span(Pointer s1, Pointer s2) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.mi_span_span(s1, s2, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	*/
+	@SuppressWarnings("unused")
+	public static Pointer minus_set_value(Pointer s, long value) {
+		return MeosLibrary.meos.minus_set_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer minus_span_value(Pointer s, long value) {
+		return MeosLibrary.meos.minus_span_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer minus_spanset_value(Pointer ss, long value) {
+		return MeosLibrary.meos.minus_spanset_value(ss, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer minus_value_set(long value, Pointer s) {
+		return MeosLibrary.meos.minus_value_set(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer minus_value_span(long value, Pointer s) {
+		return MeosLibrary.meos.minus_value_span(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer minus_value_spanset(long value, Pointer ss) {
+		return MeosLibrary.meos.minus_value_spanset(value, ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer super_union_span_span(Pointer s1, Pointer s2) {
+		return MeosLibrary.meos.super_union_span_span(s1, s2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer union_set_value(Pointer s, long value) {
+		return MeosLibrary.meos.union_set_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer union_span_value(Pointer s, long value) {
+		return MeosLibrary.meos.union_span_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer union_spanset_value(Pointer ss, long value) {
+		return MeosLibrary.meos.union_spanset_value(ss, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer union_value_set(long value, Pointer s) {
+		return MeosLibrary.meos.union_value_set(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer union_value_span(long value, Pointer s) {
+		return MeosLibrary.meos.union_value_span(value, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer union_value_spanset(long value, Pointer ss) {
+		return MeosLibrary.meos.union_value_spanset(value, ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long distance_set_set(Pointer s1, Pointer s2) {
+		return MeosLibrary.meos.distance_set_set(s1, s2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long distance_set_value(Pointer s, long value) {
+		return MeosLibrary.meos.distance_set_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long distance_span_span(Pointer s1, Pointer s2) {
+		return MeosLibrary.meos.distance_span_span(s1, s2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long distance_span_value(Pointer s, long value) {
+		return MeosLibrary.meos.distance_span_value(s, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long distance_spanset_span(Pointer ss, Pointer s) {
+		return MeosLibrary.meos.distance_spanset_span(ss, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long distance_spanset_spanset(Pointer ss1, Pointer ss2) {
+		return MeosLibrary.meos.distance_spanset_spanset(ss1, ss2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long distance_spanset_value(Pointer ss, long value) {
+		return MeosLibrary.meos.distance_spanset_value(ss, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long distance_value_value(long l, long r, meosType basetype) {
+		return MeosLibrary.meos.distance_value_value(l, r, basetype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spanbase_extent_transfn(Pointer state, long value, meosType basetype) {
+		return MeosLibrary.meos.spanbase_extent_transfn(state, value, basetype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer value_union_transfn(Pointer state, long value, meosType basetype) {
+		return MeosLibrary.meos.value_union_transfn(state, value, basetype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer number_tstzspan_to_tbox(long d, meosType basetype, Pointer s) {
+		return MeosLibrary.meos.number_tstzspan_to_tbox(d, basetype, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer number_timestamptz_to_tbox(long d, meosType basetype, OffsetDateTime t) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.number_timestamptz_to_tbox(d, basetype, t_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void stbox_set(boolean hasx, boolean hasz, boolean geodetic, int srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, Pointer s, Pointer box) {
+		MeosLibrary.meos.stbox_set(hasx, hasz, geodetic, srid, xmin, xmax, ymin, ymax, zmin, zmax, s, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tbox_set(Pointer s, Pointer p, Pointer box) {
+		MeosLibrary.meos.tbox_set(s, p, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer box3d_stbox(Pointer box) {
+		return MeosLibrary.meos.box3d_stbox(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer gbox_stbox(Pointer box) {
+		return MeosLibrary.meos.gbox_stbox(box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void float_set_tbox(double d, Pointer box) {
+		MeosLibrary.meos.float_set_tbox(d, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void gbox_set_stbox(Pointer box, int srid) {
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean geo_set_stbox(Pointer gs, Pointer box) {
+		return MeosLibrary.meos.geo_set_stbox(gs, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void geoarr_set_stbox(Pointer values, int count, Pointer box) {
+		MeosLibrary.meos.geoarr_set_stbox(values, count, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void int_set_tbox(int i, Pointer box) {
+		MeosLibrary.meos.int_set_tbox(i, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void number_set_tbox(long d, meosType basetype, Pointer box) {
+		MeosLibrary.meos.number_set_tbox(d, basetype, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer number_tbox(long value, meosType basetype) {
+		return MeosLibrary.meos.number_tbox(value, basetype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void numset_set_tbox(Pointer s, Pointer box) {
+		MeosLibrary.meos.numset_set_tbox(s, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void numspan_set_tbox(Pointer span, Pointer box) {
+		MeosLibrary.meos.numspan_set_tbox(span, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void numspanset_set_tbox(Pointer ss, Pointer box) {
+		MeosLibrary.meos.numspanset_set_tbox(ss, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean spatial_set_stbox(long d, meosType basetype, Pointer box) {
+		return MeosLibrary.meos.spatial_set_stbox(d, basetype, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void spatialset_set_stbox(Pointer set, Pointer box) {
+		MeosLibrary.meos.spatialset_set_stbox(set, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void stbox_set_box3d(Pointer box, Pointer box3d) {
+		MeosLibrary.meos.stbox_set_box3d(box, box3d);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void stbox_set_gbox(Pointer box, Pointer gbox) {
+		MeosLibrary.meos.stbox_set_gbox(box, gbox);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void timestamptz_set_stbox(OffsetDateTime t, Pointer box) {
+		var t_new = t.toEpochSecond();
+		MeosLibrary.meos.timestamptz_set_stbox(t_new, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void timestamptz_set_tbox(OffsetDateTime t, Pointer box) {
+		var t_new = t.toEpochSecond();
+		MeosLibrary.meos.timestamptz_set_tbox(t_new, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tstzset_set_stbox(Pointer s, Pointer box) {
+		MeosLibrary.meos.tstzset_set_stbox(s, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tstzset_set_tbox(Pointer s, Pointer box) {
+		MeosLibrary.meos.tstzset_set_tbox(s, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tstzspan_set_stbox(Pointer s, Pointer box) {
+		MeosLibrary.meos.tstzspan_set_stbox(s, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tstzspan_set_tbox(Pointer s, Pointer box) {
+		MeosLibrary.meos.tstzspan_set_tbox(s, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tstzspanset_set_stbox(Pointer ss, Pointer box) {
+		MeosLibrary.meos.tstzspanset_set_stbox(ss, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tstzspanset_set_tbox(Pointer ss, Pointer box) {
+		MeosLibrary.meos.tstzspanset_set_tbox(ss, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tbox_shift_scale_value(Pointer box, long shift, long width, boolean hasshift, boolean haswidth) {
+		return MeosLibrary.meos.tbox_shift_scale_value(box, shift, width, hasshift, haswidth);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void stbox_expand(Pointer box1, Pointer box2) {
+		MeosLibrary.meos.stbox_expand(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tbox_expand(Pointer box1, Pointer box2) {
+		MeosLibrary.meos.tbox_expand(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer inter_stbox_stbox(Pointer box1, Pointer box2) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.inter_stbox_stbox(box1, box2, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer inter_tbox_tbox(Pointer box1, Pointer box2) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.inter_tbox_tbox(box1, box2, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tboolinst_as_mfjson(Pointer inst, boolean with_bbox) {
+		return MeosLibrary.meos.tboolinst_as_mfjson(inst, with_bbox);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tboolinst_from_mfjson(Pointer mfjson) {
+		return MeosLibrary.meos.tboolinst_from_mfjson(mfjson);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tboolinst_in(String str) {
+		return MeosLibrary.meos.tboolinst_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tboolseq_as_mfjson(Pointer seq, boolean with_bbox) {
+		return MeosLibrary.meos.tboolseq_as_mfjson(seq, with_bbox);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tboolseq_from_mfjson(Pointer mfjson) {
+		return MeosLibrary.meos.tboolseq_from_mfjson(mfjson);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tboolseq_in(String str, int interp) {
+		return MeosLibrary.meos.tboolseq_in(str, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tboolseqset_as_mfjson(Pointer ss, boolean with_bbox) {
+		return MeosLibrary.meos.tboolseqset_as_mfjson(ss, with_bbox);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tboolseqset_from_mfjson(Pointer mfjson) {
+		return MeosLibrary.meos.tboolseqset_from_mfjson(mfjson);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tboolseqset_in(String str) {
+		return MeosLibrary.meos.tboolseqset_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_in(String str, meosType temptype) {
+		return MeosLibrary.meos.temporal_in(str, temptype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String temporal_out(Pointer temp, int maxdd) {
+		return MeosLibrary.meos.temporal_out(temp, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temparr_out(Pointer temparr, int count, int maxdd) {
+		return MeosLibrary.meos.temparr_out(temparr, count, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tfloatinst_as_mfjson(Pointer inst, boolean with_bbox, int precision) {
+		return MeosLibrary.meos.tfloatinst_as_mfjson(inst, with_bbox, precision);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloatinst_from_mfjson(Pointer mfjson) {
+		return MeosLibrary.meos.tfloatinst_from_mfjson(mfjson);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloatinst_in(String str) {
+		return MeosLibrary.meos.tfloatinst_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tfloatseq_as_mfjson(Pointer seq, boolean with_bbox, int precision) {
+		return MeosLibrary.meos.tfloatseq_as_mfjson(seq, with_bbox, precision);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloatseq_from_mfjson(Pointer mfjson, int interp) {
+		return MeosLibrary.meos.tfloatseq_from_mfjson(mfjson, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloatseq_in(String str, int interp) {
+		return MeosLibrary.meos.tfloatseq_in(str, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tfloatseqset_as_mfjson(Pointer ss, boolean with_bbox, int precision) {
+		return MeosLibrary.meos.tfloatseqset_as_mfjson(ss, with_bbox, precision);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloatseqset_from_mfjson(Pointer mfjson, int interp) {
+		return MeosLibrary.meos.tfloatseqset_from_mfjson(mfjson, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloatseqset_in(String str) {
+		return MeosLibrary.meos.tfloatseqset_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tgeoinst_as_mfjson(Pointer inst, boolean with_bbox, int precision, String srs) {
+		return MeosLibrary.meos.tgeoinst_as_mfjson(inst, with_bbox, precision, srs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeogpointinst_from_mfjson(Pointer mfjson, int srid) {
+		return MeosLibrary.meos.tgeogpointinst_from_mfjson(mfjson, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeogpointinst_in(String str) {
+		return MeosLibrary.meos.tgeogpointinst_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeogpointseq_from_mfjson(Pointer mfjson, int srid, int interp) {
+		return MeosLibrary.meos.tgeogpointseq_from_mfjson(mfjson, srid, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeogpointseq_in(String str, int interp) {
+		return MeosLibrary.meos.tgeogpointseq_in(str, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeogpointseqset_from_mfjson(Pointer mfjson, int srid, int interp) {
+		return MeosLibrary.meos.tgeogpointseqset_from_mfjson(mfjson, srid, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeogpointseqset_in(String str) {
+		return MeosLibrary.meos.tgeogpointseqset_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeompointinst_from_mfjson(Pointer mfjson, int srid) {
+		return MeosLibrary.meos.tgeompointinst_from_mfjson(mfjson, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeompointinst_in(String str) {
+		return MeosLibrary.meos.tgeompointinst_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeompointseq_from_mfjson(Pointer mfjson, int srid, int interp) {
+		return MeosLibrary.meos.tgeompointseq_from_mfjson(mfjson, srid, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeompointseq_in(String str, int interp) {
+		return MeosLibrary.meos.tgeompointseq_in(str, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeompointseqset_from_mfjson(Pointer mfjson, int srid, int interp) {
+		return MeosLibrary.meos.tgeompointseqset_from_mfjson(mfjson, srid, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeompointseqset_in(String str) {
+		return MeosLibrary.meos.tgeompointseqset_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeographyinst_from_mfjson(Pointer mfjson, int srid) {
+		return MeosLibrary.meos.tgeographyinst_from_mfjson(mfjson, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeographyinst_in(String str) {
+		return MeosLibrary.meos.tgeographyinst_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeographyseq_from_mfjson(Pointer mfjson, int srid, int interp) {
+		return MeosLibrary.meos.tgeographyseq_from_mfjson(mfjson, srid, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeographyseq_in(String str, int interp) {
+		return MeosLibrary.meos.tgeographyseq_in(str, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeographyseqset_from_mfjson(Pointer mfjson, int srid, int interp) {
+		return MeosLibrary.meos.tgeographyseqset_from_mfjson(mfjson, srid, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeographyseqset_in(String str) {
+		return MeosLibrary.meos.tgeographyseqset_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeometryinst_from_mfjson(Pointer mfjson, int srid) {
+		return MeosLibrary.meos.tgeometryinst_from_mfjson(mfjson, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeometryinst_in(String str) {
+		return MeosLibrary.meos.tgeometryinst_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeometryseq_from_mfjson(Pointer mfjson, int srid, int interp) {
+		return MeosLibrary.meos.tgeometryseq_from_mfjson(mfjson, srid, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeometryseq_in(String str, int interp) {
+		return MeosLibrary.meos.tgeometryseq_in(str, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeometryseqset_from_mfjson(Pointer mfjson, int srid, int interp) {
+		return MeosLibrary.meos.tgeometryseqset_from_mfjson(mfjson, srid, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeometryseqset_in(String str) {
+		return MeosLibrary.meos.tgeometryseqset_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tgeoseq_as_mfjson(Pointer seq, boolean with_bbox, int precision, String srs) {
+		return MeosLibrary.meos.tgeoseq_as_mfjson(seq, with_bbox, precision, srs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tgeoseqset_as_mfjson(Pointer ss, boolean with_bbox, int precision, String srs) {
+		return MeosLibrary.meos.tgeoseqset_as_mfjson(ss, with_bbox, precision, srs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_from_mfjson(Pointer mfjson, boolean isgeo, int srid, meosType temptype) {
+		return MeosLibrary.meos.tinstant_from_mfjson(mfjson, isgeo, srid, temptype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_in(String str, meosType temptype) {
+		return MeosLibrary.meos.tinstant_in(str, temptype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tinstant_out(Pointer inst, int maxdd) {
+		return MeosLibrary.meos.tinstant_out(inst, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tintinst_as_mfjson(Pointer inst, boolean with_bbox) {
+		return MeosLibrary.meos.tintinst_as_mfjson(inst, with_bbox);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintinst_from_mfjson(Pointer mfjson) {
+		return MeosLibrary.meos.tintinst_from_mfjson(mfjson);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintinst_in(String str) {
+		return MeosLibrary.meos.tintinst_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tintseq_as_mfjson(Pointer seq, boolean with_bbox) {
+		return MeosLibrary.meos.tintseq_as_mfjson(seq, with_bbox);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintseq_from_mfjson(Pointer mfjson) {
+		return MeosLibrary.meos.tintseq_from_mfjson(mfjson);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintseq_in(String str, int interp) {
+		return MeosLibrary.meos.tintseq_in(str, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tintseqset_as_mfjson(Pointer ss, boolean with_bbox) {
+		return MeosLibrary.meos.tintseqset_as_mfjson(ss, with_bbox);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintseqset_from_mfjson(Pointer mfjson) {
+		return MeosLibrary.meos.tintseqset_from_mfjson(mfjson);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tintseqset_in(String str) {
+		return MeosLibrary.meos.tintseqset_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tpointinst_as_mfjson(Pointer inst, boolean with_bbox, int precision, String srs) {
+		return MeosLibrary.meos.tpointinst_as_mfjson(inst, with_bbox, precision, srs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tpointseq_as_mfjson(Pointer seq, boolean with_bbox, int precision, String srs) {
+		return MeosLibrary.meos.tpointseq_as_mfjson(seq, with_bbox, precision, srs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tpointseqset_as_mfjson(Pointer ss, boolean with_bbox, int precision, String srs) {
+		return MeosLibrary.meos.tpointseqset_as_mfjson(ss, with_bbox, precision, srs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_from_mfjson(Pointer mfjson, boolean isgeo, int srid, meosType temptype, int interp) {
+		return MeosLibrary.meos.tsequence_from_mfjson(mfjson, isgeo, srid, temptype, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_in(String str, meosType temptype, int interp) {
+		return MeosLibrary.meos.tsequence_in(str, temptype, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tsequence_out(Pointer seq, int maxdd) {
+		return MeosLibrary.meos.tsequence_out(seq, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_from_mfjson(Pointer mfjson, boolean isgeo, int srid, meosType temptype, int interp) {
+		return MeosLibrary.meos.tsequenceset_from_mfjson(mfjson, isgeo, srid, temptype, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_in(String str, meosType temptype, int interp) {
+		return MeosLibrary.meos.tsequenceset_in(str, temptype, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String tsequenceset_out(Pointer ss, int maxdd) {
+		return MeosLibrary.meos.tsequenceset_out(ss, maxdd);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String ttextinst_as_mfjson(Pointer inst, boolean with_bbox) {
+		return MeosLibrary.meos.ttextinst_as_mfjson(inst, with_bbox);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer ttextinst_from_mfjson(Pointer mfjson) {
+		return MeosLibrary.meos.ttextinst_from_mfjson(mfjson);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer ttextinst_in(String str) {
+		return MeosLibrary.meos.ttextinst_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String ttextseq_as_mfjson(Pointer seq, boolean with_bbox) {
+		return MeosLibrary.meos.ttextseq_as_mfjson(seq, with_bbox);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer ttextseq_from_mfjson(Pointer mfjson) {
+		return MeosLibrary.meos.ttextseq_from_mfjson(mfjson);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer ttextseq_in(String str, int interp) {
+		return MeosLibrary.meos.ttextseq_in(str, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String ttextseqset_as_mfjson(Pointer ss, boolean with_bbox) {
+		return MeosLibrary.meos.ttextseqset_as_mfjson(ss, with_bbox);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer ttextseqset_from_mfjson(Pointer mfjson) {
+		return MeosLibrary.meos.ttextseqset_from_mfjson(mfjson);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer ttextseqset_in(String str) {
+		return MeosLibrary.meos.ttextseqset_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_from_mfjson(String mfjson, meosType temptype) {
+		return MeosLibrary.meos.temporal_from_mfjson(mfjson, temptype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_from_base_temp(long value, meosType temptype, Pointer temp) {
+		return MeosLibrary.meos.temporal_from_base_temp(value, temptype, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_copy(Pointer inst) {
+		return MeosLibrary.meos.tinstant_copy(inst);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_make(long value, meosType temptype, OffsetDateTime t) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.tinstant_make(value, temptype, t_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_make_free(long value, meosType temptype, OffsetDateTime t) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.tinstant_make_free(value, temptype, t_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseq_make_coords(Pointer xcoords, Pointer ycoords, Pointer zcoords, Pointer times, int count, int srid, boolean geodetic, boolean lower_inc, boolean upper_inc, int interp, boolean normalize) {
+		return MeosLibrary.meos.tpointseq_make_coords(xcoords, ycoords, zcoords, times, count, srid, geodetic, lower_inc, upper_inc, interp, normalize);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_copy(Pointer seq) {
+		return MeosLibrary.meos.tsequence_copy(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_from_base_tstzset(long value, meosType temptype, Pointer ss) {
+		return MeosLibrary.meos.tsequence_from_base_tstzset(value, temptype, ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_from_base_tstzspan(long value, meosType temptype, Pointer s, int interp) {
+		return MeosLibrary.meos.tsequence_from_base_tstzspan(value, temptype, s, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_make_exp(Pointer instants, int count, int maxcount, boolean lower_inc, boolean upper_inc, int interp, boolean normalize) {
+		return MeosLibrary.meos.tsequence_make_exp(instants, count, maxcount, lower_inc, upper_inc, interp, normalize);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_make_free(Pointer instants, int count, boolean lower_inc, boolean upper_inc, int interp, boolean normalize) {
+		return MeosLibrary.meos.tsequence_make_free(instants, count, lower_inc, upper_inc, interp, normalize);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_copy(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_copy(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tseqsetarr_to_tseqset(Pointer seqsets, int count, int totalseqs) {
+		return MeosLibrary.meos.tseqsetarr_to_tseqset(seqsets, count, totalseqs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_from_base_tstzspanset(long value, meosType temptype, Pointer ss, int interp) {
+		return MeosLibrary.meos.tsequenceset_from_base_tstzspanset(value, temptype, ss, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_make_exp(Pointer sequences, int count, int maxcount, boolean normalize) {
+		return MeosLibrary.meos.tsequenceset_make_exp(sequences, count, maxcount, normalize);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_make_free(Pointer sequences, int count, boolean normalize) {
+		return MeosLibrary.meos.tsequenceset_make_free(sequences, count, normalize);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void temporal_set_tstzspan(Pointer temp, Pointer s) {
+		MeosLibrary.meos.temporal_set_tstzspan(temp, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tinstant_set_tstzspan(Pointer inst, Pointer s) {
+		MeosLibrary.meos.tinstant_set_tstzspan(inst, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tnumber_set_tbox(Pointer temp, Pointer box) {
+		MeosLibrary.meos.tnumber_set_tbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tnumberinst_set_tbox(Pointer inst, Pointer box) {
+		MeosLibrary.meos.tnumberinst_set_tbox(inst, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tnumberseq_set_tbox(Pointer seq, Pointer box) {
+		MeosLibrary.meos.tnumberseq_set_tbox(seq, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tnumberseqset_set_tbox(Pointer ss, Pointer box) {
+		MeosLibrary.meos.tnumberseqset_set_tbox(ss, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tsequence_set_tstzspan(Pointer seq, Pointer s) {
+		MeosLibrary.meos.tsequence_set_tstzspan(seq, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tsequenceset_set_tstzspan(Pointer ss, Pointer s) {
+		MeosLibrary.meos.tsequenceset_set_tstzspan(ss, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_end_inst(Pointer temp) {
+		return MeosLibrary.meos.temporal_end_inst(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long temporal_end_value(Pointer temp) {
+		return MeosLibrary.meos.temporal_end_value(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_inst_n(Pointer temp, int n) {
+		return MeosLibrary.meos.temporal_inst_n(temp, n);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_instants_p(Pointer temp, Pointer count) {
+		return MeosLibrary.meos.temporal_instants_p(temp, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long temporal_max_value(Pointer temp) {
+		return MeosLibrary.meos.temporal_max_value(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long temporal_mem_size(Pointer temp) {
+		return MeosLibrary.meos.temporal_mem_size(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long temporal_min_value(Pointer temp) {
+		return MeosLibrary.meos.temporal_min_value(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_sequences_p(Pointer temp, Pointer count) {
+		return MeosLibrary.meos.temporal_sequences_p(temp, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void temporal_set_bbox(Pointer temp, Pointer box) {
+		MeosLibrary.meos.temporal_set_bbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_start_inst(Pointer temp) {
+		return MeosLibrary.meos.temporal_start_inst(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long temporal_start_value(Pointer temp) {
+		return MeosLibrary.meos.temporal_start_value(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_values_p(Pointer temp, Pointer count) {
+		return MeosLibrary.meos.temporal_values_p(temp, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_value_n(Pointer temp, int n) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.temporal_value_n(temp, n, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_values(Pointer temp, Pointer count) {
+		return MeosLibrary.meos.temporal_values(temp, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int tinstant_hash(Pointer inst) {
+		return MeosLibrary.meos.tinstant_hash(inst);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_insts(Pointer inst, Pointer count) {
+		return MeosLibrary.meos.tinstant_insts(inst, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tinstant_set_bbox(Pointer inst, Pointer box) {
+		MeosLibrary.meos.tinstant_set_bbox(inst, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_time(Pointer inst) {
+		return MeosLibrary.meos.tinstant_time(inst);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_timestamps(Pointer inst, Pointer count) {
+		return MeosLibrary.meos.tinstant_timestamps(inst, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long tinstant_value_p(Pointer inst) {
+		return MeosLibrary.meos.tinstant_value_p(inst);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long tinstant_value(Pointer inst) {
+		return MeosLibrary.meos.tinstant_value(inst);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_value_at_timestamptz(Pointer inst, OffsetDateTime t) {
+		var t_new = t.toEpochSecond();
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.tinstant_value_at_timestamptz(inst, t_new, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_values_p(Pointer inst, Pointer count) {
+		return MeosLibrary.meos.tinstant_values_p(inst, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tnumber_set_span(Pointer temp, Pointer span) {
+		MeosLibrary.meos.tnumber_set_span(temp, span);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberinst_valuespans(Pointer inst) {
+		return MeosLibrary.meos.tnumberinst_valuespans(inst);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberseq_valuespans(Pointer seq) {
+		return MeosLibrary.meos.tnumberseq_valuespans(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberseqset_valuespans(Pointer ss) {
+		return MeosLibrary.meos.tnumberseqset_valuespans(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_duration(Pointer seq) {
+		return MeosLibrary.meos.tsequence_duration(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static OffsetDateTime tsequence_end_timestamptz(Pointer seq) {
+		var result = MeosLibrary.meos.tsequence_end_timestamptz(seq);
+		Instant instant = Instant.ofEpochSecond(result);
+		return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int tsequence_hash(Pointer seq) {
+		return MeosLibrary.meos.tsequence_hash(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_instants_p(Pointer seq) {
+		return MeosLibrary.meos.tsequence_instants_p(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_max_inst(Pointer seq) {
+		return MeosLibrary.meos.tsequence_max_inst(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long tsequence_max_val(Pointer seq) {
+		return MeosLibrary.meos.tsequence_max_val(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_min_inst(Pointer seq) {
+		return MeosLibrary.meos.tsequence_min_inst(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long tsequence_min_val(Pointer seq) {
+		return MeosLibrary.meos.tsequence_min_val(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_segments(Pointer seq, Pointer count) {
+		return MeosLibrary.meos.tsequence_segments(seq, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_seqs(Pointer seq, Pointer count) {
+		return MeosLibrary.meos.tsequence_seqs(seq, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static OffsetDateTime tsequence_start_timestamptz(Pointer seq) {
+		var result = MeosLibrary.meos.tsequence_start_timestamptz(seq);
+		Instant instant = Instant.ofEpochSecond(result);
+		return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_time(Pointer seq) {
+		return MeosLibrary.meos.tsequence_time(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_timestamps(Pointer seq, Pointer count) {
+		return MeosLibrary.meos.tsequence_timestamps(seq, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_value_at_timestamptz(Pointer seq, OffsetDateTime t, boolean strict) {
+		var t_new = t.toEpochSecond();
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.tsequence_value_at_timestamptz(seq, t_new, strict, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_values_p(Pointer seq, Pointer count) {
+		return MeosLibrary.meos.tsequence_values_p(seq, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_duration(Pointer ss, boolean boundspan) {
+		return MeosLibrary.meos.tsequenceset_duration(ss, boundspan);
+	}
+	
+	@SuppressWarnings("unused")
+	public static OffsetDateTime tsequenceset_end_timestamptz(Pointer ss) {
+		var result = MeosLibrary.meos.tsequenceset_end_timestamptz(ss);
+		Instant instant = Instant.ofEpochSecond(result);
+		return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int tsequenceset_hash(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_hash(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_inst_n(Pointer ss, int n) {
+		return MeosLibrary.meos.tsequenceset_inst_n(ss, n);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_insts(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_insts(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_max_inst(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_max_inst(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long tsequenceset_max_val(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_max_val(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_min_inst(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_min_inst(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long tsequenceset_min_val(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_min_val(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int tsequenceset_num_instants(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_num_instants(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int tsequenceset_num_timestamps(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_num_timestamps(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_segments(Pointer ss, Pointer count) {
+		return MeosLibrary.meos.tsequenceset_segments(ss, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_sequences_p(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_sequences_p(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static OffsetDateTime tsequenceset_start_timestamptz(Pointer ss) {
+		var result = MeosLibrary.meos.tsequenceset_start_timestamptz(ss);
+		Instant instant = Instant.ofEpochSecond(result);
+		return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_time(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_time(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_timestamptz_n(Pointer ss, int n) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.tsequenceset_timestamptz_n(ss, n, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_timestamps(Pointer ss, Pointer count) {
+		return MeosLibrary.meos.tsequenceset_timestamps(ss, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_value_at_timestamptz(Pointer ss, OffsetDateTime t, boolean strict) {
+		var t_new = t.toEpochSecond();
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.tsequenceset_value_at_timestamptz(ss, t_new, strict, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_value_n(Pointer ss, int n) {
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.tsequenceset_value_n(ss, n, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_values_p(Pointer ss, Pointer count) {
+		return MeosLibrary.meos.tsequenceset_values_p(ss, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void temporal_restart(Pointer temp, int count) {
+		MeosLibrary.meos.temporal_restart(temp, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_tsequence(Pointer temp, int interp) {
+		return MeosLibrary.meos.temporal_tsequence(temp, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_tsequenceset(Pointer temp, int interp) {
+		return MeosLibrary.meos.temporal_tsequenceset(temp, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_shift_time(Pointer inst, Pointer interv) {
+		return MeosLibrary.meos.tinstant_shift_time(inst, interv);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_to_tsequence(Pointer inst, int interp) {
+		return MeosLibrary.meos.tinstant_to_tsequence(inst, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_to_tsequence_free(Pointer inst, int interp) {
+		return MeosLibrary.meos.tinstant_to_tsequence_free(inst, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_to_tsequenceset(Pointer inst, int interp) {
+		return MeosLibrary.meos.tinstant_to_tsequenceset(inst, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumber_shift_scale_value(Pointer temp, long shift, long width, boolean hasshift, boolean haswidth) {
+		return MeosLibrary.meos.tnumber_shift_scale_value(temp, shift, width, hasshift, haswidth);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberinst_shift_value(Pointer inst, long shift) {
+		return MeosLibrary.meos.tnumberinst_shift_value(inst, shift);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberseq_shift_scale_value(Pointer seq, long shift, long width, boolean hasshift, boolean haswidth) {
+		return MeosLibrary.meos.tnumberseq_shift_scale_value(seq, shift, width, hasshift, haswidth);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberseqset_shift_scale_value(Pointer ss, long start, long width, boolean hasshift, boolean haswidth) {
+		return MeosLibrary.meos.tnumberseqset_shift_scale_value(ss, start, width, hasshift, haswidth);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tsequence_restart(Pointer seq, int count) {
+		MeosLibrary.meos.tsequence_restart(seq, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_set_interp(Pointer seq, int interp) {
+		return MeosLibrary.meos.tsequence_set_interp(seq, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_shift_scale_time(Pointer seq, Pointer shift, Pointer duration) {
+		return MeosLibrary.meos.tsequence_shift_scale_time(seq, shift, duration);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_subseq(Pointer seq, int from, int to, boolean lower_inc, boolean upper_inc) {
+		return MeosLibrary.meos.tsequence_subseq(seq, from, to, lower_inc, upper_inc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_to_tinstant(Pointer seq) {
+		return MeosLibrary.meos.tsequence_to_tinstant(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_to_tsequenceset(Pointer seq) {
+		return MeosLibrary.meos.tsequence_to_tsequenceset(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_to_tsequenceset_free(Pointer seq) {
+		return MeosLibrary.meos.tsequence_to_tsequenceset_free(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_to_tsequenceset_interp(Pointer seq, int interp) {
+		return MeosLibrary.meos.tsequence_to_tsequenceset_interp(seq, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tsequenceset_restart(Pointer ss, int count) {
+		MeosLibrary.meos.tsequenceset_restart(ss, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_set_interp(Pointer ss, int interp) {
+		return MeosLibrary.meos.tsequenceset_set_interp(ss, interp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_shift_scale_time(Pointer ss, Pointer start, Pointer duration) {
+		return MeosLibrary.meos.tsequenceset_shift_scale_time(ss, start, duration);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_to_discrete(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_to_discrete(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_to_linear(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_to_linear(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_to_step(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_to_step(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_to_tinstant(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_to_tinstant(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_to_tsequence(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_to_tsequence(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_merge(Pointer inst1, Pointer inst2) {
+		return MeosLibrary.meos.tinstant_merge(inst1, inst2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_merge_array(Pointer instants, int count) {
+		return MeosLibrary.meos.tinstant_merge_array(instants, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_append_tinstant(Pointer seq, Pointer inst, double maxdist, Pointer maxt, boolean expand) {
+		return MeosLibrary.meos.tsequence_append_tinstant(seq, inst, maxdist, maxt, expand);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_append_tsequence(Pointer seq1, Pointer seq2, boolean expand) {
+		return MeosLibrary.meos.tsequence_append_tsequence(seq1, seq2, expand);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_delete_timestamptz(Pointer seq, OffsetDateTime t, boolean connect) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.tsequence_delete_timestamptz(seq, t_new, connect);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_delete_tstzset(Pointer seq, Pointer s, boolean connect) {
+		return MeosLibrary.meos.tsequence_delete_tstzset(seq, s, connect);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_delete_tstzspan(Pointer seq, Pointer s, boolean connect) {
+		return MeosLibrary.meos.tsequence_delete_tstzspan(seq, s, connect);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_delete_tstzspanset(Pointer seq, Pointer ss, boolean connect) {
+		return MeosLibrary.meos.tsequence_delete_tstzspanset(seq, ss, connect);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_insert(Pointer seq1, Pointer seq2, boolean connect) {
+		return MeosLibrary.meos.tsequence_insert(seq1, seq2, connect);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_merge(Pointer seq1, Pointer seq2) {
+		return MeosLibrary.meos.tsequence_merge(seq1, seq2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_merge_array(Pointer sequences, int count) {
+		return MeosLibrary.meos.tsequence_merge_array(sequences, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_append_tinstant(Pointer ss, Pointer inst, double maxdist, Pointer maxt, boolean expand) {
+		return MeosLibrary.meos.tsequenceset_append_tinstant(ss, inst, maxdist, maxt, expand);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_append_tsequence(Pointer ss, Pointer seq, boolean expand) {
+		return MeosLibrary.meos.tsequenceset_append_tsequence(ss, seq, expand);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_delete_timestamptz(Pointer ss, OffsetDateTime t) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.tsequenceset_delete_timestamptz(ss, t_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_delete_tstzset(Pointer ss, Pointer s) {
+		return MeosLibrary.meos.tsequenceset_delete_tstzset(ss, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_delete_tstzspan(Pointer ss, Pointer s) {
+		return MeosLibrary.meos.tsequenceset_delete_tstzspan(ss, s);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_delete_tstzspanset(Pointer ss, Pointer ps) {
+		return MeosLibrary.meos.tsequenceset_delete_tstzspanset(ss, ps);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_insert(Pointer ss1, Pointer ss2) {
+		return MeosLibrary.meos.tsequenceset_insert(ss1, ss2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_merge(Pointer ss1, Pointer ss2) {
+		return MeosLibrary.meos.tsequenceset_merge(ss1, ss2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_merge_array(Pointer seqsets, int count) {
+		return MeosLibrary.meos.tsequenceset_merge_array(seqsets, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tspatial_set_stbox(Pointer temp, Pointer box) {
+		MeosLibrary.meos.tspatial_set_stbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tgeoinst_set_stbox(Pointer inst, Pointer box) {
+		MeosLibrary.meos.tgeoinst_set_stbox(inst, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tspatialseq_set_stbox(Pointer seq, Pointer box) {
+		MeosLibrary.meos.tspatialseq_set_stbox(seq, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tspatialseqset_set_stbox(Pointer ss, Pointer box) {
+		MeosLibrary.meos.tspatialseqset_set_stbox(ss, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tsequence_expand_bbox(Pointer seq, Pointer inst) {
+		MeosLibrary.meos.tsequence_expand_bbox(seq, inst);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tsequence_set_bbox(Pointer seq, Pointer box) {
+		MeosLibrary.meos.tsequence_set_bbox(seq, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tsequenceset_expand_bbox(Pointer ss, Pointer seq) {
+		MeosLibrary.meos.tsequenceset_expand_bbox(ss, seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tsequenceset_set_bbox(Pointer ss, Pointer box) {
+		MeosLibrary.meos.tsequenceset_set_bbox(ss, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tdiscseq_restrict_minmax(Pointer seq, boolean min, boolean atfunc) {
+		return MeosLibrary.meos.tdiscseq_restrict_minmax(seq, min, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tcontseq_restrict_minmax(Pointer seq, boolean min, boolean atfunc) {
+		return MeosLibrary.meos.tcontseq_restrict_minmax(seq, min, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean temporal_bbox_restrict_set(Pointer temp, Pointer set) {
+		return MeosLibrary.meos.temporal_bbox_restrict_set(temp, set);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_restrict_minmax(Pointer temp, boolean min, boolean atfunc) {
+		return MeosLibrary.meos.temporal_restrict_minmax(temp, min, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_restrict_timestamptz(Pointer temp, OffsetDateTime t, boolean atfunc) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.temporal_restrict_timestamptz(temp, t_new, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_restrict_tstzset(Pointer temp, Pointer s, boolean atfunc) {
+		return MeosLibrary.meos.temporal_restrict_tstzset(temp, s, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_restrict_tstzspan(Pointer temp, Pointer s, boolean atfunc) {
+		return MeosLibrary.meos.temporal_restrict_tstzspan(temp, s, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_restrict_tstzspanset(Pointer temp, Pointer ss, boolean atfunc) {
+		return MeosLibrary.meos.temporal_restrict_tstzspanset(temp, ss, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_restrict_value(Pointer temp, long value, boolean atfunc) {
+		return MeosLibrary.meos.temporal_restrict_value(temp, value, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_restrict_values(Pointer temp, Pointer set, boolean atfunc) {
+		return MeosLibrary.meos.temporal_restrict_values(temp, set, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_value_at_timestamptz(Pointer temp, OffsetDateTime t, boolean strict) {
+		var t_new = t.toEpochSecond();
+		boolean out;
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer result = Memory.allocateDirect(runtime, Long.BYTES);
+		out = MeosLibrary.meos.temporal_value_at_timestamptz(temp, t_new, strict, result);
+		Pointer new_result = result.getPointer(0);
+		return out ? new_result : null ;
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_restrict_tstzspan(Pointer inst, Pointer period, boolean atfunc) {
+		return MeosLibrary.meos.tinstant_restrict_tstzspan(inst, period, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_restrict_tstzspanset(Pointer inst, Pointer ss, boolean atfunc) {
+		return MeosLibrary.meos.tinstant_restrict_tstzspanset(inst, ss, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_restrict_timestamptz(Pointer inst, OffsetDateTime t, boolean atfunc) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.tinstant_restrict_timestamptz(inst, t_new, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_restrict_tstzset(Pointer inst, Pointer s, boolean atfunc) {
+		return MeosLibrary.meos.tinstant_restrict_tstzset(inst, s, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_restrict_value(Pointer inst, long value, boolean atfunc) {
+		return MeosLibrary.meos.tinstant_restrict_value(inst, value, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tinstant_restrict_values(Pointer inst, Pointer set, boolean atfunc) {
+		return MeosLibrary.meos.tinstant_restrict_values(inst, set, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_restrict_geom(Pointer temp, Pointer gs, Pointer zspan, boolean atfunc) {
+		return MeosLibrary.meos.tgeo_restrict_geom(temp, gs, zspan, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_restrict_stbox(Pointer temp, Pointer box, boolean border_inc, boolean atfunc) {
+		return MeosLibrary.meos.tgeo_restrict_stbox(temp, box, border_inc, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeoinst_restrict_geom(Pointer inst, Pointer gs, Pointer zspan, boolean atfunc) {
+		return MeosLibrary.meos.tgeoinst_restrict_geom(inst, gs, zspan, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeoinst_restrict_stbox(Pointer inst, Pointer box, boolean border_inc, boolean atfunc) {
+		return MeosLibrary.meos.tgeoinst_restrict_stbox(inst, box, border_inc, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeoseq_restrict_geom(Pointer seq, Pointer gs, Pointer zspan, boolean atfunc) {
+		return MeosLibrary.meos.tgeoseq_restrict_geom(seq, gs, zspan, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeotseq_restrict_stbox(Pointer seq, Pointer box, boolean border_inc, boolean atfunc) {
+		return MeosLibrary.meos.tgeotseq_restrict_stbox(seq, box, border_inc, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeoseqset_restrict_geom(Pointer ss, Pointer gs, Pointer zspan, boolean atfunc) {
+		return MeosLibrary.meos.tgeoseqset_restrict_geom(ss, gs, zspan, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeoseqset_restrict_stbox(Pointer ss, Pointer box, boolean border_inc, boolean atfunc) {
+		return MeosLibrary.meos.tgeoseqset_restrict_stbox(ss, box, border_inc, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumber_restrict_span(Pointer temp, Pointer span, boolean atfunc) {
+		return MeosLibrary.meos.tnumber_restrict_span(temp, span, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumber_restrict_spanset(Pointer temp, Pointer ss, boolean atfunc) {
+		return MeosLibrary.meos.tnumber_restrict_spanset(temp, ss, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberinst_restrict_span(Pointer inst, Pointer span, boolean atfunc) {
+		return MeosLibrary.meos.tnumberinst_restrict_span(inst, span, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberinst_restrict_spanset(Pointer inst, Pointer ss, boolean atfunc) {
+		return MeosLibrary.meos.tnumberinst_restrict_spanset(inst, ss, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberseqset_restrict_span(Pointer ss, Pointer span, boolean atfunc) {
+		return MeosLibrary.meos.tnumberseqset_restrict_span(ss, span, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberseqset_restrict_spanset(Pointer ss, Pointer spanset, boolean atfunc) {
+		return MeosLibrary.meos.tnumberseqset_restrict_spanset(ss, spanset, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_at_timestamptz(Pointer seq, OffsetDateTime t) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.tsequence_at_timestamptz(seq, t_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_restrict_tstzspan(Pointer seq, Pointer s, boolean atfunc) {
+		return MeosLibrary.meos.tsequence_restrict_tstzspan(seq, s, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_restrict_tstzspanset(Pointer seq, Pointer ss, boolean atfunc) {
+		return MeosLibrary.meos.tsequence_restrict_tstzspanset(seq, ss, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_restrict_minmax(Pointer ss, boolean min, boolean atfunc) {
+		return MeosLibrary.meos.tsequenceset_restrict_minmax(ss, min, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_restrict_tstzspan(Pointer ss, Pointer s, boolean atfunc) {
+		return MeosLibrary.meos.tsequenceset_restrict_tstzspan(ss, s, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_restrict_tstzspanset(Pointer ss, Pointer ps, boolean atfunc) {
+		return MeosLibrary.meos.tsequenceset_restrict_tstzspanset(ss, ps, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_restrict_timestamptz(Pointer ss, OffsetDateTime t, boolean atfunc) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.tsequenceset_restrict_timestamptz(ss, t_new, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_restrict_tstzset(Pointer ss, Pointer s, boolean atfunc) {
+		return MeosLibrary.meos.tsequenceset_restrict_tstzset(ss, s, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_restrict_value(Pointer ss, long value, boolean atfunc) {
+		return MeosLibrary.meos.tsequenceset_restrict_value(ss, value, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_restrict_values(Pointer ss, Pointer s, boolean atfunc) {
+		return MeosLibrary.meos.tsequenceset_restrict_values(ss, s, atfunc);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int tinstant_cmp(Pointer inst1, Pointer inst2) {
+		return MeosLibrary.meos.tinstant_cmp(inst1, inst2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean tinstant_eq(Pointer inst1, Pointer inst2) {
+		return MeosLibrary.meos.tinstant_eq(inst1, inst2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int tsequence_cmp(Pointer seq1, Pointer seq2) {
+		return MeosLibrary.meos.tsequence_cmp(seq1, seq2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean tsequence_eq(Pointer seq1, Pointer seq2) {
+		return MeosLibrary.meos.tsequence_eq(seq1, seq2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int tsequenceset_cmp(Pointer ss1, Pointer ss2) {
+		return MeosLibrary.meos.tsequenceset_cmp(ss1, ss2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean tsequenceset_eq(Pointer ss1, Pointer ss2) {
+		return MeosLibrary.meos.tsequenceset_eq(ss1, ss2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_eq_base_temporal(long value, Pointer temp) {
+		return MeosLibrary.meos.always_eq_base_temporal(value, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_eq_temporal_base(Pointer temp, long value) {
+		return MeosLibrary.meos.always_eq_temporal_base(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_ne_base_temporal(long value, Pointer temp) {
+		return MeosLibrary.meos.always_ne_base_temporal(value, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_ne_temporal_base(Pointer temp, long value) {
+		return MeosLibrary.meos.always_ne_temporal_base(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_ge_base_temporal(long value, Pointer temp) {
+		return MeosLibrary.meos.always_ge_base_temporal(value, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_ge_temporal_base(Pointer temp, long value) {
+		return MeosLibrary.meos.always_ge_temporal_base(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_gt_base_temporal(long value, Pointer temp) {
+		return MeosLibrary.meos.always_gt_base_temporal(value, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_gt_temporal_base(Pointer temp, long value) {
+		return MeosLibrary.meos.always_gt_temporal_base(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_le_base_temporal(long value, Pointer temp) {
+		return MeosLibrary.meos.always_le_base_temporal(value, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_le_temporal_base(Pointer temp, long value) {
+		return MeosLibrary.meos.always_le_temporal_base(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_lt_base_temporal(long value, Pointer temp) {
+		return MeosLibrary.meos.always_lt_base_temporal(value, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int always_lt_temporal_base(Pointer temp, long value) {
+		return MeosLibrary.meos.always_lt_temporal_base(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_eq_base_temporal(long value, Pointer temp) {
+		return MeosLibrary.meos.ever_eq_base_temporal(value, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_eq_temporal_base(Pointer temp, long value) {
+		return MeosLibrary.meos.ever_eq_temporal_base(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_ne_base_temporal(long value, Pointer temp) {
+		return MeosLibrary.meos.ever_ne_base_temporal(value, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_ne_temporal_base(Pointer temp, long value) {
+		return MeosLibrary.meos.ever_ne_temporal_base(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_ge_base_temporal(long value, Pointer temp) {
+		return MeosLibrary.meos.ever_ge_base_temporal(value, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_ge_temporal_base(Pointer temp, long value) {
+		return MeosLibrary.meos.ever_ge_temporal_base(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_gt_base_temporal(long value, Pointer temp) {
+		return MeosLibrary.meos.ever_gt_base_temporal(value, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_gt_temporal_base(Pointer temp, long value) {
+		return MeosLibrary.meos.ever_gt_temporal_base(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_le_base_temporal(long value, Pointer temp) {
+		return MeosLibrary.meos.ever_le_base_temporal(value, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_le_temporal_base(Pointer temp, long value) {
+		return MeosLibrary.meos.ever_le_temporal_base(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_lt_base_temporal(long value, Pointer temp) {
+		return MeosLibrary.meos.ever_lt_base_temporal(value, temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int ever_lt_temporal_base(Pointer temp, long value) {
+		return MeosLibrary.meos.ever_lt_temporal_base(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloatseq_derivative(Pointer seq) {
+		return MeosLibrary.meos.tfloatseq_derivative(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tfloatseqset_derivative(Pointer ss) {
+		return MeosLibrary.meos.tfloatseqset_derivative(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberinst_abs(Pointer inst) {
+		return MeosLibrary.meos.tnumberinst_abs(inst);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberseq_abs(Pointer seq) {
+		return MeosLibrary.meos.tnumberseq_abs(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberseq_angular_difference(Pointer seq) {
+		return MeosLibrary.meos.tnumberseq_angular_difference(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberseq_delta_value(Pointer seq) {
+		return MeosLibrary.meos.tnumberseq_delta_value(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberseqset_abs(Pointer ss) {
+		return MeosLibrary.meos.tnumberseqset_abs(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberseqset_angular_difference(Pointer ss) {
+		return MeosLibrary.meos.tnumberseqset_angular_difference(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumberseqset_delta_value(Pointer ss) {
+		return MeosLibrary.meos.tnumberseqset_delta_value(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer distance_tnumber_number(Pointer temp, long value) {
+		return MeosLibrary.meos.distance_tnumber_number(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long nad_tbox_tbox(Pointer box1, Pointer box2) {
+		return MeosLibrary.meos.nad_tbox_tbox(box1, box2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long nad_tnumber_number(Pointer temp, long value) {
+		return MeosLibrary.meos.nad_tnumber_number(temp, value);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long nad_tnumber_tbox(Pointer temp, Pointer box) {
+		return MeosLibrary.meos.nad_tnumber_tbox(temp, box);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long nad_tnumber_tnumber(Pointer temp1, Pointer temp2) {
+		return MeosLibrary.meos.nad_tnumber_tnumber(temp1, temp2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int spatial_srid(long d, meosType basetype) {
+		return MeosLibrary.meos.spatial_srid(d, basetype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean spatial_has_z(long d, meosType basetype) {
+		return MeosLibrary.meos.spatial_has_z(d, basetype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean spatial_is_geodetic(long d, meosType basetype) {
+		return MeosLibrary.meos.spatial_is_geodetic(d, basetype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean spatial_set_srid(long d, meosType basetype, int srid) {
+		return MeosLibrary.meos.spatial_set_srid(d, basetype, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int tspatialinst_srid(Pointer inst) {
+		return MeosLibrary.meos.tspatialinst_srid(inst);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseq_azimuth(Pointer seq) {
+		return MeosLibrary.meos.tpointseq_azimuth(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseq_cumulative_length(Pointer seq, double prevlength) {
+		return MeosLibrary.meos.tpointseq_cumulative_length(seq, prevlength);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean tpointseq_is_simple(Pointer seq) {
+		return MeosLibrary.meos.tpointseq_is_simple(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double tpointseq_length(Pointer seq) {
+		return MeosLibrary.meos.tpointseq_length(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseq_linear_trajectory(Pointer seq, boolean unary_union) {
+		return MeosLibrary.meos.tpointseq_linear_trajectory(seq, unary_union);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseq_speed(Pointer seq) {
+		return MeosLibrary.meos.tpointseq_speed(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeoseq_stboxes(Pointer seq, Pointer count) {
+		return MeosLibrary.meos.tgeoseq_stboxes(seq, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseq_split_n_stboxes(Pointer seq, int max_count, Pointer count) {
+		return MeosLibrary.meos.tpointseq_split_n_stboxes(seq, max_count, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseqset_azimuth(Pointer ss) {
+		return MeosLibrary.meos.tpointseqset_azimuth(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseqset_cumulative_length(Pointer ss) {
+		return MeosLibrary.meos.tpointseqset_cumulative_length(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static boolean tpointseqset_is_simple(Pointer ss) {
+		return MeosLibrary.meos.tpointseqset_is_simple(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double tpointseqset_length(Pointer ss) {
+		return MeosLibrary.meos.tpointseqset_length(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseqset_speed(Pointer ss) {
+		return MeosLibrary.meos.tpointseqset_speed(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeoseqset_stboxes(Pointer ss, Pointer count) {
+		return MeosLibrary.meos.tgeoseqset_stboxes(ss, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseqset_split_n_stboxes(Pointer ss, int max_count, Pointer count) {
+		return MeosLibrary.meos.tpointseqset_split_n_stboxes(ss, max_count, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseqset_trajectory(Pointer ss) {
+		return MeosLibrary.meos.tpointseqset_trajectory(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpoint_get_coord(Pointer temp, int coord) {
+		return MeosLibrary.meos.tpoint_get_coord(temp, coord);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeominst_tgeoginst(Pointer inst, boolean oper) {
+		return MeosLibrary.meos.tgeominst_tgeoginst(inst, oper);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeomseq_tgeogseq(Pointer seq, boolean oper) {
+		return MeosLibrary.meos.tgeomseq_tgeogseq(seq, oper);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeomseqset_tgeogseqset(Pointer ss, boolean oper) {
+		return MeosLibrary.meos.tgeomseqset_tgeogseqset(ss, oper);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeom_tgeog(Pointer temp, boolean oper) {
+		return MeosLibrary.meos.tgeom_tgeog(temp, oper);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeo_tpoint(Pointer temp, boolean oper) {
+		return MeosLibrary.meos.tgeo_tpoint(temp, oper);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tgeompoint_tnpoint(Pointer temp) {
+		return MeosLibrary.meos.tgeompoint_tnpoint(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnpoint_tgeompoint(Pointer temp) {
+		return MeosLibrary.meos.tnpoint_tgeompoint(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tspatialinst_set_srid(Pointer inst, int srid) {
+		MeosLibrary.meos.tspatialinst_set_srid(inst, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseq_make_simple(Pointer seq, Pointer count) {
+		return MeosLibrary.meos.tpointseq_make_simple(seq, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tpointseq_set_srid(Pointer seq, int srid) {
+		MeosLibrary.meos.tpointseq_set_srid(seq, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseqset_make_simple(Pointer ss, Pointer count) {
+		return MeosLibrary.meos.tpointseqset_make_simple(ss, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void tpointseqset_set_srid(Pointer ss, int srid) {
+		MeosLibrary.meos.tpointseqset_set_srid(ss, srid);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double tnumberseq_integral(Pointer seq) {
+		return MeosLibrary.meos.tnumberseq_integral(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double tnumberseq_twavg(Pointer seq) {
+		return MeosLibrary.meos.tnumberseq_twavg(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double tnumberseqset_integral(Pointer ss) {
+		return MeosLibrary.meos.tnumberseqset_integral(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double tnumberseqset_twavg(Pointer ss) {
+		return MeosLibrary.meos.tnumberseqset_twavg(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseq_twcentroid(Pointer seq) {
+		return MeosLibrary.meos.tpointseq_twcentroid(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tpointseqset_twcentroid(Pointer ss) {
+		return MeosLibrary.meos.tpointseqset_twcentroid(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_compact(Pointer temp) {
+		return MeosLibrary.meos.temporal_compact(temp);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequence_compact(Pointer seq) {
+		return MeosLibrary.meos.tsequence_compact(seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tsequenceset_compact(Pointer ss) {
+		return MeosLibrary.meos.tsequenceset_compact(ss);
+	}
+	
+	@SuppressWarnings("unused")
+	public static void skiplist_free(Pointer list) {
+		MeosLibrary.meos.skiplist_free(list);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_app_tinst_transfn(Pointer state, Pointer inst, int interp, double maxdist, Pointer maxt) {
+		return MeosLibrary.meos.temporal_app_tinst_transfn(state, inst, interp, maxdist, maxt);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer temporal_app_tseq_transfn(Pointer state, Pointer seq) {
+		return MeosLibrary.meos.temporal_app_tseq_transfn(state, seq);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer numspanset_spans(Pointer ss, long vsize, long vorigin, Pointer count) {
+		return MeosLibrary.meos.numspanset_spans(ss, vsize, vorigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spanset_time_spans(Pointer ss, Pointer duration, long torigin, Pointer count) {
+		return MeosLibrary.meos.spanset_time_spans(ss, duration, torigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer spanset_value_spans(Pointer ss, long vsize, long vorigin, Pointer count) {
+		return MeosLibrary.meos.spanset_value_spans(ss, vsize, vorigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer timespanset_spans(Pointer ss, Pointer duration, long torigin, Pointer count) {
+		return MeosLibrary.meos.timespanset_spans(ss, duration, torigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumber_value_spans(Pointer temp, long size, long origin, Pointer count) {
+		return MeosLibrary.meos.tnumber_value_spans(temp, size, origin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumber_value_boxes(Pointer temp, long vsize, long vorigin, Pointer count) {
+		return MeosLibrary.meos.tnumber_value_boxes(temp, vsize, vorigin, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumber_time_boxes(Pointer temp, Pointer duration, OffsetDateTime torigin, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tnumber_time_boxes(temp, duration, torigin_new, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumber_value_time_boxes(Pointer temp, long vsize, Pointer duration, long vorigin, OffsetDateTime torigin, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tnumber_value_time_boxes(temp, vsize, duration, vorigin, torigin_new, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumber_value_split(Pointer temp, long vsize, long vorigin, Pointer bins, Pointer count) {
+		return MeosLibrary.meos.tnumber_value_split(temp, vsize, vorigin, bins, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tbox_get_value_time_tile(long value, OffsetDateTime t, long vsize, Pointer duration, long vorigin, OffsetDateTime torigin, meosType basetype, meosType spantype) {
+		var t_new = t.toEpochSecond();
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tbox_get_value_time_tile(value, t_new, vsize, duration, vorigin, torigin_new, basetype, spantype);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer tnumber_value_time_split(Pointer temp, long size, Pointer duration, long vorigin, OffsetDateTime torigin, Pointer value_bins, Pointer time_bins, Pointer count) {
+		var torigin_new = torigin.toEpochSecond();
+		return MeosLibrary.meos.tnumber_value_time_split(temp, size, duration, vorigin, torigin_new, value_bins, time_bins, count);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int date_in(String str) {
+		return MeosLibrary.meos.date_in(str);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String date_out(int d) {
+		return MeosLibrary.meos.date_out(d);
+	}
+	
+	@SuppressWarnings("unused")
+	public static int interval_cmp(Pointer interv1, Pointer interv2) {
+		return MeosLibrary.meos.interval_cmp(interv1, interv2);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer interval_in(String str, int typmod) {
+		return MeosLibrary.meos.interval_in(str, typmod);
+	}
+	
+	@SuppressWarnings("unused")
+	public static Pointer interval_make(int years, int months, int weeks, int days, int hours, int mins, double secs) {
+		return MeosLibrary.meos.interval_make(years, months, weeks, days, hours, mins, secs);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String interval_out(Pointer interv) {
+		return MeosLibrary.meos.interval_out(interv);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double pg_exp(double arg1) {
+		return MeosLibrary.meos.pg_exp(arg1);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double pg_ln(double arg1) {
+		return MeosLibrary.meos.pg_ln(arg1);
+	}
+	
+	@SuppressWarnings("unused")
+	public static double pg_log10(double arg1) {
+		return MeosLibrary.meos.pg_log10(arg1);
+	}
+	
+	@SuppressWarnings("unused")
+	public static long time_in(String str, int typmod) {
+		return MeosLibrary.meos.time_in(str, typmod);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String time_out(long t) {
+		return MeosLibrary.meos.time_out(t);
+	}
+	
+	@SuppressWarnings("unused")
+	public static LocalDateTime timestamp_in(String str, int typmod) {
+		var result = MeosLibrary.meos.timestamp_in(str, typmod);
+		return LocalDateTime.ofEpochSecond(result, 0, ZoneOffset.UTC);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String timestamp_out(LocalDateTime t) {
+		var t_new = t.toEpochSecond(ZoneOffset.UTC);
+		return MeosLibrary.meos.timestamp_out(t_new);
+	}
+	
+	@SuppressWarnings("unused")
+	public static OffsetDateTime timestamptz_in(String str, int typmod) {
+		var result = MeosLibrary.meos.timestamptz_in(str, typmod);
+		Instant instant = Instant.ofEpochSecond(result);
+		return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
+	}
+	
+	@SuppressWarnings("unused")
+	public static String timestamptz_out(OffsetDateTime t) {
+		var t_new = t.toEpochSecond();
+		return MeosLibrary.meos.timestamptz_out(t_new);
 	}
 }

--- a/src/test/java/basic/TBoolTest.java
+++ b/src/test/java/basic/TBoolTest.java
@@ -33,7 +33,8 @@ public class TBoolTest {
     static error_handler_fn errorHandler = new error_handler();
 
     static Stream<Arguments> TBool_copy_constructor() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst"),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq"),
@@ -44,7 +45,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_string_constructor() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("True@2019-09-01", "TBoolInst", TInterpolation.NONE, "t@2019-09-01 00:00:00+00"),
                 Arguments.of("{True@2019-09-01, False@2019-09-02}", "TBoolSeq", TInterpolation.DISCRETE, "{t@2019-09-01 00:00:00+00, f@2019-09-02 00:00:00+00}"),
@@ -55,7 +57,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_base_time_constructor() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"), "TBoolSeq", TInterpolation.DISCRETE),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"), "TBoolSeqSet", TInterpolation.STEPWISE),
@@ -65,7 +68,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_string() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", "t@2019-09-01 00:00:00+00"),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", "{t@2019-09-01 00:00:00+00, f@2019-09-02 00:00:00+00}"),
@@ -75,7 +79,8 @@ public class TBoolTest {
     }
 
     static Stream<Arguments> TBool_bounding() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new tstzspan("[2019-09-01, 2019-09-01]")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", new tstzspan("[2019-09-01, 2019-09-02]")),
@@ -86,7 +91,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_interp() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", TInterpolation.NONE),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", TInterpolation.DISCRETE),
@@ -96,7 +102,8 @@ public class TBoolTest {
     }
 
     static Stream<Arguments> TBool_start() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", true),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", true),
@@ -107,7 +114,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_end() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", true),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", false),
@@ -118,7 +126,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_time() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new tstzspanset("{[2019-09-01, 2019-09-01]}")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", new tstzspanset("{[2019-09-01, 2019-09-01], [2019-09-02, 2019-09-02]}")),
@@ -129,7 +138,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_numinst() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", 1),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",2),
@@ -140,7 +150,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_startinst() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new TBoolInst("True@2019-09-01")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", new TBoolInst("True@2019-09-01")),
@@ -151,7 +162,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_endinst() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new TBoolInst("True@2019-09-01")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", new TBoolInst("False@2019-09-02")),
@@ -162,7 +174,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_mininst() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new TBoolInst("True@2019-09-01")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", new TBoolInst("False@2019-09-02")),
@@ -173,7 +186,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_maxinst() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new TBoolInst("True@2019-09-01")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", new TBoolInst("True@2019-09-01")),
@@ -185,7 +199,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_instn() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", 0, new TBoolInst("True@2019-09-01")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",1, new TBoolInst("False@2019-09-02")),
@@ -196,7 +211,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_startmstp() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",LocalDateTime.of(2019, 9, 1, 0, 0,0)),
@@ -207,7 +223,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_endtmstp() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -218,7 +235,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_hash() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", 440045287),
 //                Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",2385901957l),
@@ -229,7 +247,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_instant() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), new TBoolInst("True@2019-09-01")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01}"), new TBoolInst("True@2019-09-01")),
@@ -240,7 +259,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_tosequence() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), TInterpolation.NONE, new TBoolSeq("[True@2019-09-01]")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), TInterpolation.DISCRETE , new TBoolSeq("{True@2019-09-01, False@2019-09-02}")),
@@ -251,7 +271,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_tosequenceset() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), TInterpolation.NONE, new TBoolSeqSet("{[True@2019-09-01]}")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), TInterpolation.NONE , new TBoolSeqSet("{[True@2019-09-01], [False@2019-09-02]}"))
@@ -261,7 +282,8 @@ public class TBoolTest {
     }
 
     static Stream<Arguments> TBool_insert() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), new TBoolSeq("{True@2019-09-03}"), new TBoolSeq("{True@2019-09-01, True@2019-09-03}"), "TBoolInst"),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), new TBoolSeq("{True@2019-09-03}") , new TBoolSeq("{True@2019-09-01, False@2019-09-02, True@2019-09-03}"), "TBoolSeq"),
@@ -271,7 +293,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_update() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), new TBoolInst("False@2019-09-01"), new TBoolInst("False@2019-09-01"), "TBoolInst"),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), new TBoolInst("False@2019-09-01") , new TBoolSeq("{False@2019-09-01, False@2019-09-02}"), "TBoolSeq"),
@@ -280,7 +303,8 @@ public class TBoolTest {
     }
 
     static Stream<Arguments> TBool_appendseq() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), new TBoolSeq("{True@2019-09-03}") , new TBoolSeq("{True@2019-09-01, False@2019-09-02, True@2019-09-03}"), "TBoolSeq"),
                 Arguments.of(new TBoolSeqSet("{[True@2019-09-01, False@2019-09-02],[True@2019-09-03, True@2019-09-05]}"), new TBoolSeq("[True@2019-09-06]"), new TBoolSeqSet("{[True@2019-09-01, False@2019-09-02],[True@2019-09-03, True@2019-09-05],[True@2019-09-06]}"), "TBoolSeqSet")
@@ -290,7 +314,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_whentrue() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new tstzspanset("{[2019-09-01, 2019-09-01]}")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq" , new tstzspanset("{[2019-09-01, 2019-09-01]}")),
@@ -300,7 +325,8 @@ public class TBoolTest {
     }
 
     static Stream<Arguments> TBool_whenfalse() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq" , new tstzspanset("{[2019-09-02, 2019-09-02]}")),
                 Arguments.of(new TBoolSeq("[True@2019-09-01, False@2019-09-02]"), "TBoolSeq", new tstzspanset("{[2019-09-02, 2019-09-02]}")),
@@ -310,7 +336,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_alwaystrue() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", true),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",false),
@@ -321,7 +348,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_alwaysfalse() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", false),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",false),
@@ -332,7 +360,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_evertrue() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", true),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",true),
@@ -343,7 +372,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_everfalse() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", false),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",true),
@@ -354,7 +384,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_nevertrue() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", false),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",false),
@@ -365,7 +396,8 @@ public class TBoolTest {
 
 
     static Stream<Arguments> TBool_neverfalse() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", true),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",false),
@@ -387,7 +419,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test from string constructor.")
     @MethodSource("TBool_string_constructor")
     public void testFromStringConstructor(String value, String type, TInterpolation interp, String repr) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             TBoolInst tb = new TBoolInst(value);
             System.out.println(tb.to_string());
@@ -413,7 +446,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test from base time constructor.")
     @MethodSource("TBool_base_time_constructor")
     public void testFromBaseTimeConstructor(Time base, String type, TInterpolation interp) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             TBoolInst tb = (TBoolInst) TBool.from_base_time(true, base);
             System.out.println(tb.to_string());
@@ -435,7 +469,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test from copy constructor.")
     @MethodSource("TBool_copy_constructor")
     public void testCopyConstructor(Temporal base, String type) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             TBoolInst tb = (TBoolInst) base.copy();
             assertEquals(tb.to_string(),(((TBoolInst) base).to_string()));
@@ -453,7 +488,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test string method.")
     @MethodSource("TBool_string")
     public void testString(Temporal base, String type, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals(expected,(((TBoolInst) base).to_string()));
         } else if (type == "TBoolSeq") {
@@ -467,7 +503,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test bounding box method.")
     @MethodSource("TBool_bounding")
     public void testBoundingBox(Temporal base, String type, tstzspan expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.bounding_box().toString(),expected.toString());
     }
 
@@ -476,7 +513,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test interpolation method.")
     @MethodSource("TBool_interp")
     public void testInterpolation(Temporal base, String type, TInterpolation expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.interpolation(),expected);
     }
 
@@ -484,7 +522,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test start values method.")
     @MethodSource("TBool_start")
     public void testStartValues(Temporal base, String type, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBool) base).start_value() ,expected);
     }
 
@@ -492,7 +531,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test end values method.")
     @MethodSource("TBool_end")
     public void testEndValues(Temporal base, String type, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBool) base).end_value() ,expected);
     }
 
@@ -500,7 +540,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test time  method.")
     @MethodSource("TBool_time")
     public void testTime(Temporal base, String type, tstzspanset expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.time().toString() ,expected.toString());
     }
 
@@ -508,7 +549,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test period method.")
     @MethodSource("TBool_bounding")
     public void testtstzspan(Temporal base, String type, tstzspan expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.period().toString() ,expected.toString());
     }
 
@@ -516,7 +558,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test span method.")
     @MethodSource("TBool_bounding")
     public void testSpan(Temporal base, String type, tstzspan expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.timespan().toString(),expected.toString());
     }
 
@@ -524,7 +567,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test numinst method.")
     @MethodSource("TBool_numinst")
     public void testNumInst(Temporal base, String type, int expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.num_instants(),expected);
     }
 
@@ -532,7 +576,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test startinst method.")
     @MethodSource("TBool_startinst")
     public void testStartInst(Temporal base, String type, TBoolInst expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBoolInst)base.start_instant()).to_string(),expected.to_string());
     }
 
@@ -540,7 +585,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test endinst method.")
     @MethodSource("TBool_endinst")
     public void testEndInst(Temporal base, String type, TBoolInst expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBoolInst)base.end_instant()).to_string(),expected.to_string());
     }
 
@@ -548,7 +594,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test mininst method.")
     @MethodSource("TBool_mininst")
     public void testMinInst(Temporal base, String type, TBoolInst expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBoolInst)base.min_instant()).to_string(),expected.to_string());
     }
 
@@ -556,14 +603,16 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test maxinst method.")
     @MethodSource("TBool_maxinst")
     public void testMaxInst(Temporal base, String type, TBoolInst expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBoolInst)base.max_instant()).to_string(),expected.to_string());
     }
 
     @ParameterizedTest(name = "Test instn method.")
     @MethodSource("TBool_instn")
     public void testInstN(Temporal base, String type, int n, TBoolInst expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBoolInst)base.instant_n(n)).to_string(),expected.to_string());
     }
 
@@ -571,7 +620,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test num timestamp method.")
     @MethodSource("TBool_numinst")
     public void testNumtmstmp(Temporal base, String type, int expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.num_timestamps(),expected);
     }
 
@@ -579,7 +629,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test start timestamp method.")
     @MethodSource("TBool_startmstp")
     public void testStarttmstmp(Temporal base, String type, LocalDateTime expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.start_timestamp(),expected);
     }
 
@@ -587,7 +638,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test end timestamp method.")
     @MethodSource("TBool_endtmstp")
     public void testEndtmstmp(Temporal base, String type, LocalDateTime expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.end_timestamp(),expected);
     }
 
@@ -595,7 +647,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test Hash method.")
     @MethodSource("TBool_hash")
     public void testHash(Temporal base, String type, long expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.hash(),expected);
     }
 
@@ -603,7 +656,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test to instant method.")
     @MethodSource("TBool_instant")
     public void testInstant(Temporal base, TBoolInst type) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         Temporal tmp = base.to_instant();
         assertTrue(tmp instanceof TBoolInst);
         assertEquals(((TBoolInst) tmp).to_string(), type.to_string());
@@ -613,7 +667,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test to sequence method.")
     @MethodSource("TBool_tosequence")
     public void testSequence(Temporal base, TInterpolation type, TBoolSeq tseq) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         Temporal tmp = base.to_sequence(type);
         assertTrue(tmp instanceof TBoolSeq);
         assertEquals(((TBoolSeq) tmp).to_string(), tseq.to_string());
@@ -623,7 +678,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test to sequenceset method.")
     @MethodSource("TBool_tosequenceset")
     public void testSequenceSet(Temporal base, TInterpolation type, TBoolSeqSet tseqset) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         Temporal tmp = base.to_sequenceset(type);
         assertTrue(tmp instanceof TBoolSeqSet);
         assertEquals(((TBoolSeqSet) tmp).to_string(), tseqset.to_string());
@@ -633,7 +689,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test insert method.")
     @MethodSource("TBool_insert")
     public void testInsert(Temporal base, Temporal base2, Temporal tseq, String type) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals(((TBoolInst)base.insert(base2)).to_string(), ((TBoolSeq) tseq).to_string());
         } else if (type == "TBoolSeq") {
@@ -647,7 +704,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test update method.")
     @MethodSource("TBool_update")
     public void testUpdate(Temporal base, Temporal base2, Temporal tseq, String type) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals(((TBoolInst)base.update(base2)).to_string(), ((TBoolInst) tseq).to_string());
         } else if (type == "TBoolSeq") {
@@ -661,7 +719,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test append sequence method.")
     @MethodSource("TBool_appendseq")
     public void testAppendSeq(Temporal base, TSequence base2, Temporal tseq, String type) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolSeq") {
             assertEquals(((TBoolSeq)base.append_sequence(base2)).to_string(), ((TBoolSeq) tseq).to_string());
         } else if (type == "TBoolSeqSet") {
@@ -674,7 +733,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test when true method.")
     @MethodSource("TBool_whentrue")
     public void testWhentrue(Temporal base, String type, tstzspanset pset) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).when_true().toString(), pset.toString());
         } else if (type == "TBoolSeq") {
@@ -688,7 +748,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test when false method.")
     @MethodSource("TBool_whenfalse")
     public void testWhenfalse(Temporal base, String type, tstzspanset pset) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolSeq") {
             System.out.println(((TBoolSeq) base).when_false().toString());
             System.out.println(pset.toString());
@@ -704,7 +765,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test to always true method.")
     @MethodSource("TBool_alwaystrue")
     public void testAlwaystrue(Temporal base, String type, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).always_eq(true), expected);
         } else if (type == "TBoolSeq") {
@@ -718,7 +780,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test to always false method.")
     @MethodSource("TBool_alwaysfalse")
     public void testAlwaysfalse(Temporal base, String type, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).always_eq(false), expected);
         } else if (type == "TBoolSeq") {
@@ -733,7 +796,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test to ever true method.")
     @MethodSource("TBool_evertrue")
     public void testEvertrue(Temporal base, String type, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).ever_eq(true), expected);
         } else if (type == "TBoolSeq") {
@@ -748,7 +812,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test to ever false method.")
     @MethodSource("TBool_everfalse")
     public void testEverfalse(Temporal base, String type, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).ever_eq(false), expected);
         } else if (type == "TBoolSeq") {
@@ -762,7 +827,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test to never true method.")
     @MethodSource("TBool_nevertrue")
     public void testNevertrue(Temporal base, String type, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).never_eq(true), expected);
         } else if (type == "TBoolSeq") {
@@ -777,7 +843,8 @@ public class TBoolTest {
     @ParameterizedTest(name = "Test to never false method.")
     @MethodSource("TBool_neverfalse")
     public void testNeverfalse(Temporal base, String type, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).never_eq(false), expected);
         } else if (type == "TBoolSeq") {

--- a/src/test/java/basic/TFloatTest.java
+++ b/src/test/java/basic/TFloatTest.java
@@ -37,7 +37,8 @@ public class TFloatTest {
     static error_handler_fn errorHandler = new error_handler();
     
     private static Stream<Arguments> frombasetemporal() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TFloatInst", TInterpolation.NONE),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TFloatSeq", TInterpolation.LINEAR),
@@ -47,7 +48,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> frombasetime() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"), "TFloatSeq", TInterpolation.DISCRETE),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"), "TFloatSeqSet", TInterpolation.LINEAR),
@@ -67,7 +69,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> fromcopy() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst"),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq"),
@@ -77,7 +80,8 @@ public class TFloatTest {
     }
 
     private static Stream<Arguments> totint() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", "1@2019-09-01 00:00:00+00")
                 //Arguments.of(new TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}"), "TFloatSeq", "[1@2019-09-01 00:00:00+00, 2@2019-09-02 00:00:00+00]"),
@@ -88,7 +92,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> bounding() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TBox("TBOXFLOAT XT([1.5,1.5],[2019-09-01, 2019-09-01])")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new TBox("TBOXFLOAT XT([1.5,2.5],[2019-09-01, 2019-09-02])")),
@@ -99,7 +104,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> interp() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", TInterpolation.NONE),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", TInterpolation.LINEAR),
@@ -109,7 +115,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> value_span() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new FloatSpan(1.5f, 1.5f, true, true)),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new FloatSpan(1.5f, 2.5f, true, true)),
@@ -119,7 +126,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> value_spans() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new IntSpanSet("{[1,1]}")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new IntSpanSet("{[1,2]}")),
@@ -129,7 +137,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> start_value() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1.5f),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", 1.5f),
@@ -139,7 +148,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> end_value() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1.5f),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", 2.5f),
@@ -149,7 +159,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> min_value() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1.5f),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", 1.5f),
@@ -159,7 +170,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> max_value() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TIntInst", 1.5f),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TIntSeq", 2.5f),
@@ -169,7 +181,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> time() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new tstzspanset("{[2019-09-01, 2019-09-01]}")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new tstzspanset("{[2019-09-01, 2019-09-02]}")),
@@ -179,7 +192,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> period() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new tstzspan("[2019-09-01, 2019-09-01]")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new tstzspan("[2019-09-01, 2019-09-02]")),
@@ -188,7 +202,8 @@ public class TFloatTest {
     }
 
     private static Stream<Arguments> num_instant() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq",2),
@@ -199,7 +214,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> start_instant() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TIntInst", new TFloatInst("1.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TIntSeq",new TFloatInst("1.5@2019-09-01")),
@@ -210,7 +226,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> end_instant() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TFloatInst("1.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq",new TFloatInst("2.5@2019-09-02")),
@@ -220,7 +237,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> max_instant() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TFloatInst("1.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq",new TFloatInst("2.5@2019-09-02")),
@@ -230,7 +248,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> instant_n() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), 0, new TFloatInst("1.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), 1,new TFloatInst("2.5@2019-09-02")),
@@ -241,7 +260,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> num_timestamps() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), 1, new TIntInst("1@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), 2,new TIntInst("2@2019-09-02")),
@@ -252,7 +272,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> start_timestamps() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), 1, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), 2, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
@@ -262,7 +283,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> end_timestamps() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), 1, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), 2, LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -272,7 +294,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> hash() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), 1307112078, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), 1935376725, LocalDateTime.of(2019, 9, 2, 0, 0,0))
@@ -282,7 +305,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> toinstant() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TFloatInst("1.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01]"), "TFloatSeq", new TFloatInst("1.5@2019-09-01")),
@@ -292,7 +316,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> tosequence() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", TInterpolation.LINEAR, new TFloatSeq("[1.5@2019-09-01]")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", TInterpolation.LINEAR, new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")),
@@ -302,7 +327,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> tosequenceset() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", TInterpolation.LINEAR, new TFloatSeqSet("{[1.5@2019-09-01]}")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", TInterpolation.LINEAR, new TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02]}")),
@@ -312,7 +338,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> insert() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 //Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TFloatSeq("{1.5@2019-09-03}"), new TFloatSeq("{1.5@2019-09-01, 1.5@2019-09-03}"))
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new TFloatSeq("[1.5@2019-09-03]"), new TFloatSeqSet("[1.5@2019-09-01, 2.5@2019-09-02, 1.5@2019-09-03]")),
@@ -322,7 +349,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> update() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TFloatInst("2.5@2019-09-01"), new TFloatInst("2.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new TFloatInst("2.5@2019-09-01"), new TFloatSeqSet("{[2.5@2019-09-01], (1.5@2019-09-01, 2.5@2019-09-02]}")),
@@ -332,7 +360,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> append_sequence() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new TFloatSeq("[1.5@2019-09-03]"), new TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02], [1.5@2019-09-03]}")),
                 Arguments.of(new TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"), "TFloatSeqSet", new TFloatSeq("[1.5@2019-09-06]"), new TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05],[1.5@2019-09-06]}"))
@@ -341,7 +370,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> abs() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TFloatInst("2.5@2019-09-01"), new TFloatInst("2.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new TFloatInst("2.5@2019-09-01"), new TFloatSeqSet("{[2.5@2019-09-01], (1.5@2019-09-01, 2.5@2019-09-02]}")),
@@ -351,7 +381,8 @@ public class TFloatTest {
 
     /*
     private static Stream<Arguments> delta_value() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new TFloatSeq("Interp=Step;[1@2019-09-01, 1@2019-09-02)")),
                 Arguments.of(new TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"), "TFloatSeqSet", new TFloatSeqSet("Interp=Step;{[1@2019-09-01, 1@2019-09-02),[0@2019-09-03, 0@2019-09-05)}"))
@@ -363,7 +394,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> always_equal() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1.5f, true ),
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 2.5f, false ),
@@ -377,7 +409,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> ever_equal() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1.5f, true ),
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 2.5f, false ),
@@ -391,7 +424,8 @@ public class TFloatTest {
 
 
     private static Stream<Arguments> ever_greater() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1.5f, false ),
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 2.5f, true ),
@@ -424,7 +458,8 @@ public class TFloatTest {
     @ParameterizedTest(name="Test from base time constructor")
     @MethodSource("frombasetime")
     void testFromBaseTimeConstructor(Time source, String type, TInterpolation interpolation) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TFloatSeq") {
             TFloatSeq ti = (TFloatSeq) TFloat.from_base_time(1.5f, source, interpolation);
             assertTrue(ti instanceof TFloatSeq);
@@ -443,7 +478,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test from base temporal constructor")
     @MethodSource("frombasetemporal")
     void testFromBaseTemporalConstructor(Temporal source, String type, TInterpolation interpolation) {
-        //functions.meos_initialize("UTC", errorHandler);
+        //functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TFloatInst ti = new TFloatInst();
             TFloatInst new_ti = (TFloatInst) ti.from_base_temporal(1.5f,source,interpolation);
@@ -470,7 +506,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test from string constructor")
     @MethodSource("fromstring")
     void testStringConstructor(String source, String type, TInterpolation interpolation, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TFloatInst tinst = new TFloatInst(source);
             assertTrue(tinst instanceof TFloatInst);
@@ -497,7 +534,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test from copy constructor")
     @MethodSource("fromcopy")
     void testCopyConstructor(Temporal source, String type) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TFloatInst tb = (TFloatInst)source.copy();
             assertEquals(tb.to_string(15),(((TFloatInst) source).to_string(15)));
@@ -517,7 +555,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test  string ")
     @MethodSource("fromstring")
     void testString(String source, String type, TInterpolation interpolation, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TFloatInst tinst = new TFloatInst(source);
             assertEquals(tinst.to_string(15),expected);
@@ -536,7 +575,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test to tint ")
     @MethodSource("totint")
     void testToTInt(TFloat source, String type, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TInt tinst = ((TFloatInst) source).to_tint();
             assertEquals(tinst.to_string(),expected);
@@ -558,7 +598,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test bounding box ")
     @MethodSource("bounding")
     void testBoundingBox(Temporal source, String type, Box expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.bounding_box().toString(),expected.to_period().toString());
     }
 
@@ -568,7 +609,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test interpolation ")
     @MethodSource("interp")
     void testInterpolation(Temporal source, String type, TInterpolation expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.interpolation(),expected);
     }
 
@@ -576,7 +618,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test value span ")
     @MethodSource("value_span")
     void testValueSpan(TFloat source, String type, FloatSpan expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.value_span().toString(15),expected.toString(15));
     }
 
@@ -584,7 +627,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test values span ")
     @MethodSource("value_spans")
     void testValuesSpan(TInt source, String type, IntSpanSet expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.value_spans().toString(),expected.toString());
     }
 
@@ -594,7 +638,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test start value")
     @MethodSource("start_value")
     void testStart_value(TFloat source, String type, float expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_value(),expected);
     }
 
@@ -602,7 +647,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test end value")
     @MethodSource("end_value")
     void testEnd_value(TFloat source, String type, float expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_value(),expected);
     }
 
@@ -610,7 +656,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test min value")
     @MethodSource("min_value")
     void testMin_value(TFloat source, String type, float expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.min_value(),expected);
     }
 
@@ -618,7 +665,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test max value")
     @MethodSource("max_value")
     void testMax_value(TFloat source, String type, float expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.max_value(),expected);
     }
 
@@ -626,7 +674,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test time method")
     @MethodSource("time")
     void testTime(Temporal source, String type, tstzspanset expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.time().toString(),expected.toString());
     }
 
@@ -635,7 +684,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test period method")
     @MethodSource("period")
     void testtstzspan(Temporal source, String type, tstzspan expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.period().toString(),expected.toString());
     }
 
@@ -643,7 +693,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test timespan method")
     @MethodSource("period")
     void testTimespan(Temporal source, String type, tstzspan expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.timespan().toString(),expected.toString());
     }
 
@@ -651,7 +702,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test num instant method")
     @MethodSource("num_instant")
     void testNumInstant(Temporal source, String type, int expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.num_instants(),expected);
     }
 
@@ -659,7 +711,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test start instant method")
     @MethodSource("start_instant")
     void testStartInstant(Temporal source, String type, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloatInst)source.start_instant()).to_string(15),((TFloatInst)expected.start_instant()).to_string(15));
     }
 
@@ -667,7 +720,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test end instant method")
     @MethodSource("end_instant")
     void testEndInstant(Temporal source, String type, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloatInst)source.end_instant()).to_string(15),((TFloatInst)expected.end_instant()).to_string(15));
     }
 
@@ -676,7 +730,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test min instant method")
     @MethodSource("start_instant")
     void testMinInstant(Temporal source, String type, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloatInst)source.min_instant()).to_string(15),((TFloatInst)expected.min_instant()).to_string(15));
     }
 
@@ -684,7 +739,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test max instant method")
     @MethodSource("max_instant")
     void testMaxInstant(Temporal source, String type, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloatInst)source.max_instant()).to_string(15),((TFloatInst)expected.max_instant()).to_string(15));
     }
 
@@ -693,7 +749,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test instant n method")
     @MethodSource("instant_n")
     void testInstant_n(Temporal source, int n, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloatInst)source.instant_n(n)).to_string(15),((TFloatInst)expected).to_string(15));
     }
 
@@ -701,7 +758,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test num timestamps method")
     @MethodSource("num_timestamps")
     void testNumTimestamps(Temporal source, int n, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.num_timestamps(),n);
     }
 
@@ -709,7 +767,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test start timestamps method")
     @MethodSource("start_timestamps")
     void testStartTimestamps(Temporal source, int n, LocalDateTime expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_timestamp(),expected);
     }
 
@@ -717,7 +776,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test end timestamps method")
     @MethodSource("end_timestamps")
     void testEndTimestamps(Temporal source, int n, LocalDateTime expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_timestamp(),expected);
     }
 
@@ -725,7 +785,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test hash method")
     @MethodSource("hash")
     void testHash(Temporal source, long n, LocalDateTime expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.hash(),n);
     }
 
@@ -733,7 +794,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test to instant method")
     @MethodSource("toinstant")
     void testToinstant(Temporal source, String type, TFloatInst expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TFloatInst tmp = (TFloatInst) source.to_instant();
         assertTrue(tmp instanceof TFloatInst);
         assertEquals(tmp.to_string(15),expected.to_string(15));
@@ -745,7 +807,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test to sequence method")
     @MethodSource("tosequence")
     void testTosequence(Temporal source, String type, TInterpolation interp, TFloatSeq expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TFloatSeq tmp = (TFloatSeq) source.to_sequence(interp);
         assertTrue(tmp instanceof TFloatSeq);
         assertEquals(tmp.to_string(15),expected.to_string(15));
@@ -756,7 +819,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test to sequenceset method")
     @MethodSource("tosequenceset")
     void testTosequenceset(Temporal source, String type, TInterpolation interp, TFloatSeqSet expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TFloatSeqSet tmp = (TFloatSeqSet) source.to_sequenceset(interp);
         assertTrue(tmp instanceof TFloatSeqSet);
         assertEquals(tmp.to_string(15),expected.to_string(15));
@@ -768,7 +832,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test insert method")
     @MethodSource("insert")
     void testInsert(Temporal source, String type, TFloatSeq tseq, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TFloatInst tmp = (TFloatInst) source.insert(tseq);
             assertEquals(tmp.to_string(15), ((TFloatSeq)expected).to_string(15));
@@ -787,7 +852,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test update method")
     @MethodSource("update")
     void testUpdate(Temporal source, String type, TFloatInst tseq, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TFloatInst tmp = (TFloatInst) source.update(tseq);
             assertEquals(tmp.to_string(15), ((TFloatInst)expected).to_string(15));
@@ -804,7 +870,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test append sequence method")
     @MethodSource("append_sequence")
     void testAppendSequence(Temporal source, String type, TFloatSeq tseq, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TFloatSeq") {
             TFloatSeq tmp = (TFloatSeq) source.append_sequence(tseq);
             assertEquals(tmp.to_string(15), ((TFloatSeqSet)expected).to_string(15));
@@ -821,7 +888,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test abs method")
     @MethodSource("abs")
     void testAbs(Temporal source, String type, TFloatInst tseq, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TNumber tmp = ((TNumber) source).abs();
             assertEquals(((TFloatInst)tmp).to_string(15), ((TFloatInst)source).to_string(15));
@@ -838,7 +906,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test delta value method")
     @MethodSource("delta_value")
     void testDeltaValue(Temporal source, String type, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TNumber tmp = ((TNumber) source).delta_value();
             assertEquals(((TFloatInst)tmp).tostring(15), ((TFloatInst)expected).tostring(15));
@@ -858,7 +927,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test always equal method")
     @MethodSource("always_equal")
     void testAlwaysEqual(Temporal source, String type, float arg, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloat)source).always_equal(arg),expected);
         assertEquals(((TFloat)source).never_not_equal(arg),expected);
         assertEquals(((TFloat)source).ever_not_equal(arg),! expected);
@@ -870,7 +940,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test ever equal method")
     @MethodSource("ever_equal")
     void testEverEqual(Temporal source, String type, float arg, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloat)source).ever_equal(arg),expected);
         assertEquals(((TFloat)source).always_not_equal(arg),!expected);
         assertEquals(((TFloat)source).never_equal(arg),! expected);
@@ -880,7 +951,8 @@ public class TFloatTest {
     @ParameterizedTest(name ="Test ever greater method")
     @MethodSource("ever_greater")
     void testEverGreater(Temporal source, String type, float arg, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloat)source).always_less(arg),expected);
         assertEquals(((TFloat)source).never_greater_or_equal(arg),expected);
         assertEquals(((TFloat)source).ever_greater_or_equal(arg),! expected);

--- a/src/test/java/basic/TGeogPointTest.java
+++ b/src/test/java/basic/TGeogPointTest.java
@@ -51,7 +51,8 @@ public class TGeogPointTest {
     static error_handler_fn errorHandler = new error_handler();
 
     private static Stream<Arguments> fromtemporal() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1.5 1.5)@2019-09-01"), "TGeogPointInst",TInterpolation.NONE, "POINT(1 1)@2019-09-01 00:00:00+00"),
                 Arguments.of(new TGeogPointSeq("{Point(1.5 1.5)@2019-09-01, Point(2.5 2.5)@2019-09-02}"), "TGeogPointSeq",TInterpolation.DISCRETE, "{POINT(1 1)@2019-09-01 00:00:00+00, POINT(2 2)@2019-09-02 00:00:00+00}"),
@@ -63,7 +64,8 @@ public class TGeogPointTest {
 
 
     static Stream<Arguments> from_time() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"), "TGeogPointSeq", TInterpolation.DISCRETE),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"), "TGeogPointSeqSet", TInterpolation.STEPWISE),
@@ -74,7 +76,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> fromstring() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst",TInterpolation.NONE, "POINT(1 1)@2019-09-01 00:00:00+00"),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq",TInterpolation.DISCRETE, "{POINT(1 1)@2019-09-01 00:00:00+00, POINT(2 2)@2019-09-02 00:00:00+00}"),
@@ -85,7 +88,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> bounding() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", new STBox("GEODSTBOX XT(((1, 1),(1, 1)),[2019-09-01, 2019-09-01])")    ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", new STBox("GEODSTBOX XT(((1, 1),(2, 2)),[2019-09-01, 2019-09-02])")  ),
@@ -96,7 +100,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> fromstart() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", "POINT (1 1)"    ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", "POINT (1 1)" ),
@@ -107,7 +112,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> endstart() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", "POINT (1 1)"    ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", "POINT (2 2)" ),
@@ -118,7 +124,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> test_time() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", new tstzspanset("{[2019-09-01, 2019-09-01]}") ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", new tstzspanset("{[2019-09-01, 2019-09-01], [2019-09-02, 2019-09-02]}") ),
@@ -129,7 +136,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> period() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", new tstzspan("[2019-09-01, 2019-09-01]") ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", new tstzspan("[2019-09-01, 2019-09-02]") ),
@@ -139,7 +147,8 @@ public class TGeogPointTest {
     }
 
     private static Stream<Arguments> num_instant() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", 1 ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", 2 ),
@@ -150,7 +159,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> start_instant() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("Point(1 1)@2019-09-01", "TGeogPointInst", new TGeogPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}", "TGeogPointSeq", new TGeogPointInst("Point(1 1)@2019-09-01") ),
@@ -163,7 +173,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> end_instant() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("Point(1 1)@2019-09-01", "TGeogPointInst", new TGeogPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}", "TGeogPointSeq", new TGeogPointInst("Point(2 2)@2019-09-02") ),
@@ -174,7 +185,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> asmfjson() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         String jsonString1 = "{\n" +
                 "  \"type\": \"MovingGeomPoint\",\n" +
                 "  \"bbox\": [\n" +
@@ -353,7 +365,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> min_instant() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", new TGeogPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", new TGeogPointInst("Point(1 1)@2019-09-01") ),
@@ -364,7 +377,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> max_instant() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", new TGeogPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", new TGeogPointInst("Point(2 2)@2019-09-02") ),
@@ -375,7 +389,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> instantn() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), 0, new TGeogPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 1, new TGeogPointInst("Point(2 2)@2019-09-02") ),
@@ -386,7 +401,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> num_timestamps() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), 1),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 2),
@@ -398,7 +414,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> start_timestamps() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), LocalDateTime.of(2019, 9, 1, 0, 0,0)),
@@ -409,7 +426,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> end_timestamps() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -421,7 +439,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> hash() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
 //                Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), 382694564),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 1545137628),
@@ -432,7 +451,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> lower_inc() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), true),
                 Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), true)
@@ -442,7 +462,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> length() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), 0),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 0),
@@ -453,7 +474,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> cumullength() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), new TFloatInst("0@2019-09-01")),
                 Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), new TFloatSeq("[0@2019-09-01, 156876.14940188668@2019-09-02]")),
@@ -463,7 +485,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> speed() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), null),
                 Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), new TFloatSeq("[1.8157@2019-09-01, 1.8157@2019-09-02]")),
@@ -473,7 +496,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> xy() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), new TFloatInst("1@2019-09-01")),
                 Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), new TFloatSeq("[1@2019-09-01, 2@2019-09-02]")),
@@ -483,7 +507,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> xyz() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1 1)@2019-09-01"), new TFloatInst("1@2019-09-01")),
                 Arguments.of(new TGeogPointSeq("[Point(1 1 1)@2019-09-01, Point(2 2 2)@2019-09-02]"), new TFloatSeq("[1@2019-09-01, 2@2019-09-02]")),
@@ -493,7 +518,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> hasz() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), false),
                 Arguments.of(new TGeogPointSeq("[Point(1 1 1)@2019-09-01, Point(2 2 2)@2019-09-02]"), true),
@@ -503,7 +529,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> is_simple() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), true),
                 Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), true),
@@ -513,7 +540,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> angular_difference() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), "TGeogPointSeqSet", new TFloatSeqSet("{0@2019-09-01,0@2019-09-02}"))
         );
@@ -522,7 +550,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> togeom() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), new TGeomPointInst("Point(1 1)@2019-09-01"))
                 //Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}")),
@@ -533,7 +562,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> to_instant() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), new TGeogPointInst("Point(1 1)@2019-09-01")),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01}"), new TGeogPointInst("Point(1 1)@2019-09-01")),
@@ -545,7 +575,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> to_sequence() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), TInterpolation.LINEAR, new TGeogPointSeq("[Point(1 1)@2019-09-01]")),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), TInterpolation.DISCRETE, new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}")),
@@ -556,7 +587,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> to_sequenceset() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), TInterpolation.LINEAR, new TGeogPointSeqSet("{[Point(1 1)@2019-09-01]}")),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), TInterpolation.LINEAR, new TGeogPointSeqSet("{[Point(1 1)@2019-09-01], [Point(2 2)@2019-09-02]}")),
@@ -568,7 +600,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> set_interp() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", TInterpolation.DISCRETE, new TGeogPointSeq("{Point(1 1)@2019-09-01}")),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"),"TGeogPointSeq", TInterpolation.DISCRETE, new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}")),
@@ -579,7 +612,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> round() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1.123456789 1.123456789)@2019-09-01"), "TGeogPointInst", new TGeogPointInst("Point(1.12 1.12)@2019-09-01")),
                 Arguments.of(new TGeogPointSeq("{Point(1.123456789 1.123456789)@2019-09-01, Point(2.123456789 2.123456789)@2019-09-02}"),"TGeogPointSeq", new TGeogPointSeq("{Point(1.12 1.12)@2019-09-01,Point(2.12 2.12)@2019-09-02}")),
@@ -590,7 +624,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> insert() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq",new TGeogPointSeq("{Point(1 1)@2019-09-03}"), new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02, Point(1 1)@2019-09-03}")  ),
                 Arguments.of(new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), "TGeogPointSeqSet", new TGeogPointSeq("[Point(1 1)@2019-09-06]"), new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02],[Point(1 1)@2019-09-03, Point(1 1)@2019-09-05],[Point(1 1)@2019-09-06]}"))
@@ -600,7 +635,8 @@ public class TGeogPointTest {
 
 
     private static Stream<Arguments> append_sequence() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"),"TGeogPointSeq", new TGeogPointSeq("[Point(1 1)@2019-09-03]"), new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03]}")),
                 Arguments.of(new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02],[Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), "TGeogPointSeqSet", new TGeogPointSeq("[Point(1 1)@2019-09-06]"), new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02],[Point(1 1)@2019-09-03, Point(1 1)@2019-09-05],[Point(1 1)@2019-09-06]}"))
@@ -633,7 +669,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test from temporal constructor")
     @MethodSource("fromtemporal")
     void testFromTemporalConstructor(TGeogPoint source, String type, TInterpolation interpolation, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             GeometryFactory factory4326 = new GeometryFactory(new PrecisionModel(PrecisionModel.FLOATING), 4326);
             Point point = factory4326.createPoint(new Coordinate(1, 1));
@@ -659,7 +696,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test string constructor")
     @MethodSource("from_time")
     void testFromBaseTimeConstructor(Time source, String type, TInterpolation interpolation) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             GeometryFactory factory4326 = new GeometryFactory(new PrecisionModel(PrecisionModel.FLOATING), 4326);
             Point p = factory4326.createPoint(new Coordinate(1, 1));
@@ -681,7 +719,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test string constructor")
     @MethodSource("fromstring")
     void testFromStringConstructor(TGeogPoint source, String type, TInterpolation interpolation, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             TGeogPointInst ti = new TGeogPointInst(expected);
             assertTrue(ti instanceof TGeogPointInst);
@@ -704,7 +743,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test copy constructor")
     @MethodSource("fromstring")
     void testCopyConstructor(Temporal source, String type, TInterpolation interpolation, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             TGeogPointInst ti = (TGeogPointInst) source.copy();
             assertTrue(ti instanceof TGeogPointInst);
@@ -727,7 +767,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test bounding method")
     @MethodSource("bounding")
     void testBounding(TGeogPoint source, String type, STBox expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             //assertEquals(source.bounding_box_point().toString(15), expected.toString(15));
         } else if (type == "TGeogPointSeq") {
@@ -742,7 +783,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test interpolation method")
     @MethodSource("fromstring")
     void testInterpolation(Temporal source, String type, TInterpolation interpolation, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             assertEquals(source.interpolation(),interpolation);
         } else if (type == "TGeogPointSeq") {
@@ -757,7 +799,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test as mfjson method")
     @MethodSource("asmfjson")
     void testAsmfjson(Temporal source, String type, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         System.out.println(source.as_mfjson());
 //        assertEquals(source.as_mfjson(), expected);
     }
@@ -766,7 +809,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test start value method")
     @MethodSource("fromstart")
     void testStartvalue(TGeogPoint source, String type,  String expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_value(15).toString(), expected);
     }
 
@@ -774,7 +818,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test end value method")
     @MethodSource("endstart")
     void testEndvalue(TGeogPoint source, String type,  String expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_value(15).toString(), expected);
     }
 
@@ -782,7 +827,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test time method")
     @MethodSource("test_time")
     void testTime(TGeogPoint source, String type,  tstzspanset expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).time().toString(), expected.toString());
     }
 
@@ -791,7 +837,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test period method")
     @MethodSource("period")
     void testtstzspan(TGeogPoint source, String type,  tstzspan expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).period().toString(), expected.toString());
     }
 
@@ -799,14 +846,16 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test timespan method")
     @MethodSource("period")
     void testTimeSpan(TGeogPoint source, String type,  tstzspan expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).period().toString(), expected.toString());
     }
 
     @ParameterizedTest(name="Test num instant method")
     @MethodSource("num_instant")
     void testNumInst(TGeogPoint source, String type,  int expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).num_instants(), expected);
     }
 
@@ -814,7 +863,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test start instant method")
     @MethodSource("start_instant")
     void testStartInstant(String source, String type,  TGeogPoint expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             TGeogPointInst tg = new TGeogPointInst(source);
             TGeogPointInst new_tg = (TGeogPointInst) tg.start_instant();
@@ -835,7 +885,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test end instant method")
     @MethodSource("end_instant")
     void testEndInstant(String source, String type,  TGeogPoint expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             TGeogPointInst tg = new TGeogPointInst(source);
             TGeogPointInst new_tg = (TGeogPointInst) tg.end_instant();
@@ -855,7 +906,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test min instant method")
     @MethodSource("min_instant")
     void testMinInst(Temporal source, String type,  TGeogPointInst expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TGeogPointInst)source.min_instant()).to_string(), expected.to_string());
     }
 
@@ -864,7 +916,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test max instant method")
     @MethodSource("max_instant")
     void testMaxInst(Temporal source, String type,  TGeogPointInst expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TGeogPointInst)source.max_instant()).to_string(), expected.to_string());
     }
 
@@ -872,7 +925,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test instant n method")
     @MethodSource("instantn")
     void testInstN(Temporal source, int n,  TGeogPointInst expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TGeogPointInst)source.instant_n(n)).to_string(), expected.to_string());
     }
 
@@ -880,7 +934,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test num timestamps method")
     @MethodSource("num_timestamps")
     void testNumTimestamps(Temporal source, int n) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.num_timestamps(), n);
     }
 
@@ -888,7 +943,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test start timestamps method")
     @MethodSource("start_timestamps")
     void testStartTimestamps(Temporal source, LocalDateTime local) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_timestamp(), local);
     }
 
@@ -896,7 +952,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test end timestamps method")
     @MethodSource("end_timestamps")
     void testEndTimestamps(Temporal source, LocalDateTime local) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_timestamp(), local);
     }
 
@@ -904,7 +961,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test Hash method")
     @MethodSource("hash")
     void testHash(Temporal source, long hash) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.hash(), hash);
     }
 
@@ -912,7 +970,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test length method")
     @MethodSource("length")
     void testLength(TGeogPoint source, double hash) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TPoint)source).length(), hash);
     }
 
@@ -920,7 +979,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test cumulative length method")
     @MethodSource("cumullength")
     void testCumulLength(TGeogPoint source, TFloat tfloat) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals((source).cumulative_length().to_string(15), tfloat.to_string(15));
     }
 
@@ -928,7 +988,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test x y  method")
     @MethodSource("xy")
     void testXY(TGeogPoint source, TFloat tfloat) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.x().to_string(15), tfloat.to_string(15));
         assertEquals(source.y().to_string(15), tfloat.to_string(15));
     }
@@ -937,7 +998,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test x y z method")
     @MethodSource("xyz")
     void testXYZ(TGeogPoint source, TFloat tfloat) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.x().to_string(15), tfloat.to_string(15));
         assertEquals(source.y().to_string(15), tfloat.to_string(15));
         assertEquals(source.z().to_string(15), tfloat.to_string(15));
@@ -947,7 +1009,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test hasz method")
     @MethodSource("hasz")
     void testHasz(TGeogPoint source, boolean val) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.has_z(), val);
     }
 
@@ -955,7 +1018,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test is simple method")
     @MethodSource("is_simple")
     void testIsSimple(TGeogPoint source, boolean val) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.is_simple(), val);
     }
 
@@ -963,7 +1027,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test srid method")
     @MethodSource("is_simple")
     void testSRID(TGeogPoint source, boolean val) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.srid(), 4326);
     }
 
@@ -972,7 +1037,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test angular difference method")
     @MethodSource("angular_difference")
     void testAngula(TGeogPoint source, String type, TFloat val) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointSeq"){
             TFloatSeqSet tf = (TFloatSeqSet) source.angular_difference().to_degrees(true);
             assertEquals(tf.to_string(15), val.to_string(15));
@@ -987,7 +1053,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test to instant method")
     @MethodSource("to_instant")
     void testToInstant(Temporal source, TGeogPointInst tgeog) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TGeogPointInst tmp = (TGeogPointInst) source.to_instant();
         assertTrue(tmp instanceof TGeogPointInst);
         assertEquals(tmp.to_string(),tgeog.to_string());
@@ -997,7 +1064,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test to sequence method")
     @MethodSource("to_sequence")
     void testToSequence(Temporal source, TInterpolation interpolation, TGeogPointSeq tgeog) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TGeogPointSeq tmp = (TGeogPointSeq) source.to_sequence(interpolation);
         assertTrue(tmp instanceof TGeogPointSeq);
         assertEquals(tmp.to_string(),tgeog.to_string());
@@ -1007,7 +1075,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test to sequenceset method")
     @MethodSource("to_sequenceset")
     void testToSequenceSet(Temporal source, TInterpolation interpolation, TGeogPointSeqSet tgeog) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TGeogPointSeqSet tmp = (TGeogPointSeqSet) source.to_sequenceset(interpolation);
         assertTrue(tmp instanceof TGeogPointSeqSet);
         assertEquals(tmp.to_string(),tgeog.to_string());
@@ -1017,7 +1086,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test set interpolation method")
     @MethodSource("set_interp")
     void testSetInterp(Temporal source, String type, TInterpolation interpolation, TGeogPointSeq tgeog) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst"){
             TGeogPointInst tmp = (TGeogPointInst) source.set_interpolation(interpolation);
             assertTrue(tmp instanceof TGeogPointInst);
@@ -1039,7 +1109,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test round method")
     @MethodSource("round")
     void testRound(TPoint source, String type, TPoint tgeog) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TGeogPointInst" ){
             assertTrue(source instanceof TGeogPointInst);
             assertEquals(source.round(2).to_string(),tgeog.to_string());
@@ -1056,7 +1127,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test insert method")
     @MethodSource("insert")
     void testInsert(Temporal source, String type, Temporal add, Temporal expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointSeq"){
             TGeogPointSeq tgeog = (TGeogPointSeq) source.insert(add);
             assertEquals(tgeog.to_string(), ((TGeogPointSeq) expected).to_string());
@@ -1070,7 +1142,8 @@ public class TGeogPointTest {
     @ParameterizedTest(name="Test append sequence method")
     @MethodSource("append_sequence")
     void testAppendSequence(Temporal source, String type, TGeogPointSeq tgeoseq, Temporal expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 
         if (type == "TGeogPointSeq"){
             TGeogPointSeq tseq = (TGeogPointSeq) source.append_sequence(tgeoseq);

--- a/src/test/java/basic/TGeomPointTest.java
+++ b/src/test/java/basic/TGeomPointTest.java
@@ -49,7 +49,8 @@ public class TGeomPointTest {
     static error_handler_fn errorHandler = new error_handler();
 
     private static Stream<Arguments> fromtemporal() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1.5 1.5)@2019-09-01"), "TGeomPointInst",TInterpolation.NONE, "POINT(1 1)@2019-09-01 00:00:00+00"),
                 Arguments.of(new TGeomPointSeq("{Point(1.5 1.5)@2019-09-01, Point(2.5 2.5)@2019-09-02}"), "TGeomPointSeq",TInterpolation.DISCRETE, "{POINT(1 1)@2019-09-01 00:00:00+00, POINT(2 2)@2019-09-02 00:00:00+00}"),
@@ -61,7 +62,8 @@ public class TGeomPointTest {
 
 
     static Stream<Arguments> from_time() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"), "TGeomPointSeq", TInterpolation.DISCRETE),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"), "TGeomPointSeqSet", TInterpolation.LINEAR),
@@ -72,7 +74,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> fromstring() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst",TInterpolation.NONE, "POINT(1 1)@2019-09-01 00:00:00+00"),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq",TInterpolation.DISCRETE, "{POINT(1 1)@2019-09-01 00:00:00+00, POINT(2 2)@2019-09-02 00:00:00+00}"),
@@ -83,7 +86,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> bounding() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", new STBox("STBOX XT(((1, 1),(1, 1)),[2019-09-01, 2019-09-01])")    ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq", new STBox("STBOX XT(((1, 1),(2, 2)),[2019-09-01, 2019-09-02])")  ),
@@ -94,7 +98,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> fromstart() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", "POINT (1 1)"    ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq", "POINT (1 1)" ),
@@ -105,7 +110,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> endstart() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", "POINT (1 1)"    ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq", "POINT (2 2)" ),
@@ -148,7 +154,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> start_instant() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("Point(1 1)@2019-09-01", "TGeomPointInst", new TGeomPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}", "TGeomPointSeq", new TGeomPointInst("Point(1 1)@2019-09-01") ),
@@ -161,7 +168,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> end_instant() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("Point(1 1)@2019-09-01", "TGeomPointInst", new TGeomPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}", "TGeomPointSeq", new TGeomPointInst("Point(2 2)@2019-09-02") ),
@@ -172,7 +180,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> asmfjson() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         String jsonString1 = "{\n" +
                 "  \"type\": \"MovingGeomPoint\",\n" +
                 "  \"bbox\": [\n" +
@@ -351,7 +360,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> min_instant() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", new TGeomPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq", new TGeomPointInst("Point(1 1)@2019-09-01") ),
@@ -362,7 +372,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> max_instant() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", new TGeomPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq", new TGeomPointInst("Point(2 2)@2019-09-02") ),
@@ -373,7 +384,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> instantn() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), 0, new TGeomPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 1, new TGeomPointInst("Point(2 2)@2019-09-02") ),
@@ -384,7 +396,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> num_timestamps() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), 1),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 2),
@@ -396,7 +409,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> start_timestamps() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), LocalDateTime.of(2019, 9, 1, 0, 0,0)),
@@ -407,7 +421,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> end_timestamps() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -419,7 +434,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> hash() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), 382694564),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 1664033448),
@@ -430,7 +446,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> lower_inc() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), true),
                 Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), true)
@@ -440,7 +457,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> length() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), 0),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 0),
@@ -451,7 +469,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> cumullength() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), new TFloatInst("0@2019-09-01")),
                 Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), new TFloatSeq("[0@2019-09-01, 1.4142135623730951@2019-09-02]")),
@@ -461,7 +480,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> speed() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), null),
                 Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), new TFloatSeq("[1.8157@2019-09-01, 1.8157@2019-09-02]")),
@@ -471,7 +491,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> xy() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), new TFloatInst("1@2019-09-01")),
                 Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), new TFloatSeq("[1@2019-09-01, 2@2019-09-02]")),
@@ -481,7 +502,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> xyz() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1 1)@2019-09-01"), new TFloatInst("1@2019-09-01")),
                 Arguments.of(new TGeomPointSeq("[Point(1 1 1)@2019-09-01, Point(2 2 2)@2019-09-02]"), new TFloatSeq("[1@2019-09-01, 2@2019-09-02]")),
@@ -491,7 +513,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> hasz() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), false),
                 Arguments.of(new TGeomPointSeq("[Point(1 1 1)@2019-09-01, Point(2 2 2)@2019-09-02]"), true),
@@ -501,7 +524,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> is_simple() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), true),
                 Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), true),
@@ -511,7 +535,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> angular_difference() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), "TGeomPointSeqSet", new TFloatSeqSet("{0@2019-09-01,0@2019-09-02}"))
         );
@@ -520,7 +545,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> togeom() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), new TGeomPointInst("Point(1 1)@2019-09-01"))
                 //Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}")),
@@ -531,7 +557,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> to_instant() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), new TGeomPointInst("Point(1 1)@2019-09-01")),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01}"), new TGeomPointInst("Point(1 1)@2019-09-01")),
@@ -543,7 +570,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> to_sequence() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), TInterpolation.LINEAR, new TGeomPointSeq("[Point(1 1)@2019-09-01]")),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), TInterpolation.DISCRETE, new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}")),
@@ -554,7 +582,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> to_sequenceset() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), TInterpolation.LINEAR, new TGeomPointSeqSet("{[Point(1 1)@2019-09-01]}")),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), TInterpolation.LINEAR, new TGeomPointSeqSet("{[Point(1 1)@2019-09-01], [Point(2 2)@2019-09-02]}")),
@@ -566,7 +595,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> set_interp() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", TInterpolation.DISCRETE, new TGeomPointSeq("{Point(1 1)@2019-09-01}")),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"),"TGeomPointSeq", TInterpolation.DISCRETE, new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}")),
@@ -577,7 +607,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> round() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1.123456789 1.123456789)@2019-09-01"), "TGeomPointInst", new TGeomPointInst("Point(1.12 1.12)@2019-09-01")),
                 Arguments.of(new TGeomPointSeq("{Point(1.123456789 1.123456789)@2019-09-01, Point(2.123456789 2.123456789)@2019-09-02}"),"TGeomPointSeq", new TGeomPointSeq("{Point(1.12 1.12)@2019-09-01,Point(2.12 2.12)@2019-09-02}")),
@@ -588,7 +619,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> insert() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq",new TGeomPointSeq("{Point(1 1)@2019-09-03}"), new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02, Point(1 1)@2019-09-03}")  ),
                 Arguments.of(new TGeomPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), "TGeomPointSeqSet", new TGeomPointSeq("[Point(1 1)@2019-09-06]"), new TGeomPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02],[Point(1 1)@2019-09-03, Point(1 1)@2019-09-05],[Point(1 1)@2019-09-06]}"))
@@ -598,7 +630,8 @@ public class TGeomPointTest {
 
 
     private static Stream<Arguments> append_sequence() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"),"TGeomPointSeq", new TGeomPointSeq("[Point(1 1)@2019-09-03]"), new TGeomPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03]}")),
                 Arguments.of(new TGeomPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02],[Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), "TGeomPointSeqSet", new TGeomPointSeq("[Point(1 1)@2019-09-06]"), new TGeomPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02],[Point(1 1)@2019-09-03, Point(1 1)@2019-09-05],[Point(1 1)@2019-09-06]}"))
@@ -631,7 +664,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test from temporal constructor")
     @MethodSource("fromtemporal")
     void testFromTemporalConstructor(TGeomPoint source, String type, TInterpolation interpolation, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             GeometryFactory factory4326 = new GeometryFactory(new PrecisionModel(PrecisionModel.FLOATING), 4326);
             Point point = factory4326.createPoint(new Coordinate(1, 1));
@@ -657,7 +691,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test from time constructor")
     @MethodSource("from_time")
     void testFromBaseTimeConstructor(Time source, String type, TInterpolation interpolation) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             GeometryFactory factory4326 = new GeometryFactory(new PrecisionModel(PrecisionModel.FLOATING));
             Point p = factory4326.createPoint(new Coordinate(1, 1));
@@ -679,7 +714,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test string constructor")
     @MethodSource("fromstring")
     void testFromStringConstructor(TGeomPoint source, String type, TInterpolation interpolation, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             TGeomPointInst ti = new TGeomPointInst(expected);
             assertTrue(ti instanceof TGeomPointInst);
@@ -702,7 +738,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test copy constructor")
     @MethodSource("fromstring")
     void testCopyConstructor(Temporal source, String type, TInterpolation interpolation, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             TGeomPointInst ti = (TGeomPointInst) source.copy();
             assertTrue(ti instanceof TGeomPointInst);
@@ -725,7 +762,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test bounding method")
     @MethodSource("bounding")
     void testBounding(TGeomPoint source, String type, STBox expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             //assertEquals(source.bounding_box_point().toString(15), expected.toString(15));
         } else if (type == "TGeomPointSeq") {
@@ -740,7 +778,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test interpolation method")
     @MethodSource("fromstring")
     void testInterpolation(Temporal source, String type, TInterpolation interpolation, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             assertEquals(source.interpolation(),interpolation);
         } else if (type == "TGeomPointSeq") {
@@ -755,7 +794,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test as mfjson method")
     @MethodSource("asmfjson")
     void testAsmfjson(Temporal source, String type, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         System.out.println(source.as_mfjson());
     }
 
@@ -763,7 +803,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test start value method")
     @MethodSource("fromstart")
     void testStartvalue(TGeomPoint source, String type,  String expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_value(15).toString(), expected);
     }
 
@@ -771,7 +812,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test end value method")
     @MethodSource("endstart")
     void testEndvalue(TGeomPoint source, String type,  String expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_value(15).toString(), expected);
     }
 
@@ -779,7 +821,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test time method")
     @MethodSource("test_time")
     void testTime(TGeomPoint source, String type,  tstzspanset expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).time().toString(), expected.toString());
     }
 
@@ -788,7 +831,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test period method")
     @MethodSource("period")
     void testtstzspan(TGeomPoint source, String type,  tstzspan expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).period().toString(), expected.toString());
     }
 
@@ -796,14 +840,16 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test timespan method")
     @MethodSource("period")
     void testTimeSpan(TGeomPoint source, String type,  tstzspan expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).period().toString(), expected.toString());
     }
 
     @ParameterizedTest(name="Test num instant method")
     @MethodSource("num_instant")
     void testNumInst(TGeomPoint source, String type,  int expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).num_instants(), expected);
     }
 
@@ -811,7 +857,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test start instant method")
     @MethodSource("start_instant")
     void testStartInstant(String source, String type,  TGeomPoint expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             TGeomPointInst tg = new TGeomPointInst(source);
             TGeomPointInst new_tg = (TGeomPointInst) tg.start_instant();
@@ -832,7 +879,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test end instant method")
     @MethodSource("end_instant")
     void testEndInstant(String source, String type,  TGeomPoint expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             TGeomPointInst tg = new TGeomPointInst(source);
             TGeomPointInst new_tg = (TGeomPointInst) tg.end_instant();
@@ -852,7 +900,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test min instant method")
     @MethodSource("min_instant")
     void testMinInst(Temporal source, String type,  TGeomPointInst expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TGeomPointInst)source.min_instant()).to_string(), expected.to_string());
     }
 
@@ -861,7 +910,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test max instant method")
     @MethodSource("max_instant")
     void testMaxInst(Temporal source, String type,  TGeomPointInst expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TGeomPointInst)source.max_instant()).to_string(), expected.to_string());
     }
 
@@ -869,7 +919,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test instant n method")
     @MethodSource("instantn")
     void testInstN(Temporal source, int n,  TGeomPointInst expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TGeomPointInst)source.instant_n(n)).to_string(), expected.to_string());
     }
 
@@ -877,7 +928,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test num timestamps method")
     @MethodSource("num_timestamps")
     void testNumTimestamps(Temporal source, int n) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.num_timestamps(), n);
     }
 
@@ -885,7 +937,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test start timestamps method")
     @MethodSource("start_timestamps")
     void testStartTimestamps(Temporal source, LocalDateTime local) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_timestamp(), local);
     }
 
@@ -893,7 +946,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test end timestamps method")
     @MethodSource("end_timestamps")
     void testEndTimestamps(Temporal source, LocalDateTime local) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_timestamp(), local);
     }
 
@@ -901,7 +955,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test Hash method")
     @MethodSource("hash")
     void testHash(Temporal source, long hash) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.hash(), hash);
     }
 
@@ -909,7 +964,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test length method")
     @MethodSource("length")
     void testLength(TGeomPoint source, double hash) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TPoint)source).length(), hash);
     }
 
@@ -917,7 +973,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test cumulative length method")
     @MethodSource("cumullength")
     void testCumulLength(TGeomPoint source, TFloat tfloat) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals((source).cumulative_length().to_string(15), tfloat.to_string(15));
     }
 
@@ -925,7 +982,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test x y  method")
     @MethodSource("xy")
     void testXY(TGeomPoint source, TFloat tfloat) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.x().to_string(15), tfloat.to_string(15));
         assertEquals(source.y().to_string(15), tfloat.to_string(15));
     }
@@ -934,7 +992,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test x y z method")
     @MethodSource("xyz")
     void testXYZ(TGeomPoint source, TFloat tfloat) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.x().to_string(15), tfloat.to_string(15));
         assertEquals(source.y().to_string(15), tfloat.to_string(15));
         assertEquals(source.z().to_string(15), tfloat.to_string(15));
@@ -944,7 +1003,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test hasz method")
     @MethodSource("hasz")
     void testHasz(TGeomPoint source, boolean val) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.has_z(), val);
     }
 
@@ -952,7 +1012,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test is simple method")
     @MethodSource("is_simple")
     void testIsSimple(TGeomPoint source, boolean val) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.is_simple(), val);
     }
 
@@ -960,7 +1021,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test srid method")
     @MethodSource("is_simple")
     void testSRID(TGeomPoint source, boolean val) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.srid(), 0);
     }
 
@@ -969,7 +1031,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test angular difference method")
     @MethodSource("angular_difference")
     void testAngula(TGeomPoint source, String type, TFloat val) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointSeq"){
             TFloatSeqSet tf = (TFloatSeqSet) source.angular_difference().to_degrees(true);
             assertEquals(tf.to_string(15), val.to_string(15));
@@ -984,7 +1047,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test to instant method")
     @MethodSource("to_instant")
     void testToInstant(Temporal source, TGeomPointInst TGeom) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TGeomPointInst tmp = (TGeomPointInst) source.to_instant();
         assertTrue(tmp instanceof TGeomPointInst);
         assertEquals(tmp.to_string(),TGeom.to_string());
@@ -994,7 +1058,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test to sequence method")
     @MethodSource("to_sequence")
     void testToSequence(Temporal source, TInterpolation interpolation, TGeomPointSeq TGeom) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TGeomPointSeq tmp = (TGeomPointSeq) source.to_sequence(interpolation);
         assertTrue(tmp instanceof TGeomPointSeq);
         assertEquals(tmp.to_string(),TGeom.to_string());
@@ -1004,7 +1069,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test to sequenceset method")
     @MethodSource("to_sequenceset")
     void testToSequenceSet(Temporal source, TInterpolation interpolation, TGeomPointSeqSet TGeom) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TGeomPointSeqSet tmp = (TGeomPointSeqSet) source.to_sequenceset(interpolation);
         assertTrue(tmp instanceof TGeomPointSeqSet);
         assertEquals(tmp.to_string(),TGeom.to_string());
@@ -1014,7 +1080,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test set interpolation method")
     @MethodSource("set_interp")
     void testSetInterp(Temporal source, String type, TInterpolation interpolation, TGeomPointSeq TGeom) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst"){
             TGeomPointInst tmp = (TGeomPointInst) source.set_interpolation(interpolation);
             assertTrue(tmp instanceof TGeomPointInst);
@@ -1036,7 +1103,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test round method")
     @MethodSource("round")
     void testRound(TPoint source, String type, TPoint TGeom) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TGeomPointInst" ){
             assertTrue(source instanceof TGeomPointInst);
             assertEquals(source.round(2).to_string(),TGeom.to_string());
@@ -1053,7 +1121,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test insert method")
     @MethodSource("insert")
     void testInsert(Temporal source, String type, Temporal add, Temporal expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointSeq"){
             TGeomPointSeq TGeom = (TGeomPointSeq) source.insert(add);
             assertEquals(TGeom.to_string(), ((TGeomPointSeq) expected).to_string());
@@ -1067,7 +1136,8 @@ public class TGeomPointTest {
     @ParameterizedTest(name="Test append sequence method")
     @MethodSource("append_sequence")
     void testAppendSequence(Temporal source, String type, TGeomPointSeq tgeoseq, Temporal expected) throws ParseException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 
         if (type == "TGeomPointSeq"){
             TGeomPointSeq tseq = (TGeomPointSeq) source.append_sequence(tgeoseq);

--- a/src/test/java/basic/TIntTest.java
+++ b/src/test/java/basic/TIntTest.java
@@ -33,7 +33,8 @@ public class TIntTest {
     static error_handler_fn errorHandler = new error_handler();
 
     private static Stream<Arguments> frombasetemporal() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TIntInst", TInterpolation.NONE),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 0.5@2019-09-02]"), "TIntSeq", TInterpolation.STEPWISE),
@@ -43,7 +44,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> frombasetime() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"), "TIntSeq", TInterpolation.DISCRETE),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"), "TIntSeq", TInterpolation.STEPWISE),
@@ -63,7 +65,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> fromcopy() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst"),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq"),
@@ -72,7 +75,8 @@ public class TIntTest {
     }
 
     private static Stream<Arguments> totfloat() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", "1@2019-09-01 00:00:00+00"),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", "Interp=Step;[1@2019-09-01 00:00:00+00, 2@2019-09-02 00:00:00+00]"),
@@ -83,7 +87,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> bounding() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TBox("TBOXINT XT([1,1],[2019-09-01, 2019-09-01])")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new TBox("TBOXINT XT([1,2],[2019-09-01, 2019-09-02])")),
@@ -92,7 +97,8 @@ public class TIntTest {
     }
 
     private static Stream<Arguments> interp() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", TInterpolation.NONE),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", TInterpolation.STEPWISE),
@@ -102,7 +108,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> value_span() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new IntSpan(1, 1, true, true)),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new IntSpan(1, 2, true, true)),
@@ -112,7 +119,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> value_spans() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new IntSpanSet("{[1,1]}")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new IntSpanSet("{[1,2]}")),
@@ -122,7 +130,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> start_value() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", 1),
@@ -132,7 +141,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> end_value() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", 2),
@@ -142,7 +152,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> min_value() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", 1),
@@ -152,7 +163,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> max_value() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", 2),
@@ -162,7 +174,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> time() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new tstzspanset("{[2019-09-01, 2019-09-01]}")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new tstzspanset("{[2019-09-01, 2019-09-02]}")),
@@ -172,7 +185,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> period() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new tstzspan("[2019-09-01, 2019-09-01]")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new tstzspan("[2019-09-01, 2019-09-02]")),
@@ -181,7 +195,8 @@ public class TIntTest {
     }
 
     private static Stream<Arguments> num_instant() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq",2),
@@ -192,7 +207,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> start_instant() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntInst("1@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq",new TIntInst("1@2019-09-01")),
@@ -203,7 +219,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> end_instant() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntInst("1@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq",new TIntInst("2@2019-09-02")),
@@ -213,7 +230,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> max_instant() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntInst("1@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq",new TIntInst("2@2019-09-02")),
@@ -223,7 +241,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> instant_n() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), 0, new TIntInst("1@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), 1,new TIntInst("2@2019-09-02")),
@@ -234,7 +253,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> num_timestamps() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), 1, new TIntInst("1@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), 2,new TIntInst("2@2019-09-02")),
@@ -245,7 +265,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> start_timestamps() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), 1, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), 2, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
@@ -255,7 +276,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> end_timestamps() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), 1, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), 2, LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -265,7 +287,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> hash() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), 440045287, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
 //                Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), 3589664982l, LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -275,7 +298,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> toinstant() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntInst("1@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01]"), "TIntSeq", new TIntInst("1@2019-09-01")),
@@ -285,7 +309,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> tosequence() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", TInterpolation.NONE, new TIntSeq("[1@2019-09-01]")),
 //                Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", TInterpolation.DISCRETE, new TIntSeq("[1@2019-09-01, 2@2019-09-02]"))
@@ -295,7 +320,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> tosequenceset() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", TInterpolation.NONE, new TIntSeqSet("{[1@2019-09-01]}"))
 //                Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", TInterpolation.STEPWISE, new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02]}"))
@@ -305,7 +331,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> insert() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntSeq("{1@2019-09-03}"), new TIntSeq("{1@2019-09-01, 1@2019-09-03}")),
                 Arguments.of(new TIntSeq("{[1@2019-09-01, 2@2019-09-02]}"), "TIntSeq", new TIntSeq("[1@2019-09-03]"), new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02], [1@2019-09-03]}")),
@@ -315,7 +342,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> update() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntInst("2@2019-09-01"), new TIntInst("2@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new TIntInst("2@2019-09-01"), new TIntSeqSet("{[2@2019-09-01], (1@2019-09-01, 2@2019-09-02]}")),
@@ -325,7 +353,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> append_sequence() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new TIntSeq("[1@2019-09-03]"), new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02], [1@2019-09-03]}")),
                 Arguments.of(new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05]}"), "TIntSeqSet", new TIntSeq("[1@2019-09-06]"), new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05],[1@2019-09-06]}"))
@@ -334,7 +363,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> abs() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntInst("2@2019-09-01"), new TIntInst("2@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new TIntInst("2@2019-09-01"), new TIntSeqSet("{[2@2019-09-01], (1@2019-09-01, 2@2019-09-02]}")),
@@ -344,7 +374,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> delta_value() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new TIntInst("2@2019-09-01"), new TIntSeq("[1@2019-09-01, 1@2019-09-02)")),
                 Arguments.of(new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05]}"), "TIntSeqSet", new TIntInst("2@2019-09-01"), new TIntSeqSet("{[1@2019-09-01, 1@2019-09-02),[0@2019-09-03, 0@2019-09-05)}"))
@@ -354,7 +385,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> always_equal() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1, true ),
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 2, false ),
@@ -368,7 +400,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> ever_equal() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1, true ),
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 2, false ),
@@ -382,7 +415,8 @@ public class TIntTest {
 
 
     private static Stream<Arguments> ever_greater() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1, false ),
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 2, true ),
@@ -415,7 +449,8 @@ public class TIntTest {
     @ParameterizedTest(name="Test from base time constructor")
     @MethodSource("frombasetime")
     void testFromBaseTimeConstructor(Time source, String type, TInterpolation interpolation) throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TIntSeq") {
             System.out.println(source.toString());
             TIntSeq ti = (TIntSeq)TInt.from_base_time(1, source, interpolation);
@@ -463,7 +498,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test from string constructor")
     @MethodSource("fromstring")
     void testStringConstructor(String source, String type, TInterpolation interpolation, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TIntInst tinst = new TIntInst(source);
             assertTrue(tinst instanceof TIntInst);
@@ -490,7 +526,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test from copy constructor")
     @MethodSource("fromcopy")
     void testCopyConstructor(Temporal source, String type) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TIntInst tb = (TIntInst)source.copy();
             assertEquals(tb.to_string(),(((TIntInst) source).to_string()));
@@ -510,7 +547,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test  string ")
     @MethodSource("fromstring")
     void testString(String source, String type, TInterpolation interpolation, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TIntInst tinst = new TIntInst(source);
             assertEquals(tinst.to_string(),expected);
@@ -529,7 +567,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test to tfloat ")
     @MethodSource("totfloat")
     void testToTfloat(TInt source, String type, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TFloatInst tinst = (TFloatInst) source.to_tfloat();
             assertEquals(tinst.to_string(2),expected);
@@ -549,7 +588,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test bounding box ")
     @MethodSource("bounding")
     void testBoundingBox(Temporal source, String type, Box expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.bounding_box().toString(),expected.to_period().toString());
     }
 
@@ -557,7 +597,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test interpolation ")
     @MethodSource("interp")
     void testInterpolation(Temporal source, String type, TInterpolation expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.interpolation(),expected);
     }
 
@@ -565,7 +606,7 @@ public class TIntTest {
     @ParameterizedTest(name ="Test value span ")
     @MethodSource("value_span")
     void testValueSpan(TInt source, String type, IntSpan expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC"  );
         assertEquals(source.value_span().toString(),expected.toString());
     }
 
@@ -573,7 +614,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test values span ")
     @MethodSource("value_spans")
     void testValuesSpan(TInt source, String type, IntSpanSet expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.value_spans().toString(),expected.toString());
     }
 
@@ -581,7 +623,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test start value")
     @MethodSource("start_value")
     void testStart_value(TInt source, String type, int expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_value(),expected);
     }
 
@@ -589,7 +632,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test end value")
     @MethodSource("end_value")
     void testEnd_value(TInt source, String type, int expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_value(),expected);
     }
 
@@ -597,7 +641,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test min value")
     @MethodSource("min_value")
     void testMin_value(TInt source, String type, int expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.min_value(),expected);
     }
 
@@ -605,7 +650,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test max value")
     @MethodSource("max_value")
     void testMax_value(TInt source, String type, int expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.max_value(),expected);
     }
 
@@ -613,7 +659,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test time method")
     @MethodSource("time")
     void testTime(Temporal source, String type, tstzspanset expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.time().toString(),expected.toString());
     }
 
@@ -622,7 +669,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test period method")
     @MethodSource("period")
     void testtstzspan(Temporal source, String type, tstzspan expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.period().toString(),expected.toString());
     }
 
@@ -630,7 +678,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test period method")
     @MethodSource("period")
     void testTimespan(Temporal source, String type, tstzspan expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.timespan().toString(),expected.toString());
     }
 
@@ -638,7 +687,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test num instant method")
     @MethodSource("num_instant")
     void testNumInstant(Temporal source, String type, int expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.num_instants(),expected);
     }
 
@@ -646,7 +696,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test start instant method")
     @MethodSource("start_instant")
     void testStartInstant(Temporal source, String type, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TIntInst)source.start_instant()).to_string(),((TIntInst)expected.start_instant()).to_string());
     }
 
@@ -654,7 +705,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test end instant method")
     @MethodSource("end_instant")
     void testEndInstant(Temporal source, String type, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TIntInst)source.end_instant()).to_string(),((TIntInst)expected.end_instant()).to_string());
     }
 
@@ -663,7 +715,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test min instant method")
     @MethodSource("start_instant")
     void testMinInstant(Temporal source, String type, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TIntInst)source.min_instant()).to_string(),((TIntInst)expected.min_instant()).to_string());
     }
 
@@ -671,7 +724,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test max instant method")
     @MethodSource("max_instant")
     void testMaxInstant(Temporal source, String type, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TIntInst)source.max_instant()).to_string(),((TIntInst)expected.max_instant()).to_string());
     }
 
@@ -680,7 +734,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test instant n method")
     @MethodSource("instant_n")
     void testInstant_n(Temporal source, int n, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TIntInst)source.instant_n(n)).to_string(),((TIntInst)expected).to_string());
     }
 
@@ -688,7 +743,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test num timestamps method")
     @MethodSource("num_timestamps")
     void testNumTimestamps(Temporal source, int n, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.num_timestamps(),n);
     }
 
@@ -696,7 +752,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test start timestamps method")
     @MethodSource("start_timestamps")
     void testStartTimestamps(Temporal source, int n, LocalDateTime expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_timestamp(),expected);
     }
 
@@ -704,7 +761,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test end timestamps method")
     @MethodSource("end_timestamps")
     void testEndTimestamps(Temporal source, int n, LocalDateTime expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_timestamp(),expected);
     }
 
@@ -712,7 +770,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test hash method")
     @MethodSource("hash")
     void testHash(Temporal source, long n, LocalDateTime expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.hash(),n);
     }
 
@@ -720,7 +779,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test to instant method")
     @MethodSource("toinstant")
     void testToinstant(Temporal source, String type, TIntInst expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TIntInst tmp = (TIntInst) source.to_instant();
         assertTrue(tmp instanceof TIntInst);
         assertEquals(tmp.to_string(),expected.to_string());
@@ -732,7 +792,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test to sequence method")
     @MethodSource("tosequence")
     void testTosequence(Temporal source, String type, TInterpolation interp, TIntSeq expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         System.out.println(source.to_sequence(interp).start_timestamp());
 //        System.out.println(source.to_sequenceset(interp));
         TIntSeq tmp = (TIntSeq) source.to_sequence(interp);
@@ -744,7 +805,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test to sequenceset method")
     @MethodSource("tosequenceset")
     void testTosequenceset(Temporal source, String type, TInterpolation interp, TIntSeqSet expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         System.out.println(source.to_sequenceset(interp).start_timestamp());
         TIntSeqSet tmp = (TIntSeqSet) source.to_sequenceset(interp);
         assertTrue(tmp instanceof TIntSeqSet);
@@ -757,7 +819,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test insert method")
     @MethodSource("insert")
     void testInsert(Temporal source, String type, TIntSeq tseq, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TIntInst tmp = (TIntInst) source.insert(tseq);
             assertEquals(tmp.to_string(), ((TIntSeq)expected).to_string());
@@ -776,7 +839,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test update method")
     @MethodSource("update")
     void testUpdate(Temporal source, String type, TIntInst tseq, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TIntInst tmp = (TIntInst) source.update(tseq);
             assertEquals(tmp.to_string(), ((TIntInst)expected).to_string());
@@ -792,7 +856,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test append sequence method")
     @MethodSource("append_sequence")
     void testAppendSequence(Temporal source, String type, TIntSeq tseq, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TIntSeq") {
             TIntSeq tmp = (TIntSeq) source.append_sequence(tseq);
             assertEquals(tmp.to_string(), ((TIntSeqSet)expected).to_string());
@@ -805,7 +870,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test abs method")
     @MethodSource("abs")
     void testAbs(Temporal source, String type, TIntInst tseq, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TNumber tmp = ((TNumber) source).abs();
             assertEquals(((TIntInst)tmp).to_string(), ((TIntInst)source).to_string());
@@ -822,7 +888,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test delta value method")
     @MethodSource("delta_value")
     void testDeltaValue(Temporal source, String type, TIntInst tseq, Temporal expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TNumber tmp = ((TNumber) source).delta_value();
             assertEquals(((TIntInst)tmp).to_string(), ((TIntInst)expected).to_string());
@@ -840,7 +907,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test always equal method")
     @MethodSource("always_equal")
     void testAlwaysEqual(Temporal source, String type, int arg, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         System.out.println(((TInt)source).never_not_equal(arg));
         System.out.println(expected);
         assertEquals(((TInt)source).always_equal(arg),expected);
@@ -854,7 +922,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test ever equal method")
     @MethodSource("ever_equal")
     void testEverEqual(Temporal source, String type, int arg, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 //        assertEquals(((TInt)source).ever_equal(arg),expected);
         assertEquals(((TInt)source).always_not_equal(arg),!expected);
 //        assertEquals(((TInt)source).never_equal(arg),! expected);
@@ -864,7 +933,8 @@ public class TIntTest {
     @ParameterizedTest(name ="Test ever greater method")
     @MethodSource("ever_greater")
     void testEverGreater(Temporal source, String type, int arg, boolean expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TInt)source).always_less(arg),expected);
         assertEquals(((TInt)source).never_greater_or_equal(arg),expected);
         assertEquals(((TInt)source).ever_greater_or_equal(arg),! expected);

--- a/src/test/java/basic/TTextTest.java
+++ b/src/test/java/basic/TTextTest.java
@@ -28,7 +28,8 @@ public class TTextTest {
     static error_handler_fn errorHandler = new error_handler();
     
     static Stream<Arguments> TText_string_constructor() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("AAA@2019-09-01", "TTextInst", TInterpolation.NONE, "\"AAA\"@2019-09-01 00:00:00+00"),
                 Arguments.of("{AAA@2019-09-01, BBB@2019-09-02}", "TTextSeq", TInterpolation.DISCRETE, "{\"AAA\"@2019-09-01 00:00:00+00, \"BBB\"@2019-09-02 00:00:00+00}"),
@@ -38,7 +39,8 @@ public class TTextTest {
     }
 
     static Stream<Arguments> TText_base_time_constructor() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"), "TTextSeq", TInterpolation.DISCRETE),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"), "TTextSeqSet", TInterpolation.STEPWISE),
@@ -48,7 +50,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_copy_constructor() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", TInterpolation.NONE),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", TInterpolation.DISCRETE),
@@ -59,7 +62,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_string() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", "\"AAA\"@2019-09-01 00:00:00+00"),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq","{\"AAA\"@2019-09-01 00:00:00+00, \"BBB\"@2019-09-02 00:00:00+00}"),
@@ -70,7 +74,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_bounding() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst",new tstzspan("[2019-09-01, 2019-09-01]")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", new tstzspan("[2019-09-01, 2019-09-02]")),
@@ -81,7 +86,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_interp() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", TInterpolation.NONE),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", TInterpolation.DISCRETE),
@@ -91,7 +97,8 @@ public class TTextTest {
     }
 
     static Stream<Arguments> TText_start() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", "AAA"),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", "AAA"),
@@ -102,7 +109,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_end() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", "AAA"),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", "BBB"),
@@ -113,7 +121,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_time() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", new tstzspanset("{[2019-09-01, 2019-09-01]}")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", new tstzspanset("{[2019-09-01, 2019-09-01], [2019-09-02, 2019-09-02]}")),
@@ -124,7 +133,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_numinst() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", 1),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", 2),
@@ -136,7 +146,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_startinst() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", new TTextInst("AAA@2019-09-01")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", new TTextInst("AAA@2019-09-01")),
@@ -147,7 +158,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_endinst() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", new TTextInst("AAA@2019-09-01")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", new TTextInst("BBB@2019-09-02")),
@@ -159,7 +171,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_mininst() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", new TTextInst("AAA@2019-09-01")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", new TTextInst("AAA@2019-09-01")),
@@ -170,7 +183,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_maxinst() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", new TTextInst("AAA@2019-09-01")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", new TTextInst("BBB@2019-09-02")),
@@ -180,7 +194,8 @@ public class TTextTest {
     }
 
     static Stream<Arguments> TText_instn() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", 0, new TTextInst("AAA@2019-09-01")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq",1, new TTextInst("BBB@2019-09-02")),
@@ -191,7 +206,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_numtmstp() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", 1),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq",2),
@@ -202,7 +218,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_starttmstp() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq",LocalDateTime.of(2019, 9, 1, 0, 0,0)),
@@ -212,7 +229,8 @@ public class TTextTest {
     }
 
     static Stream<Arguments> TText_endtmstp() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq",LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -223,7 +241,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_hash() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", 1893808825),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq",1223816819),
@@ -234,7 +253,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_toinstant() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"),new TTextInst("AAA@2019-09-01")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01}"), new TTextInst("AAA@2019-09-01")),
@@ -245,7 +265,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_tosequence() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), TInterpolation.STEPWISE, new TTextSeq("[AAA@2019-09-01]")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), TInterpolation.DISCRETE,  new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}")),
@@ -256,7 +277,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_tosequenceset() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), TInterpolation.STEPWISE, new TTextSeqSet("{[AAA@2019-09-01]}")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), TInterpolation.STEPWISE,  new TTextSeqSet("{[AAA@2019-09-01], [BBB@2019-09-02]}"))
@@ -268,7 +290,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_insert() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), new TTextSeq("{AAA@2019-09-03}"), new TTextSeq("{AAA@2019-09-01, AAA@2019-09-03}"), "TTextInst"),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), new TTextSeq("{AAA@2019-09-03}"), new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02, AAA@2019-09-03}"), "TTextSeq"),
@@ -279,7 +302,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_update() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), new TTextInst("BBB@2019-09-01"), new TTextInst("BBB@2019-09-01"), "TTextInst" ),
                 Arguments.of(new TTextSeq("[AAA@2019-09-01, BBB@2019-09-02]"), new TTextInst("BBB@2019-09-01"), new TTextSeqSet("{[BBB@2019-09-01], (AAA@2019-09-01, BBB@2019-09-02]}"), "TTextSeq"),
@@ -290,7 +314,8 @@ public class TTextTest {
 
 
     static Stream<Arguments> TText_appendseq() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), new TTextSeq("{AAA@2019-09-03}"),  new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02, AAA@2019-09-03}"), "TTextSeq"),
                 Arguments.of(new TTextSeqSet("{[AAA@2019-09-01, BBB@2019-09-02],[AAA@2019-09-03, AAA@2019-09-05]}"), new TTextSeq("[AAA@2019-09-06]"), new TTextSeqSet("{[AAA@2019-09-01, BBB@2019-09-02],[AAA@2019-09-03, AAA@2019-09-05],[AAA@2019-09-06]}"), "TTextSeqSet")
@@ -316,7 +341,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test from string constructor.")
     @MethodSource("TText_string_constructor")
     public void testFromStringConstructor(String value, String type, TInterpolation interp, String repr) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextInst") {
             TTextInst tb = new TTextInst(value);
             assertTrue(tb instanceof TTextInst);
@@ -339,7 +365,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test from time constructor.")
     @MethodSource("TText_base_time_constructor")
     public void testFromBaseTimeConstructor(Time base, String type, TInterpolation interp) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextInst") {
             TTextInst tb = (TTextInst) TText.from_base_time("AAA", base);
             assertTrue(tb instanceof TTextInst);
@@ -361,7 +388,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test copy constructor.")
     @MethodSource("TText_copy_constructor")
     public void testCopyConstructor(Temporal base, String type, TInterpolation interp) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextInst") {
             TTextInst tb = (TTextInst) base.copy();
             assertEquals(tb.to_string(),(((TTextInst) base).to_string()));
@@ -379,7 +407,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test string.")
     @MethodSource("TText_string")
     public void testString(Temporal base, String type, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextInst") {
             TTextInst tb = (TTextInst) base.copy();
             assertEquals(tb.to_string(),expected);
@@ -396,7 +425,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test bounding box method.")
     @MethodSource("TText_bounding")
     public void testBoundingBox(Temporal base, String type, tstzspan expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.bounding_box().toString(),expected.toString());
     }
 
@@ -405,7 +435,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test interpolation method.")
     @MethodSource("TText_interp")
     public void testInterpolation(Temporal base, String type, TInterpolation expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.interpolation(),expected);
     }
 
@@ -413,7 +444,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test start values method.")
     @MethodSource("TText_start")
     public void testStartValues(Temporal base, String type, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TText) base).start_value() ,expected);
     }
 
@@ -421,7 +453,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test end values method.")
     @MethodSource("TText_end")
     public void testEndValues(Temporal base, String type, String expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TText) base).end_value() ,expected);
     }
 
@@ -429,7 +462,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test time method.")
     @MethodSource("TText_time")
     public void testTime(Temporal base, String type, tstzspanset expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.time().toString() ,expected.toString());
     }
 
@@ -437,7 +471,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test period method.")
     @MethodSource("TText_bounding")
     public void testtstzspan(Temporal base, String type, tstzspan expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.period().toString() ,expected.toString());
     }
 
@@ -445,14 +480,16 @@ public class TTextTest {
     @ParameterizedTest(name = "Test span method.")
     @MethodSource("TText_bounding")
     public void testSpan(Temporal base, String type, tstzspan expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.timespan().toString(),expected.toString());
     }
 
     @ParameterizedTest(name = "Test numinst method.")
     @MethodSource("TText_numinst")
     public void testNumInst(Temporal base, String type, int expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.num_instants(),expected);
     }
 
@@ -460,7 +497,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test startinst method.")
     @MethodSource("TText_startinst")
     public void testStartInst(Temporal base, String type, TTextInst expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TTextInst)base.start_instant()).to_string(),expected.to_string());
     }
 
@@ -468,7 +506,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test endinst method.")
     @MethodSource("TText_endinst")
     public void testEndInst(Temporal base, String type, TTextInst expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TTextInst)base.end_instant()).to_string(),expected.to_string());
     }
 
@@ -476,7 +515,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test mininst method.")
     @MethodSource("TText_mininst")
     public void testMinInst(Temporal base, String type, TTextInst expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TTextInst)base.min_instant()).to_string(),expected.to_string());
     }
 
@@ -484,7 +524,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test maxinst method.")
     @MethodSource("TText_maxinst")
     public void testMaxInst(Temporal base, String type, TTextInst expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TTextInst)base.max_instant()).to_string(),expected.to_string());
     }
 
@@ -492,7 +533,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test instn method.")
     @MethodSource("TText_instn")
     public void testInstN(Temporal base, String type, int n, TTextInst expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TTextInst)base.instant_n(n)).to_string(),expected.to_string());
     }
 
@@ -500,7 +542,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test num timestamp method.")
     @MethodSource("TText_numtmstp")
     public void testNumtmstmp(Temporal base, String type, int expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.num_timestamps(),expected);
     }
 
@@ -508,7 +551,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test start timestamp method.")
     @MethodSource("TText_starttmstp")
     public void testStarttmstmp(Temporal base, String type, LocalDateTime expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.start_timestamp(),expected);
     }
 
@@ -516,7 +560,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test end timestamp method.")
     @MethodSource("TText_endtmstp")
     public void testEndtmstmp(Temporal base, String type, LocalDateTime expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.end_timestamp(),expected);
     }
 
@@ -524,7 +569,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test Hash method.")
     @MethodSource("TText_hash")
     public void testHash(Temporal base, String type, long expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.hash(),expected);
     }
 
@@ -532,7 +578,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test to instant method.")
     @MethodSource("TText_toinstant")
     public void testToInstant(Temporal base, TTextInst type) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         Temporal tmp = base.to_instant();
         assertTrue(tmp instanceof TTextInst);
         assertEquals(((TTextInst) tmp).to_string(), type.to_string());
@@ -542,7 +589,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test to sequence method.")
     @MethodSource("TText_tosequence")
     public void testToSequence(Temporal base, TInterpolation interp, TTextSeq type) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         Temporal tmp = base.to_sequence(interp);
         assertTrue(tmp instanceof TTextSeq);
         assertEquals(((TTextSeq) tmp).to_string(), type.to_string());
@@ -553,7 +601,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test to sequence method.")
     @MethodSource("TText_tosequenceset")
     public void testToSequenceSet(Temporal base, TInterpolation interp, TTextSeqSet type) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         Temporal tmp = base.to_sequenceset(interp);
         assertTrue(tmp instanceof TTextSeqSet);
         assertEquals(((TTextSeqSet) tmp).to_string(), type.to_string());
@@ -564,7 +613,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test insert method.")
     @MethodSource("TText_insert")
     public void testInsert(Temporal base, Temporal base2, Temporal tseq, String type) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextInst") {
             assertEquals(((TTextInst)base.insert(base2)).to_string(), ((TTextSeq) tseq).to_string());
         } else if (type == "TTextSeq") {
@@ -578,7 +628,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test update method.")
     @MethodSource("TText_update")
     public void testUpdate(Temporal base, Temporal base2, Temporal tseq, String type) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextInst") {
             assertEquals(((TTextInst)base.update(base2)).to_string(), ((TTextInst) tseq).to_string());
         } else if (type == "TTextSeq") {
@@ -593,7 +644,8 @@ public class TTextTest {
     @ParameterizedTest(name = "Test append sequence method.")
     @MethodSource("TText_appendseq")
     public void testAppendSeq(Temporal base, TSequence base2, Temporal tseq, String type) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextSeq") {
             assertEquals(((TTextSeq)base.append_sequence(base2)).to_string(), ((TTextSeq) tseq).to_string());
         } else if (type == "TTextSeqSet") {

--- a/src/test/java/boxes/STBoxTest.java
+++ b/src/test/java/boxes/STBoxTest.java
@@ -29,7 +29,8 @@ public class STBoxTest {
 	static error_handler_fn errorHandler = new error_handler();
 
     public STBoxTest() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		stbx = new STBox("STBOX X((1, 1),(2, 2))");
 		stbz = new STBox("STBOX Z((1, 1, 1),(2, 2, 2))");
 		stbt = new STBox("STBOX T([2019-09-01,2019-09-02])");
@@ -38,7 +39,8 @@ public class STBoxTest {
     }
 
 	static Stream<Arguments> STBox_sources() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new STBox("STBOX X((1, 1),(2, 2))"), "STBOX X((1, 1),(2, 2))" ),
 				Arguments.of(new STBox("STBOX Z((1, 1, 1),(2, 2, 2))"), "STBOX Z((1, 1, 1),(2, 2, 2))" ),
@@ -106,7 +108,8 @@ public class STBoxTest {
 	@ParameterizedTest(name = "Test from as constructor.")
 	@MethodSource("STBox_sources")
 	public void testFromAsConstructor(STBox box, String str) throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		STBox stb = new STBox(str);
 		assertTrue(stb.eq(box));
 	}
@@ -115,7 +118,8 @@ public class STBoxTest {
 	@ParameterizedTest(name = "Test copy constructor.")
 	@MethodSource("STBox_sources")
 	public void testCopyConstructor(STBox box, String str) throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		STBox stb = box.copy();
 		assertTrue(stb.eq(box));
 		assertFalse(stb.get_inner() == box.get_inner());

--- a/src/test/java/boxes/TBoxTest.java
+++ b/src/test/java/boxes/TBoxTest.java
@@ -27,7 +27,8 @@ class TBoxTest {
     static error_handler_fn errorHandler = new error_handler();
 
     static Stream<Arguments> TBox_sources() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1, 2])"),"TBox", "TBOXFLOAT X([1, 2])" ),
                 Arguments.of(new TBox("TBOX T([2019-09-01, 2019-09-02])"), "TBox", "TBOX T([2019-09-01 00:00:00+00, 2019-09-02 00:00:00+00])" ),
@@ -36,7 +37,8 @@ class TBoxTest {
     }
 
     static Stream<Arguments> TBox_number() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(1, "TBOXINT X([1, 2))","TBox"),
                 Arguments.of(1.5f, "TBOXFLOAT X([1.5, 1.5])", "TBox")
@@ -44,7 +46,8 @@ class TBoxTest {
     }
 
     static Stream<Arguments> TBox_span() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new IntSpan(1, 2, true, true),"TBox", "TBOXINT X([1, 3))" ),
                 Arguments.of(new FloatSpan(1.5f, 2.5f, true, true),"TBox", "TBOXFLOAT X([1.5, 2.5])" )
@@ -53,7 +56,8 @@ class TBoxTest {
 
 
     static Stream<Arguments> TBox_time() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"),"TBox", "TBOX T([2019-09-01 00:00:00+00, 2019-09-02 00:00:00+00])" ),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"),"TBox", "TBOX T([2019-09-01 00:00:00+00, 2019-09-02 00:00:00+00])" ),
@@ -63,7 +67,8 @@ class TBoxTest {
 
 
     static Stream<Arguments> TBox_basic() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1,2])"),"TBox", "TBOXFLOAT X([1, 2])" ),
                 Arguments.of(new TBox("TBOX T([2019-09-01,2019-09-02])"),"TBox", "TBOX T([2019-09-01 00:00:00+00, 2019-09-02 00:00:00+00])" ),
@@ -73,7 +78,8 @@ class TBoxTest {
 
 
     static Stream<Arguments> TBox_tofloatspan() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1,2])"),"TBox", new FloatSpan(1.0f, 2.0f, true, true) ),
                 Arguments.of(new TBox("TBOXFLOAT XT([1,2],[2019-09-01,2019-09-02])"), "TBox",new FloatSpan(1.0f, 2.0f, true, true))
@@ -81,7 +87,8 @@ class TBoxTest {
     }
 
     static Stream<Arguments> TBox_toperiod() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1,2])"),"TBox", new tstzspan("[2019-09-08 02:03:00+0, 2019-09-10 02:03:00+0]")),
                 Arguments.of(new TBox("TBOXFLOAT XT([1,2],[2019-09-01,2019-09-02])"), "TBox", new tstzspan("[2019-09-08 02:03:00+0, 2019-09-10 02:03:00+0]"))
@@ -89,7 +96,8 @@ class TBoxTest {
     }
 
     static Stream<Arguments> TBox_expandfloat() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1,2])"),"TBox", new TBox("TBOXFLOAT X([1, 2])")),
                 Arguments.of(new TBox("TBOXFLOAT XT([1,2],[2019-09-01,2019-09-02])"), "TBox", new TBox("TBOXFLOAT XT([1,2],[2019-09-01, 2019-09-02])"))
@@ -97,7 +105,8 @@ class TBoxTest {
     }
 
     static Stream<Arguments> TBox_expandtime() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1,2])"),"TBox", new tstzspan("[2019-09-08 02:03:00+0, 2019-09-10 02:03:00+0]")),
                 Arguments.of(new TBox("TBOXFLOAT XT([1,2],[2019-09-01,2019-09-02])"), "TBox", new tstzspan("[2019-09-08 02:03:00+0, 2019-09-10 02:03:00+0]"))
@@ -107,7 +116,8 @@ class TBoxTest {
 
 
     static Stream<Arguments> TBox_round() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1.123456789,2.123456789])"),"TBox", new TBox("TBOXFLOAT X([1.12,2.12])")),
                 Arguments.of(new TBox("TBOXFLOAT XT([1.123456789,2.123456789],[2019-09-01, 2019-09-03])"), "TBox", new TBox("TBOXFLOAT XT([1.12,2.12],[2019-09-01, 2019-09-03])"))
@@ -128,7 +138,8 @@ class TBoxTest {
     @ParameterizedTest(name = "Test from as constructor.")
     @MethodSource("TBox_sources")
     public void testStringConstructor(TBox box, String type, String expected) throws ParseException, SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertTrue(box instanceof TBox);
         assertEquals(box.toString(),expected);
     }
@@ -137,7 +148,8 @@ class TBoxTest {
     @ParameterizedTest(name = "Test from value number constructor.")
     @MethodSource("TBox_number")
     public void testFromValueNConstructor(Number val, String box, String type) throws ParseException, SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TBox new_tb = TBox.from_value_number(val);
         assertTrue(new_tb instanceof TBox);
         assertEquals(new_tb.toString(),box);
@@ -147,7 +159,8 @@ class TBoxTest {
     @ParameterizedTest(name = "Test from span constructor.")
     @MethodSource("TBox_span")
     public void testFromSpanConstructor(Span sp, String type, String expected) throws ParseException, SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TBox new_tb = TBox.from_value_span(sp);
         assertTrue(new_tb instanceof TBox);
         assertEquals(new_tb.toString(),expected);
@@ -157,7 +170,8 @@ class TBoxTest {
     @ParameterizedTest(name = "Test from time constructor.")
     @MethodSource("TBox_time")
     public void testFromTimeConstructor(Time t, String type, String expected) throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TBox new_tb = TBox.from_time(t);
         assertTrue(new_tb instanceof TBox);
         assertEquals(new_tb.toString(),expected);
@@ -168,7 +182,8 @@ class TBoxTest {
     @ParameterizedTest(name = "Test from time constructor.")
     @MethodSource("TBox_time")
     public void testCopyConstructor(Time t, String type, String expected) throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TBox new_tb = TBox.from_time(t);
         assertTrue(new_tb instanceof TBox);
         assertEquals(new_tb.toString(),expected);
@@ -178,7 +193,8 @@ class TBoxTest {
     @ParameterizedTest(name = "Test copy constructor.")
     @MethodSource("TBox_basic")
     public void testCopyConstructor(TBox t, String type, String expected) throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TBox new_tb = t.copy();
         assertTrue(new_tb instanceof TBox);
         assertEquals(new_tb.toString(), t.toString());
@@ -188,7 +204,8 @@ class TBoxTest {
     @ParameterizedTest(name = "Test copy constructor.")
     @MethodSource("TBox_basic")
     public void testStrConstructor(TBox t, String type, String expected) throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertTrue(t instanceof TBox);
         assertEquals(t.toString(), expected);
     }
@@ -196,7 +213,8 @@ class TBoxTest {
     @ParameterizedTest(name = "Test floatspan method.")
     @MethodSource("TBox_tofloatspan")
     public void testStrConstructor(TBox t, String type, Span expected) throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         FloatSpan z = t.to_floatspan();
         assertTrue(z instanceof FloatSpan);
         assertEquals(z.toString(15), ((FloatSpan)expected).toString(15));
@@ -208,7 +226,8 @@ class TBoxTest {
     @ParameterizedTest(name = "Test expand float method.")
     @MethodSource("TBox_expandfloat")
     public void testExpandFloat(TBox t, String type, TBox expected) throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TBox tb = t.expand(1.0f);
         assertTrue(tb instanceof TBox);
         assertEquals(t.toString(15),expected.toString(15));
@@ -219,7 +238,8 @@ class TBoxTest {
     @ParameterizedTest(name = "Test round float method.")
     @MethodSource("TBox_round")
     public void testRound(TBox t, String type, TBox expected) throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         TBox new_tb = t.round(2);
         System.out.println(t.toString());
         System.out.println(new_tb.toString());

--- a/src/test/java/collections/number/FloatSetTest.java
+++ b/src/test/java/collections/number/FloatSetTest.java
@@ -32,7 +32,8 @@ public class FloatSetTest {
 //            }
 //        };
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(5.0f, false ),
                 Arguments.of(new FloatSet("{5, 10}"), false )
@@ -41,7 +42,8 @@ public class FloatSetTest {
 
     static Stream<Arguments> FloatSet_distances() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(5.0f, 2.0f ),
                 Arguments.of(new FloatSet("{5, 10}"), 2.0f )

--- a/src/test/java/collections/number/FloatSpanSetTest.java
+++ b/src/test/java/collections/number/FloatSpanSetTest.java
@@ -20,7 +20,8 @@ public class FloatSpanSetTest {
 
     static Stream<Arguments> IntSpan_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("(7, 10)", 8, 10, true, false),
                 Arguments.of("[7, 10]", 7, 11, true, false)
@@ -29,7 +30,8 @@ public class FloatSpanSetTest {
 
     static Stream<Arguments> IntSpan_mulsources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("7", "10", 7, 10),
                 Arguments.of(7, 10, 7, 10),
@@ -39,7 +41,8 @@ public class FloatSpanSetTest {
 
     static Stream<Arguments> Bound_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(true,true),
                 Arguments.of(true,false),

--- a/src/test/java/collections/number/FloatSpanTest.java
+++ b/src/test/java/collections/number/FloatSpanTest.java
@@ -20,7 +20,8 @@ public class FloatSpanTest {
 
     static Stream<Arguments> IntSpan_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("(2.5, 5.21)", 2.5f, 5.21f, false, false),
                 Arguments.of("[2.5, 5.21]", 2.5f, 5.21f, true, true)
@@ -29,7 +30,8 @@ public class FloatSpanTest {
 
     static Stream<Arguments> IntSpan_mulsources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("2.5", "5.21", 2.5f, 5.21f),
                 Arguments.of(2.5f, 5.21f, 2.5f, 5.21f),
@@ -39,7 +41,8 @@ public class FloatSpanTest {
 
     static Stream<Arguments> Bound_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(true,true),
                 Arguments.of(true,false),

--- a/src/test/java/collections/number/IntSetTest.java
+++ b/src/test/java/collections/number/IntSetTest.java
@@ -23,7 +23,8 @@ public class IntSetTest {
 
     static Stream<Arguments> IntSet_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(5, false ),
                 Arguments.of(new IntSet("{5, 10}"), false )
@@ -32,7 +33,8 @@ public class IntSetTest {
 
     static Stream<Arguments> IntSet_distances() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(5, 2 ),
                 Arguments.of(new IntSet("{5, 10}"), 2 )

--- a/src/test/java/collections/number/IntSpanSetTest.java
+++ b/src/test/java/collections/number/IntSpanSetTest.java
@@ -22,7 +22,8 @@ public class IntSpanSetTest {
 
     static Stream<Arguments> IntSpan_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("(7, 10)", 8, 10, true, false),
                 Arguments.of("[7, 10]", 7, 11, true, false)
@@ -31,7 +32,8 @@ public class IntSpanSetTest {
 
     static Stream<Arguments> IntSpan_mulsources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("7", "10", 7, 10),
                 Arguments.of(7, 10, 7, 10),
@@ -41,7 +43,8 @@ public class IntSpanSetTest {
 
     static Stream<Arguments> Bound_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(true,true),
                 Arguments.of(true,false),

--- a/src/test/java/collections/number/IntSpanTest.java
+++ b/src/test/java/collections/number/IntSpanTest.java
@@ -20,7 +20,7 @@ public class IntSpanTest {
 
     static Stream<Arguments> IntSpan_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
         return Stream.of(
                 Arguments.of("(7, 10)", 8, 10, true, false),
                 Arguments.of("[7, 10]", 7, 11, true, false)
@@ -29,7 +29,7 @@ public class IntSpanTest {
 
     static Stream<Arguments> IntSpan_mulsources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
         return Stream.of(
                 Arguments.of("7", "10", 7, 10),
                 Arguments.of(7, 10, 7, 10),
@@ -39,7 +39,7 @@ public class IntSpanTest {
 
     static Stream<Arguments> Bound_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
         return Stream.of(
                 Arguments.of(true,true),
                 Arguments.of(true,false),

--- a/src/test/java/collections/time/datesetTest.java
+++ b/src/test/java/collections/time/datesetTest.java
@@ -30,7 +30,7 @@ class datesetTest {
     private final dateset dset2;
 
     datesetTest() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
         dset = new dateset("{2019-09-25, 2019-09-26, 2019-09-27}");
         dset2 = new dateset("{2019-09-08, 2019-09-10}");
     }

--- a/src/test/java/collections/time/datespanTest.java
+++ b/src/test/java/collections/time/datespanTest.java
@@ -28,7 +28,8 @@ class datespanTest {
     private final datespan dspan2;
 
     datespanTest() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         dspan = new datespan("[2019-09-25, 2019-09-27]");
         dspan2 = new datespan("[2019-09-08, 2019-09-10)");
     }

--- a/src/test/java/collections/time/datespansetTest.java
+++ b/src/test/java/collections/time/datespansetTest.java
@@ -29,7 +29,8 @@ class datespansetTest {
     private final datespanset dsset2;
 
     datespansetTest() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         dsset = new datespanset("{[2019-09-08, 2019-09-10], [2019-09-11, 2019-09-12]}");
         dsset2 = new datespanset("{[2020-09-08, 2020-09-10], [2020-09-11, 2020-09-12]}");
     }

--- a/src/test/java/collections/time/tstzsetTest.java
+++ b/src/test/java/collections/time/tstzsetTest.java
@@ -28,7 +28,8 @@ class tstzsetTest {
 
 
     private static Stream<Arguments> times() {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
                 Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -40,7 +41,8 @@ class tstzsetTest {
 
 
     public void assert_tstzset_equality(tstzset vset, List<LocalDateTime> timestamps){
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(vset.num_elements(), timestamps.size());
     }
 
@@ -48,7 +50,8 @@ class tstzsetTest {
 
     @Test
     public void testStringConstructor(){
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         List<LocalDateTime> list = new ArrayList<>();
         list.add(LocalDateTime.of(2019, 9, 1, 0, 0,0));
         list.add(LocalDateTime.of(2019, 9, 2, 0, 0,0));
@@ -58,7 +61,8 @@ class tstzsetTest {
 
     @Test
     public void testHexwkbConstructor() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 //        tstzset tsett = types.collections.time.tstzset.from_hexwkb("012100000040021FFE3402000000B15A26350200");
         String hexwkb_string= tset.as_hexwkb();
 		System.out.println(hexwkb_string);
@@ -75,7 +79,8 @@ class tstzsetTest {
 
     @Test
     public void testFromAsConstructor() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         tstzset newtset = new tstzset("{2019-09-01 00:00:00+0, 2019-09-02 00:00:00+0, 2019-09-03 00:00:00+0}");
         assertEquals(tset.toString(), newtset.toString());
     }
@@ -83,7 +88,8 @@ class tstzsetTest {
 
     @Test
     public void testCopyConstructor() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         tstzset tsett = tset;
         assertEquals(tset.toString(),tsett.toString());
     }
@@ -91,14 +97,16 @@ class tstzsetTest {
 
     @Test
     public void testStrOutput() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(tset.toString(),"{\"2019-09-01 00:00:00+00\", \"2019-09-02 00:00:00+00\", \"2019-09-03 00:00:00+00\"}");
     }
 
 
     @Test
     public void testTimestampConversion() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         tstzspanset pset = new tstzspanset("{[2019-09-01 00:00:00+00, 2019-09-01 00:00:00+00], [2019-09-02 00:00:00+00, 2019-09-02 00:00:00+00], [2019-09-03 00:00:00+00, 2019-09-03 00:00:00+00]}");
         tstzspanset converted = tset.to_spanset();
         System.out.println(converted.toString());
@@ -108,7 +116,8 @@ class tstzsetTest {
 
     @Test
     public void testtstzsetConversion() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         tstzspan p = new tstzspan("[2019-09-01 00:00:00+00, 2019-09-03 00:00:00+00]");
         tstzspan converted = tset.to_span();
         System.out.println(converted.toString());
@@ -118,33 +127,38 @@ class tstzsetTest {
 
     @Test
     public void testNumTimestamps() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(tset.num_elements(),3);
     }
 
     @Test
     public void testStartTimestamps() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(tset.start_element(),LocalDateTime.of(2019, 9, 1, 0, 0,0));
     }
 
 
     @Test
     public void testEndTimestamps() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(tset.end_element(),LocalDateTime.of(2019, 9, 3, 0, 0,0));
     }
 
     @Test
     public void testHash() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(tset.hash(),527267058);
     }
 
 
     @Test
     public void testIsContainedInFunction() throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         assertFalse(tset.is_contained_in(tmp_set));
     }
@@ -152,7 +166,8 @@ class tstzsetTest {
 
     @Test
     public void testOverlapsFunction() throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         assertFalse(tset.overlaps(tmp_set));
     }
@@ -160,14 +175,16 @@ class tstzsetTest {
 
     @Test
     public void testIsBeforeFunction() throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         assertTrue(tset.is_before(tmp_set));
     }
 
     @Test
     public void testIsOverOrBeforeFunction() throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         assertTrue(tset.is_over_or_before(tmp_set));
     }
@@ -175,21 +192,24 @@ class tstzsetTest {
 
     @Test
     public void testIsAfterFunction() throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         assertFalse(tset.is_after(tmp_set));
     }
 
     @Test
     public void testIsOverOrAfterFunction() throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         assertFalse(tset.is_over_or_after(tmp_set));
     }
 
     @Test
     public void testDistanceFunction() throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         System.out.println(Duration.ofSeconds((long) functions.distance_tstzset_tstzset(tset.get_inner(), tmp_set.get_inner())));
         tset.distance(tmp_set);
@@ -199,14 +219,16 @@ class tstzsetTest {
     @ParameterizedTest(name="Test intersection method")
     @MethodSource("times")
     public void testIntersection(Time other, boolean expected) throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         this.tset.intersection(other);
     }
 
     @ParameterizedTest(name="Test union method")
     @MethodSource("times")
     public void testUnion(Time other, boolean expected) throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         this.tset.union(other);
     }
 
@@ -214,7 +236,8 @@ class tstzsetTest {
     @ParameterizedTest(name="Test minus method")
     @MethodSource("times")
     public void testMinus(Time other, boolean expected) throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         this.tset.minus(other);
     }
 

--- a/src/test/java/collections/time/tstzspanTest.java
+++ b/src/test/java/collections/time/tstzspanTest.java
@@ -44,7 +44,8 @@ class tstzspanTest {
 
 
 	static Stream<Arguments> tstzspan_constructor() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of("(2019-09-08 00:00:00+0, 2019-09-10 00:00:00+0)",LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0), false,false),
 				Arguments.of("[2019-09-08 00:00:00+0, 2019-09-10 00:00:00+0]", LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0), true,true)
@@ -52,21 +53,24 @@ class tstzspanTest {
 	}
 
 	static Stream<Arguments> tstzspan_constructor2() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of("2019-09-08 00:00:00+0", "2019-09-10 00:00:00+0",LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0))
 				);
 	}
 
 	static Stream<Arguments> tstzspan_constructor3() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0), LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0))
 		);
 	}
 
 	static Stream<Arguments> tstzspan_constructor4() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of("2019-09-08 00:00:00+0", LocalDateTime.of(2019, 9, 10, 0, 0),LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0))
 		);
@@ -74,7 +78,8 @@ class tstzspanTest {
 
 
 	static Stream<Arguments> tstzspan_constructor5() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(true,true),
 				Arguments.of(true,false),
@@ -84,7 +89,8 @@ class tstzspanTest {
 	}
 
 	private static Stream<Arguments> temporals_adjacent() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -98,7 +104,8 @@ class tstzspanTest {
 
 
 	private static Stream<Arguments> temporals_iscontained() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -112,7 +119,8 @@ class tstzspanTest {
 
 
 	private static Stream<Arguments> temporals_contains() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -126,7 +134,8 @@ class tstzspanTest {
 
 
 	private static Stream<Arguments> temporals_overlaps() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -140,7 +149,8 @@ class tstzspanTest {
 
 
 	private static Stream<Arguments> temporals_same() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -154,7 +164,8 @@ class tstzspanTest {
 
 
 	private static Stream<Arguments> temporals_before() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -168,7 +179,8 @@ class tstzspanTest {
 
 
 	private static Stream<Arguments> temporals_after() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -182,7 +194,8 @@ class tstzspanTest {
 
 
 	private static Stream<Arguments> temporals_overbefore() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -196,7 +209,8 @@ class tstzspanTest {
 
 
 	private static Stream<Arguments> temporals_overafter() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -210,7 +224,8 @@ class tstzspanTest {
 
 
 	private static Stream<Arguments> temporals_distance() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), 0.0),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), 0.0),
@@ -221,7 +236,8 @@ class tstzspanTest {
 
 
 	private static Stream<Arguments> intersection() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true)
@@ -230,7 +246,8 @@ class tstzspanTest {
 
 
 	private static Stream<Arguments> other() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true)
 		);
@@ -261,7 +278,8 @@ class tstzspanTest {
 	@ParameterizedTest(name = "Test Constructor method")
 	@MethodSource("tstzspan_constructor")
 	public void testtstzspanConstructor(String source, LocalDateTime lower, LocalDateTime upper, boolean lower_inc, boolean upper_inc) throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		tstzspan p = new tstzspan(source);
 		assert_tstzspan_equality(p,lower,upper,lower_inc,upper_inc);
 	}
@@ -269,7 +287,8 @@ class tstzspanTest {
 	@ParameterizedTest(name = "Test Constructor method")
 	@MethodSource("tstzspan_constructor2")
 	public void testtstzspanConstructor2(String lower, String upper, LocalDateTime lowerv, LocalDateTime upperv) throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		tstzspan p = new tstzspan(lower,upper);
 		assert_tstzspan_equality(p,lowerv,upperv,true,false);
 	}
@@ -278,7 +297,8 @@ class tstzspanTest {
 	@ParameterizedTest(name = "Test Constructor method")
 	@MethodSource("tstzspan_constructor3")
 	public void testtstzspanConstructor3(LocalDateTime lower, LocalDateTime upper, LocalDateTime lowerv, LocalDateTime upperv) throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		tstzspan p = new tstzspan(lower,upper);
 		assert_tstzspan_equality(p,lowerv,upperv,true,false);
 	}
@@ -287,14 +307,16 @@ class tstzspanTest {
 	@ParameterizedTest(name = "Test Constructor method")
 	@MethodSource("tstzspan_constructor4")
 	public void testtstzspanConstructor4(String lower, LocalDateTime upper, LocalDateTime lowerv, LocalDateTime upperv) throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		tstzspan p = new tstzspan(lower,upper);
 		assert_tstzspan_equality(p,lowerv,upperv,true,false);
 	}
 
 	@Test
 	public void testtstzspanBounds() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		tstzspan p = new tstzspan("2019-09-08 00:00:00+0", "2019-09-10 00:00:00+0");
 		assert_tstzspan_equality(p, LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0),true,false);
 	}
@@ -303,7 +325,8 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test Bound Inclusivity")
 	@MethodSource("tstzspan_constructor5")
 	public void testtstzspanIncluBounds(boolean lower,boolean upper) throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		tstzspan p = new tstzspan("2019-09-08 00:00:00+0", "2019-09-10 00:00:00+0",lower,upper);
 		assert_tstzspan_equality(p, LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0),lower,upper);
 	}
@@ -311,7 +334,8 @@ class tstzspanTest {
 
 	@Test
 	public void testHexwkbConstructor() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 //		tstzspan p = types.collections.time.tstzspan.from_hexwkb("012100000040021FFE3402000000B15A26350200");
 		String hexwkb_string= tstzspan.as_hexwkb();
 //		System.out.println(hexwkb_string);
@@ -322,13 +346,15 @@ class tstzspanTest {
 
 	@Test
 	public void testFromAsConstructor() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertNotEquals(this.tstzspan,new tstzspan("(2019-09-08 00:00:00+00, 2019-09-10 00:00:00+00)"));
 	}
 
 	@Test
 	public void testCopyConstructor() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		tstzspan other = this.tstzspan.copy();
 		assertNotEquals(this.tstzspan, other);
 		assertEquals(other.toString(), this.tstzspan.toString());
@@ -336,14 +362,16 @@ class tstzspanTest {
 
 	@Test
 	public void testtstzspanOut() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.tstzspan.toString(), "(2019-09-08 00:00:00+00, 2019-09-10 00:00:00+00)");
 	}
 
 
 	@Test
 	public void testTotstzspanSet() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		tstzspanset pset = tstzspan.to_spanset();
 		System.out.println(pset.toString());
 		String spanset_string= pset.toString();
@@ -355,7 +383,8 @@ class tstzspanTest {
 
 	@Test
 	public void testUpperAccessors() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.tstzspan.lower(), LocalDateTime.of(2019, 9, 8, 0, 0));
 		assertEquals(this.tstzspan2.lower(), LocalDateTime.of(2019, 9, 8, 2, 3));
 	}
@@ -363,21 +392,24 @@ class tstzspanTest {
 
 	@Test
 	public void testLowerAccessors() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.tstzspan.upper(), LocalDateTime.of(2019, 9, 10, 0, 0));
 		assertEquals(this.tstzspan2.upper(), LocalDateTime.of(2019, 9, 10, 2, 3));
 	}
 
 	@Test
 	public void testLowerIncAccessors() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertFalse(this.tstzspan.lower_inc());
 		assertTrue(this.tstzspan2.lower_inc());
 	}
 
 	@Test
 	public void testUpperIncAccessors() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertFalse(this.tstzspan.upper_inc());
 		assertTrue(this.tstzspan2.upper_inc());
 	}
@@ -385,7 +417,8 @@ class tstzspanTest {
 
 	@Test
 	public void testDurationInSeconds() throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 //		System.out.println(tstzspan.toString());
 		types.collections.time.tstzspan tst= new tstzspan("(2019-09-08 00:00:00+00, 2022-10-25 00:05:00+00)");
 //		System.out.println(tst.duration());
@@ -399,7 +432,8 @@ class tstzspanTest {
 
 //	@Test
 //	public void testHash() throws SQLException {
-//		functions.meos_initialize("UTC", errorHandler);
+//		functions.meos_initialize_timezone("UTC");
+//      functions.meos_initialize_error_handler(errorHandler);
 //		assertEquals(this.tstzspan.hash(), 1164402929);
 //	}
 
@@ -407,8 +441,9 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test Adjacency method")
 	@MethodSource("temporals_adjacent")
 	public void testAdjacency(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
-		STBox st= new STBox(functions.tstzspan_to_stbox(p.get_inner()));
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
+		STBox st= new STBox(functions.tstzspan_stbox(p.get_inner()));
 		System.out.println(st.toString(15));
 		assertEquals(this.p.is_adjacent(other), expected);
 	}
@@ -416,7 +451,8 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test is contained in method")
 	@MethodSource("temporals_iscontained")
 	public void testIsContainedIn(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.p.is_contained_in(other), expected);
 
 	}
@@ -425,7 +461,8 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test contains method")
 	@MethodSource("temporals_contains")
     public void testContains(TemporalObject other, boolean expected) throws Exception {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(this.p.contains(other), expected);
 
     }
@@ -434,7 +471,8 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test overlaps method")
 	@MethodSource("temporals_overlaps")
 	public void testOverlaps(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.p.overlaps(other), expected);
 	}
 
@@ -442,7 +480,8 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test is same method")
 	@MethodSource("temporals_same")
 	public void testIsSame(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.p.is_same(other), expected);
 	}
 
@@ -451,7 +490,8 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test is before method")
 	@MethodSource("temporals_before")
 	public void testIsBefore(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.p.is_before(other), expected);
 	}
 
@@ -460,7 +500,8 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test is after method")
 	@MethodSource("temporals_after")
 	public void testIsAfter(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.p.is_after(other), expected);
 	}
 
@@ -468,7 +509,8 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test is over or before method")
 	@MethodSource("temporals_overbefore")
 	public void testIsOverOrBefore(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.p.is_over_or_before(other), expected);
 
 	}
@@ -477,8 +519,9 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test is over or after method")
 	@MethodSource("temporals_overafter")
 	public void testIsOverOrAfter(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
-		STBox st= new STBox(functions.tstzspan_to_stbox(p.get_inner()));
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
+		STBox st= new STBox(functions.tstzspan_stbox(p.get_inner()));
 		System.out.println(st.toString(15));
 		assertEquals(this.p.is_over_or_after(other), expected);
 
@@ -489,7 +532,8 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test distance method")
 	@MethodSource("temporals_distance")
 	public void testDistance(TemporalObject other, double expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		STBox st= new STBox("STBOX ZT(((1.0, 2.0, 3.0),(4.0, 5.0, 6.0)),[2001-01-01, 2001-01-02])");
 		double dist= p.distance(st);
 		System.out.println(dist);
@@ -502,21 +546,24 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test intersection method")
 	@MethodSource("intersection")
 	public void testIntersection(Time other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		this.p.intersection(other);
 	}
 
 	@ParameterizedTest(name="Test minus method")
 	@MethodSource("intersection")
 	public void testMinus(Time other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		this.p.minus(other);
 	}
 
 	@ParameterizedTest(name="Test union method")
 	@MethodSource("intersection")
 	public void testUnion(Time other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		this.p.union(other);
 	}
 
@@ -525,7 +572,8 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test equal method")
 	@MethodSource("other")
 	public void testEqual(Time t) throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertFalse(this.tstzspan.equals(t));
 	}
 
@@ -533,35 +581,40 @@ class tstzspanTest {
 	@ParameterizedTest(name="Test ne method")
 	@MethodSource("other")
 	public void testNotEqual(Time t) throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.tstzspan.notEquals(t));
 	}
 
 	@ParameterizedTest(name="Test lt method")
 	@MethodSource("other")
 	public void testLessThan(Time t) throws SQLException, OperationNotSupportedException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.tstzspan.lessThan(t));
 	}
 
 	@ParameterizedTest(name="Test le method")
 	@MethodSource("other")
 	public void testLessThanOrEqual(Time t) throws SQLException, OperationNotSupportedException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.tstzspan.lessThanOrEqual(t));
 	}
 
 	@ParameterizedTest(name="Test gt method")
 	@MethodSource("other")
 	public void testGreaterThan(Time t) throws SQLException, OperationNotSupportedException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.tstzspan.greaterThan(t));
 	}
 
 	@ParameterizedTest(name="Test ge method")
 	@MethodSource("other")
 	public void testGreaterThanOrEqual(Time t) throws SQLException, OperationNotSupportedException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertFalse(this.tstzspan.greaterThanOrEqual(t));
 	}
 

--- a/src/test/java/collections/time/tstzspansetTest.java
+++ b/src/test/java/collections/time/tstzspansetTest.java
@@ -37,7 +37,8 @@ class tstzspansetTest {
 	static error_handler_fn errorHandler= new error_handler();
 	
 	private static Stream<Arguments> temporals_adjacent() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -51,7 +52,8 @@ class tstzspansetTest {
 
 
 	private static Stream<Arguments> temporals_iscontained() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -65,7 +67,8 @@ class tstzspansetTest {
 
 
 	private static Stream<Arguments> temporals_contains() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -79,7 +82,8 @@ class tstzspansetTest {
 
 
 	private static Stream<Arguments> temporals_overlaps() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -93,7 +97,8 @@ class tstzspansetTest {
 
 
 	private static Stream<Arguments> temporals_same() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -107,7 +112,8 @@ class tstzspansetTest {
 
 
 	private static Stream<Arguments> temporals_before() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -121,7 +127,8 @@ class tstzspansetTest {
 
 
 	private static Stream<Arguments> temporals_after() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -135,7 +142,8 @@ class tstzspansetTest {
 
 
 	private static Stream<Arguments> temporals_overbefore() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -149,7 +157,8 @@ class tstzspansetTest {
 
 
 	private static Stream<Arguments> temporals_overafter() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -163,7 +172,8 @@ class tstzspansetTest {
 
 
 	private static Stream<Arguments> intersection() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true)
@@ -171,7 +181,8 @@ class tstzspansetTest {
 	}
 
 	private static Stream<Arguments> other() {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true)
 		);
@@ -186,14 +197,16 @@ class tstzspansetTest {
 
 	@Test
 	public void testStringConstructor(){
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		System.out.println(pset.toString());
 		assert_tstzspanset_equality(this.pset,null);
 	}
 
 	@Test
 	public void testtstzspansetListConstructor(){
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		List<tstzspan> lst = new ArrayList<tstzspan>();
 		lst.add(new tstzspan("[2019-09-01, 2019-09-02]"));
 		lst.add(new tstzspan("[2019-09-03, 2019-09-04]"));
@@ -205,7 +218,8 @@ class tstzspansetTest {
 
 	@Test
 	public void testCopyConstructor(){
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		tstzspanset new_pset = new tstzspanset(pset.copy());
 		assertEquals(this.pset.toString(),new_pset.toString());
 	}
@@ -213,21 +227,24 @@ class tstzspansetTest {
 
 	@Test
 	public void testTotstzset(){
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.to_period().toString(), new tstzspan("[2019-09-01, 2019-09-04]").toString());
 	}
 
 
 	@Test
 	public void testNumTimestamps(){
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.num_timestamps(),4);
 		assertEquals(this.pset2.num_timestamps(),3);
 	}
 
 	@Test
 	public void testStartTimestamps(){
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.start_timestamp(), LocalDateTime.of(2019,9,1,0,0,0));
 		assertEquals(this.pset2.start_timestamp(),LocalDateTime.of(2019,9,1,0,0,0));
 	}
@@ -235,7 +252,8 @@ class tstzspansetTest {
 
 	@Test
 	public void testEndTimestamps(){
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.end_timestamp(),LocalDateTime.of(2019,9,4,0,0,0));
 		assertEquals(this.pset2.end_timestamp(),LocalDateTime.of(2019,9,4,0,0,0));
 	}
@@ -243,7 +261,8 @@ class tstzspansetTest {
 
 	@Test
 	public void testNumtstzsets(){
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.num_periods(),2);
 		assertEquals(this.pset2.num_periods(),2);
 	}
@@ -251,14 +270,16 @@ class tstzspansetTest {
 
 	@Test
 	public void testStarttstzset(){
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.start_period().toString(),new tstzspan("[2019-09-01 00:00:00+00, 2019-09-02 00:00:00+00]").toString());
 	}
 
 
 	@Test
 	public void testEndtstzset(){
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.end_period().toString(),new tstzspan("[2019-09-03 00:00:00+00, 2019-09-04 00:00:00+00]").toString());
 	}
 
@@ -266,7 +287,8 @@ class tstzspansetTest {
 
 //	@Test
 //	public void testHash(){
-//		functions.meos_initialize("UTC", errorHandler);
+//		functions.meos_initialize_timezone("UTC");
+//      functions.meos_initialize_error_handler(errorHandler);
 //		assertEquals(this.pset.hash(),552347465);
 //	}
 
@@ -274,14 +296,16 @@ class tstzspansetTest {
 	@ParameterizedTest(name="Test Adjacency method")
 	@MethodSource("temporals_adjacent")
 	public void testAdjacency(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_adjacent(other), expected);
 	}
 
 	@ParameterizedTest(name="Test is contained in method")
 	@MethodSource("temporals_iscontained")
 	public void testIsContainedIn(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_contained_in(other), expected);
 
 	}
@@ -290,7 +314,8 @@ class tstzspansetTest {
 	@ParameterizedTest(name="Test contains method")
 	@MethodSource("temporals_contains")
 	public void testContains(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.contains(other), expected);
 
 	}
@@ -299,7 +324,8 @@ class tstzspansetTest {
 	@ParameterizedTest(name="Test overlaps method")
 	@MethodSource("temporals_overlaps")
 	public void testOverlaps(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.overlaps(other), expected);
 	}
 
@@ -307,7 +333,8 @@ class tstzspansetTest {
 	@ParameterizedTest(name="Test is same method")
 	@MethodSource("temporals_same")
 	public void testIsSame(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_same(other), expected);
 	}
 
@@ -316,7 +343,8 @@ class tstzspansetTest {
 	@ParameterizedTest(name="Test is before method")
 	@MethodSource("temporals_before")
 	public void testIsBefore(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_before(other), expected);
 	}
 
@@ -325,7 +353,8 @@ class tstzspansetTest {
 	@ParameterizedTest(name="Test is after method")
 	@MethodSource("temporals_after")
 	public void testIsAfter(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_after(other), expected);
 	}
 
@@ -333,7 +362,8 @@ class tstzspansetTest {
 	@ParameterizedTest(name="Test is over or before method")
 	@MethodSource("temporals_overbefore")
 	public void testIsOverOrBefore(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_over_or_before(other), expected);
 
 	}
@@ -342,7 +372,8 @@ class tstzspansetTest {
 	@ParameterizedTest(name="Test is over or after method")
 	@MethodSource("temporals_overafter")
 	public void testIsOverOrAfter(TemporalObject other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_over_or_after(other), expected);
 
 	}
@@ -352,21 +383,24 @@ class tstzspansetTest {
 	@ParameterizedTest(name="Test intersection method")
 	@MethodSource("intersection")
 	public void testIntersection(Time other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		this.pset.intersection(other);
 	}
 
 	@ParameterizedTest(name="Test minus method")
 	@MethodSource("intersection")
 	public void testMinus(Time other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		this.pset.minus(other);
 	}
 
 	@ParameterizedTest(name="Test union method")
 	@MethodSource("intersection")
 	public void testUnion(Time other, boolean expected) throws Exception {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		this.pset.union(other);
 	}
 
@@ -374,7 +408,8 @@ class tstzspansetTest {
 	@ParameterizedTest(name="Test equal method")
 	@MethodSource("other")
 	public void testEqual(Time t) throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertNotEquals(this.pset, t);
 	}
 
@@ -382,35 +417,40 @@ class tstzspansetTest {
 	@ParameterizedTest(name="Test ne method")
 	@MethodSource("other")
 	public void testNotEqual(Time t) throws SQLException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.pset.notEquals(t));
 	}
 
 	@ParameterizedTest(name="Test lt method")
 	@MethodSource("other")
 	public void testLessThan(Time t) throws SQLException, OperationNotSupportedException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.pset.lessThan(t));
 	}
 
 	@ParameterizedTest(name="Test le method")
 	@MethodSource("other")
 	public void testLessThanOrEqual(Time t) throws SQLException, OperationNotSupportedException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.pset.lessThanOrEqual(t));
 	}
 
 	@ParameterizedTest(name="Test gt method")
 	@MethodSource("other")
 	public void testGreaterThan(Time t) throws SQLException, OperationNotSupportedException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.pset.greaterThan(t));
 	}
 
 	@ParameterizedTest(name="Test ge method")
 	@MethodSource("other")
 	public void testGreaterThanOrEqual(Time t) throws SQLException, OperationNotSupportedException {
-		functions.meos_initialize("UTC", errorHandler);
+		functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
 		assertFalse(this.pset.greaterThanOrEqual(t));
 	}
 

--- a/src/test/java/temporal/InterpolationTest.java
+++ b/src/test/java/temporal/InterpolationTest.java
@@ -24,7 +24,8 @@ public class InterpolationTest {
     error_handler_fn errorHandler = new error_handler();
 
     Stream<Arguments> TInterp() throws SQLException {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("discrete", TInterpolation.DISCRETE),
                 Arguments.of("linear", TInterpolation.LINEAR),
@@ -37,7 +38,8 @@ public class InterpolationTest {
     @ParameterizedTest(name = "Test TInterpolation class.")
     @MethodSource("TInterp")
     public void testFromString(String base, TInterpolation expected) {
-        functions.meos_initialize("UTC", errorHandler);
+        functions.meos_initialize_timezone("UTC");
+functions.meos_initialize_error_handler(errorHandler);
         assertEquals(TInterpolation.fromString(base),expected);
     }
 }


### PR DESCRIPTION
## Summary
This PR upgrades the JMEOS Java bindings to work with MEOS 1.3. 
The upgrade compiles successfully

## Changes
- Updated bindings to match the MEOS 1.3 C API.
- Adjusted `FunctionsGenerator` and `functions.java` to reflect API changes.
- Updated related tests (`TGeomPointTest`, `tstzspanTest`, etc.) to ensure compatibility.
- 
## Notes
- This PR is opened as a **draft** to allow discussion and incremental review.  
- Some tests may still need adaptation to validate against MEOS 1.3.  
- A large test file (`scale10.csv`, ~50 MB) is currently tracked in Git — this may need to be moved to **Git LFS** or excluded.  

## To Do
- Finalize documentation updates once the bindings are stable.

---

**Status:**  compiles but pending further review and feedback.  
