### PR TITLE
Read temporal timestamp accessors as int64 and convert via the epoch converter

### DIFF
--- a/jmeos-core/src/main/java/types/temporal/Temporal.java
+++ b/jmeos-core/src/main/java/types/temporal/Temporal.java
@@ -434,13 +434,9 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         return ConversionUtils.timestamptz_to_datetime(functions.temporal_end_timestamptz(this.inner));
     }
 
-    // Convert timestamp (number of seconds since epoch) to LocalDateTime
-    public static LocalDateTime timestampToLocalDateTime(int timestamp) {
-        return LocalDateTime.ofEpochSecond(timestamp, 0, ZoneOffset.UTC);
-    }
-
     public LocalDateTime timestamp_n(int n){
-        return timestampToLocalDateTime(Objects.requireNonNull(functions.temporal_timestamptz_n(this.inner, n + 1)).getInt(Integer.BYTES));
+        Pointer result = Objects.requireNonNull(functions.temporal_timestamptz_n(this.inner, n + 1));
+        return utils.TimestampTzConverter.toLocalDateTime(result.getLong(0));
     }
 
 /**
@@ -454,12 +450,12 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         // Create a JNR-FFI runtime instance
         Runtime runtime = Runtime.getSystemRuntime();
         // Allocate memory for an integer (4 bytes) but do not set a value
-        Pointer intPointer = Memory.allocate(Runtime.getRuntime(runtime), 4);
+        Pointer intPointer = Memory.allocate(runtime, 4);
         Pointer array= functions.temporal_timestamps(this.inner, intPointer);
         List<LocalDateTime> datetimeList= new ArrayList<LocalDateTime>();
         for(int i=0;i<this.num_timestamps(); i++){
-            int p= array.getInt((long) i *Integer.BYTES);
-            LocalDateTime ldt= timestampToLocalDateTime(p);
+            long ts= array.getLong((long) i * Long.BYTES);
+            LocalDateTime ldt= utils.TimestampTzConverter.toLocalDateTime(ts);
             datetimeList.add(ldt);
         }
         return datetimeList;

--- a/jmeos-core/src/test/java/basic/TimestampAccessorTest.java
+++ b/jmeos-core/src/test/java/basic/TimestampAccessorTest.java
@@ -1,0 +1,46 @@
+package basic;
+
+import functions.error_handler;
+import functions.error_handler_fn;
+import functions.functions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import types.basic.tint.TIntSeq;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("Temporal timestamp accessors")
+class TimestampAccessorTest {
+
+    static error_handler_fn errorHandler = new error_handler();
+
+    @BeforeAll
+    static void init() {
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
+    }
+
+    private static LocalDateTime day(int d) {
+        return LocalDateTime.of(2019, 9, d, 0, 0, 0);
+    }
+
+    @Test
+    @DisplayName("timestamp_n returns the n-th timestamp as a calendar value")
+    void timestampN() throws Exception {
+        TIntSeq seq = new TIntSeq("[1@2019-09-01, 2@2019-09-02, 3@2019-09-03]");
+        assertEquals(day(1), seq.timestamp_n(0));
+        assertEquals(day(2), seq.timestamp_n(1));
+        assertEquals(day(3), seq.timestamp_n(2));
+    }
+
+    @Test
+    @DisplayName("timestamps returns every timestamp in order")
+    void timestamps() throws Exception {
+        TIntSeq seq = new TIntSeq("[1@2019-09-01, 2@2019-09-02, 3@2019-09-03]");
+        assertEquals(List.of(day(1), day(2), day(3)), seq.timestamps());
+    }
+}


### PR DESCRIPTION
`Temporal.timestamp_n(n)` returns the n-th timestamp and `timestamps()` returns the full list, as `LocalDateTime` values.

Each reads the native `TimestampTz` as a 64-bit value — `getLong(0)`, and an 8-byte stride across the `TimestampTz` array — and converts it with `TimestampTzConverter`, which maps microseconds since the PostgreSQL epoch to `java.time`.

`TimestampAccessorTest` covers both accessors over `[1@2019-09-01, 2@2019-09-02, 3@2019-09-03]`. The `jmeos-core` suite runs in CI.