### PR TITLE
Return the upper bound from datespan.upper

### DIFF
--- a/jmeos-core/src/main/java/types/collections/time/datespan.java
+++ b/jmeos-core/src/main/java/types/collections/time/datespan.java
@@ -177,7 +177,7 @@ public class datespan extends Span<LocalDate> implements Time, TimeCollection{
 
     @Override
     public LocalDate upper() {
-        return date_adt_to_date(functions.datespan_lower(this._inner));
+        return date_adt_to_date(functions.datespan_upper(this._inner));
     }
 
     @Override

--- a/jmeos-core/src/test/java/collections/time/DateSpanTest.java
+++ b/jmeos-core/src/test/java/collections/time/DateSpanTest.java
@@ -46,6 +46,12 @@ class DateSpanTest {
         assertEquals("[2019-09-25, 2019-09-28)", dspan.toString());
     }
 
+    @Test
+    public void testLowerUpper(){
+        assertEquals(LocalDate.of(2019, 9, 25), dspan.lower());
+        assertEquals(LocalDate.of(2019, 9, 28), dspan.upper());
+    }
+
 
     @Test
     public void testFromAsConstructor() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {


### PR DESCRIPTION
## Problem

`datespan.upper()` calls `datespan_lower`, so it returns the span's **lower** bound — identical to `datespan.lower()`. (The `end_element()` accessor is unaffected; it routes through `datespanset_end_date`.)

## Fix

Read `datespan_upper`, and add a `DateSpanTest` case asserting both bounds of `[2019-09-25, 2019-09-27]` (normalized `[2019-09-25, 2019-09-28)`): `lower()` = 2019-09-25, `upper()` = 2019-09-28.

## Verification

`mvn -pl jmeos-core -am test-compile` — BUILD SUCCESS. The `jmeos-core` FFI suite (including the new assertion) runs in CI.