### PR TITLE
fix(ci): refresh apt cache before installing system deps

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,17 +45,15 @@ jobs:
       - name: Print current working directory
         run: pwd
 
-      # Install GEOS library
-      - name: Install GEOS
-        run: sudo apt-get install -y libgeos-dev
-
-      # Install PROJ library
-      - name: Install PROJ
-        run: sudo apt-get install proj-bin libproj-dev proj-data
-
-      # Install JSON-C library
-      - name: Install JSON-C
-        run: sudo apt install libjson-c-dev
+      # Install system dependencies (GEOS, PROJ, JSON-C, GSL). Refresh
+      # apt cache first so the runner doesn't 404 on stale Azure-mirror
+      # state. GSL is required by MobilityDB; without it cmake fails
+      # with "Could NOT find GSL".
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libgeos-dev proj-bin libproj-dev proj-data libjson-c-dev libgsl-dev
 
       # Fetch and install MEOS library
       - name: Fetch MEOS sources


### PR DESCRIPTION
The workflow installs GEOS / PROJ / JSON-C from apt without first running \`apt-get update\`, so the GitHub Actions runner re-uses a stale cache from its base image. When Azure's apt mirror retires an older patch version (e.g. \`libcurl4-gnutls-dev 8.5.0-2ubuntu10.8\`), the install step 404s and the build fails with exit code 100.

This is currently breaking every JMEOS CI run including the doc-only PR #13.

## Fix
- Consolidate the three separate \`apt-get install\` steps into one
- Run \`apt-get update -qq\` first
- Add \`--no-install-recommends\` so unrelated packages aren't pulled in

## Test plan
- [ ] CI green on this PR (the only meaningful test of an apt-cache fix)
- [ ] Once merged, PR #13 (and every future PR) gets unblocked