### PR TITLE
Return the correct collection type from date set operations

### DIFF
--- a/jmeos-core/src/main/java/types/collections/time/dateset.java
+++ b/jmeos-core/src/main/java/types/collections/time/dateset.java
@@ -520,11 +520,6 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     /*---------------Set Operations-------------------*/
 
-    // Convert timestamp (number of seconds since epoch) to LocalDateTime
-    public static LocalDateTime timestampToLocalDateTime(int timestamp) {
-        return LocalDateTime.ofEpochSecond(timestamp, 0, ZoneOffset.UTC);
-    }
-
 /**
         Returns the temporal intersection of ``self`` and ``other``.
 
@@ -532,37 +527,30 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
             other: temporal object to intersect with
 
         Returns:
-            A :class:`TimeDate` instance. The actual class depends on ``other``.
+            A :class:`Time` instance. The actual class depends on ``other``:
+            a :class:`dateset` for a date or a set, a :class:`datespan` for a span,
+            a :class:`datespanset` for a span set.
 
         MEOS Functions:
-            intersection_set_date, intersection_set_set, intersection_spanset_span,
+            intersection_set_date, intersection_set_set, intersection_span_span,
             intersection_spanset_spanset
 */
 
-    public LocalDateTime intersection(Object other) throws Exception {
-        LocalDateTime result = null;
+    public Time intersection(Object other) throws Exception {
+        Time result;
         if (other instanceof LocalDate){
-            System.out.println(dateToTimestamp((LocalDate) other));
-            Pointer resultPointer= functions.intersection_set_date(this._inner, dateToTimestamp((LocalDate) other));
-            int resultTimestamp= resultPointer.getInt(Integer.BYTES);
-            result = timestampToLocalDateTime(resultTimestamp);
+            result = new dateset(functions.intersection_set_date(this._inner, dateToTimestamp((LocalDate) other)));
         }
         else if (other instanceof dateset){
-            Pointer resultPointer= functions.intersection_set_set(this._inner, ((dateset) other)._inner);
-            int resultTimestamp= resultPointer.getInt(Integer.BYTES);
-            result = timestampToLocalDateTime(resultTimestamp);
+            result = new dateset(functions.intersection_set_set(this._inner, ((dateset) other)._inner));
         }
         else if (other instanceof datespan){
             datespan ds = this.to_span(datespan.class);
-            Pointer resultPointer = functions.intersection_span_span(ds.get_inner(), ((datespan) other).get_inner());
-            int resultTimestamp= resultPointer.getInt(Integer.BYTES);
-            result = timestampToLocalDateTime(resultTimestamp);
+            result = new datespan(functions.intersection_span_span(ds.get_inner(), ((datespan) other).get_inner()));
         }
         else if (other instanceof datespanset){
             datespanset dss = this.to_spanset(datespanset.class);
-            Pointer resultPointer = functions.intersection_spanset_spanset(dss.get_inner(), ((datespanset) other).get_inner());
-            int resultTimestamp= resultPointer.getInt(Integer.BYTES);
-            result = timestampToLocalDateTime(resultTimestamp);
+            result = new datespanset(functions.intersection_spanset_spanset(dss.get_inner(), ((datespanset) other).get_inner()));
         }
         else{
             throw new Exception("Operation not supported with this type");
@@ -584,29 +572,21 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
             minus_spanset_spanset
 */
 
-    public LocalDateTime minus(Object other) throws Exception{
-        LocalDateTime result = null;
+    public Time minus(Object other) throws Exception{
+        Time result;
         if (other instanceof LocalDate){
-            Pointer resultPointer= functions.minus_set_date(this._inner, dateToTimestamp((LocalDate) other));
-            int resultTimestamp= resultPointer.getInt(Integer.BYTES);
-            result = timestampToLocalDateTime(resultTimestamp);
+            result = new dateset(functions.minus_set_date(this._inner, dateToTimestamp((LocalDate) other)));
         }
         else if (other instanceof dateset){
-            Pointer resultPointer= functions.minus_set_set(this._inner, ((dateset) other)._inner);
-            int resultTimestamp= resultPointer.getInt(Integer.BYTES);
-            result = timestampToLocalDateTime(resultTimestamp);
+            result = new dateset(functions.minus_set_set(this._inner, ((dateset) other)._inner));
         }
         else if (other instanceof datespan){
             datespan ds = this.to_span(datespan.class);
-            Pointer resultPointer= functions.minus_span_span(ds.get_inner(), ((datespan) other).get_inner());
-            int resultTimestamp= resultPointer.getInt(Integer.BYTES);
-            result = timestampToLocalDateTime(resultTimestamp);
+            result = new datespanset(functions.minus_span_span(ds.get_inner(), ((datespan) other).get_inner()));
         }
         else if (other instanceof datespanset){
             datespanset dss = this.to_spanset(datespanset.class);
-            Pointer resultPointer= functions.minus_spanset_spanset(dss.get_inner(), ((datespanset) other).get_inner());
-            int resultTimestamp= resultPointer.getInt(Integer.BYTES);
-            result = timestampToLocalDateTime(resultTimestamp);
+            result = new datespanset(functions.minus_spanset_spanset(dss.get_inner(), ((datespanset) other).get_inner()));
         }
         else{
             throw new Exception("Operation not supported with this type");
@@ -614,19 +594,21 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
         return result;
     }
 
-    /**
-     * Convert timestamp (number of seconds since epoch) to LocalDate
-     */
+/**
+        Returns the temporal difference of ``other`` and ``self``.
 
-    public static LocalDate timestampToLocalDate(int timestamp) {
-        return LocalDate.ofEpochDay(timestamp / 86400); // Convert seconds back to days
-    }
+        Args:
+            other: the date to subtract this set from
 
-    public LocalDate subtract_from(Object other) throws Exception {
-        int ts= dateToTimestamp((LocalDate) other);
-        Pointer resultPointer= functions.minus_date_set(ts, this._inner);
-        int resultTimestamp= resultPointer.getInt(0);
-        return timestampToLocalDate(resultTimestamp);
+        Returns:
+            A :class:`dateset` instance.
+
+        MEOS Functions:
+            minus_date_set
+*/
+
+    public dateset subtract_from(LocalDate other) throws Exception {
+        return new dateset(functions.minus_date_set(dateToTimestamp(other), this._inner));
     }
 
 /**

--- a/jmeos-core/src/main/java/types/collections/time/datespan.java
+++ b/jmeos-core/src/main/java/types/collections/time/datespan.java
@@ -570,15 +570,6 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     /*---------------Set Operations-------------------*/
 
-    /**
-     *
-     * Convert timestamp (number of seconds since epoch) to LocalDateTime
-     */
-
-    public static LocalDateTime timestampToLocalDateTime(int timestamp) {
-        return LocalDateTime.ofEpochSecond(timestamp, 0, ZoneOffset.UTC);
-    }
-
 /**
         Returns the temporal intersection of ``self`` and ``other``.
 
@@ -586,35 +577,27 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
             other: temporal object to intersect with
 
         Returns:
-            A :class:`TimeDate` instance. The actual class depends on ``other``.
+            A :class:`Time` instance. The actual class depends on ``other``:
+            a :class:`datespan` for a date or a span, a :class:`datespanset` otherwise.
 
         MEOS Functions:
-            intersection_set_date, intersection_set_set, intersection_spanset_span,
-            intersection_spanset_spanset
+            intersection_span_date, intersection_span_span, intersection_spanset_span
 */
 
-    public LocalDateTime intersection(Object other) throws Exception {
-        LocalDateTime result = null;
+    public Time intersection(Object other) throws Exception {
+        Time result;
         if (other instanceof LocalDate){
-            Pointer resultPointer= functions.intersection_span_date(this._inner, dateToTimestamp((LocalDate) other));
-            int resultTimestamp= resultPointer.getInt(Integer.BYTES);
-            result = timestampToLocalDateTime(resultTimestamp);
+            result = new datespan(functions.intersection_span_date(this._inner, dateToTimestamp((LocalDate) other)));
+        }
+        else if (other instanceof datespan){
+            result = new datespan(functions.intersection_span_span(this._inner, ((datespan) other)._inner));
         }
         else if (other instanceof dateset){
             datespanset ds = ((dateset) other).to_spanset(datespanset.class);
-            Pointer resultPointer= functions.intersection_spanset_span(ds.get_inner(), this.get_inner());
-            int resultTimestamp= resultPointer.getInt(Integer.BYTES);
-            result = timestampToLocalDateTime(resultTimestamp);
-        }
-        else if (other instanceof datespan){
-            Pointer resultPointer = functions.intersection_span_span(this._inner, ((datespan) other)._inner);
-            int resultTimestamp= resultPointer.getInt(Integer.BYTES);
-            result = timestampToLocalDateTime(resultTimestamp);
+            result = new datespanset(functions.intersection_spanset_span(ds.get_inner(), this._inner));
         }
         else if (other instanceof datespanset){
-            Pointer resultPointer = functions.intersection_spanset_span(((datespanset) other).get_inner(), this._inner);
-            int resultTimestamp= resultPointer.getInt(Integer.BYTES);
-            result = timestampToLocalDateTime(resultTimestamp);
+            result = new datespanset(functions.intersection_spanset_span(((datespanset) other).get_inner(), this._inner));
         }
         else{
             throw new Exception("Operation not supported with this type");
@@ -660,20 +643,21 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
         return result;
     }
 
-    /**
-     *
-     * Convert timestamp (number of seconds since epoch) to LocalDate
-     */
+/**
+        Returns the temporal difference of ``other`` and ``self``.
 
-    public static LocalDate timestampToLocalDate(int timestamp) {
-        return LocalDate.ofEpochDay(timestamp / 86400); // Convert seconds back to days
-    }
+        Args:
+            other: the date to subtract this span from
 
-    public LocalDate subtract_from(Object other) throws Exception {
-        int ts= dateToTimestamp((LocalDate) other);
-        Pointer resultPointer= functions.minus_date_set(ts, this._inner);
-        int resultTimestamp= resultPointer.getInt(0);
-        return timestampToLocalDate(resultTimestamp);
+        Returns:
+            A :class:`datespanset` instance.
+
+        MEOS Functions:
+            minus_date_span
+*/
+
+    public datespanset subtract_from(LocalDate other) throws Exception {
+        return new datespanset(functions.minus_date_span(dateToTimestamp(other), this._inner));
     }
 
 /**

--- a/jmeos-core/src/main/java/types/collections/time/datespanset.java
+++ b/jmeos-core/src/main/java/types/collections/time/datespanset.java
@@ -578,15 +578,6 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     /*---------------Set Operations-------------------*/
 
-    /**
-     *
-     * Convert timestamp (number of seconds since epoch) to LocalDateTime
-     */
-
-    public static LocalDateTime timestampToLocalDateTime(int timestamp) {
-        return LocalDateTime.ofEpochSecond(timestamp, 0, ZoneOffset.UTC);
-    }
-
 /**
         Returns the temporal intersection of ``self`` and ``other``.
 
@@ -664,20 +655,21 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
         return result;
     }
 
-    /**
-     *
-     * convert timestamp (number of seconds since epoch) to LocalDate
-     */
+/**
+        Returns the temporal difference of ``other`` and ``self``.
 
-    public static LocalDate timestampToLocalDate(int timestamp) {
-        return LocalDate.ofEpochDay(timestamp / 86400); // Convert seconds back to days
-    }
+        Args:
+            other: the date to subtract this span set from
 
-    public LocalDate subtract_from(Object other) throws Exception {
-        int ts= dateToTimestamp((LocalDate) other);
-        Pointer resultPointer= functions.minus_date_set(ts, this._inner);
-        int resultTimestamp= resultPointer.getInt(Integer.BYTES);
-        return timestampToLocalDate(resultTimestamp);
+        Returns:
+            A :class:`datespanset` instance.
+
+        MEOS Functions:
+            minus_date_spanset
+*/
+
+    public datespanset subtract_from(LocalDate other) throws Exception {
+        return new datespanset(functions.minus_date_spanset(dateToTimestamp(other), this._inner));
     }
 
 /**

--- a/jmeos-core/src/test/java/collections/time/DateSetOperationsTest.java
+++ b/jmeos-core/src/test/java/collections/time/DateSetOperationsTest.java
@@ -1,0 +1,74 @@
+package collections.time;
+
+import functions.error_handler;
+import functions.error_handler_fn;
+import functions.functions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import types.collections.time.Time;
+import types.collections.time.datespan;
+import types.collections.time.dateset;
+import types.collections.time.datespanset;
+import utils.TestLogger;
+
+import java.sql.SQLException;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+@ExtendWith(TestLogger.class)
+class DateSetOperationsTest {
+
+    static error_handler_fn errorHandler = new error_handler();
+
+    DateSetOperationsTest() throws SQLException {
+        functions.meos_initialize_timezone("UTC");
+        functions.meos_initialize_error_handler(errorHandler);
+    }
+
+    @Test
+    void spanIntersectionIsASpan() throws Exception {
+        datespan a = new datespan("[2019-09-01, 2019-09-10]");
+        datespan b = new datespan("[2019-09-05, 2019-09-15]");
+        Time result = a.intersection(b);
+        datespan span = assertInstanceOf(datespan.class, result);
+        assertEquals(LocalDate.of(2019, 9, 5), span.lower());
+        assertEquals(LocalDate.of(2019, 9, 11), span.upper());
+    }
+
+    @Test
+    void setIntersectionIsASet() throws Exception {
+        dateset a = new dateset("{2019-09-01, 2019-09-03, 2019-09-05}");
+        dateset b = new dateset("{2019-09-03, 2019-09-05, 2019-09-07}");
+        dateset result = assertInstanceOf(dateset.class, a.intersection(b));
+        assertEquals(2, result.num_elements());
+    }
+
+    @Test
+    void setMinusIsASet() throws Exception {
+        dateset a = new dateset("{2019-09-01, 2019-09-03, 2019-09-05}");
+        dateset b = new dateset("{2019-09-03, 2019-09-05, 2019-09-07}");
+        dateset result = assertInstanceOf(dateset.class, a.minus(b));
+        assertEquals(1, result.num_elements());
+    }
+
+    @Test
+    void subtractDateFromSetIsASet() throws Exception {
+        dateset a = new dateset("{2019-09-01, 2019-09-03, 2019-09-05}");
+        dateset result = a.subtract_from(LocalDate.of(2019, 9, 2));
+        assertEquals(1, result.num_elements());
+    }
+
+    @Test
+    void subtractDateFromSpanIsASpanSet() throws Exception {
+        datespan a = new datespan("[2019-09-01, 2019-09-10]");
+        assertInstanceOf(datespanset.class, a.subtract_from(LocalDate.of(2019, 9, 20)));
+    }
+
+    @Test
+    void subtractDateFromSpanSetIsASpanSet() throws Exception {
+        datespanset a = new datespanset("{[2019-09-01, 2019-09-05], [2019-09-10, 2019-09-15]}");
+        assertInstanceOf(datespanset.class, a.subtract_from(LocalDate.of(2019, 9, 20)));
+    }
+}


### PR DESCRIPTION
The set operations on the date collection types (`datespan`, `dateset`, `datespanset`) return a `Time` collection, matching the MEOS result:

- `datespan.intersection` / `dateset.intersection` return the `Time` whose class follows the operand — a `datespan` for a date or span, a `dateset` for a set, a `datespanset` for a span set.
- `dateset.minus` returns a `dateset` (against a date or set) or a `datespanset` (against a span or span set).
- `subtract_from` returns the `datespanset` (or `dateset`) produced by `minus_date_span` / `minus_date_spanset` / `minus_date_set`, and passes the receiver's own pointer to the matching function rather than a span or span set to `minus_date_set`.

Each case wraps the MEOS result pointer directly in its collection type. This replaces reading the result struct as a 4-byte integer through a seconds-based epoch helper (which is removed).

`DateSetOperationsTest` asserts the result types and cardinalities for span/set intersection, set difference, and the three `subtract_from` forms. The `jmeos-core` suite runs in CI.
