### PR TITLE
Build sources before generating Javadoc and publish the jmeos-core API docs

### DIFF
--- a/.github/workflows/deploy_javadoc.yml
+++ b/.github/workflows/deploy_javadoc.yml
@@ -22,15 +22,20 @@ jobs:
       - name: Set up Maven
         run: mvn -B wrapper:wrapper
 
+      - name: Build sources
+        run: mvn -B -DskipTests compile
+        # Compiles the codegen module and generates functions/GeneratedFunctions.java, so the
+        # generate-meos-facade step invoked by javadoc:javadoc finds the FunctionsGenerator class.
+
       - name: Generate Javadoc
         run: mvn -B javadoc:javadoc
         # By default, this generates Javadoc in the target/site/apidocs/ directory
 
       - name: Verify Javadoc Directory
         run: |
-          if [ -d "target/site/apidocs" ]; then
+          if [ -d "jmeos-core/target/site/apidocs" ]; then
           echo "Javadoc generated successfully";
-          ls -la target/site/apidocs;
+          ls -la jmeos-core/target/site/apidocs;
           else
           echo "Javadoc directory not found!";
           exit 1;
@@ -40,4 +45,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: target/site/apidocs
+          publish_dir: jmeos-core/target/site/apidocs


### PR DESCRIPTION
## What

The `Deploy Javadoc to GitHub Pages` workflow ran `mvn -B javadoc:javadoc` directly. That goal invokes the `generate-meos-facade` step, which runs `FunctionsGenerator` from the `codegen` module — but the module was never compiled, so the class was not on the classpath and generation failed with `ClassNotFoundException: FunctionsGenerator`. On a fresh checkout the job could never succeed.

- Add a `Build sources` step (`mvn -B -DskipTests compile`) so the `codegen` module is compiled and `functions/GeneratedFunctions.java` is generated before Javadoc runs. This is native-free (no `libmeos` needed).
- Point the verify and deploy steps at `jmeos-core/target/site/apidocs`, where the module's API docs are produced.

## Validation

Ran the full job locally in the CI environment (no `libmeos` present, clean tree): `wrapper:wrapper` → `compile` → `javadoc:javadoc` all succeed, and the verify step finds a complete `jmeos-core/target/site/apidocs` (index.html + 27 entries).
