### PR TITLE
Build libmeos with all MEOS families via -DALL

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,6 +45,24 @@ jobs:
       - name: Print current working directory
         run: pwd
 
+      # Prefer apt.postgresql.org over the runner's preinstalled PostgreSQL so
+      # the postgresql-server-dev package resolves cleanly. Only pg_config is
+      # needed here — pgPointCloud produces a static libpc.a, no server.
+      - name: Remove existing PostgreSQL installations [prefer apt.postgresql.org]
+        run: |
+          sudo service postgresql stop || true
+          sudo apt-get --purge remove postgresql* -y || true
+          sudo rm -rf /var/lib/postgresql/ /etc/postgresql/ \
+            /var/log/postgresql/ || true
+
+      - name: Add PostgreSQL APT repository
+        run: |
+          sudo apt-get install -y curl ca-certificates gnupg
+          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            | sudo apt-key add -
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ \
+            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+
       - name: Update apt cache
         run: sudo apt-get update
 
@@ -64,6 +82,11 @@ jobs:
       - name: Install GSL
         run: sudo apt-get install -y libgsl-dev
 
+      # Install libraries needed by the optional MEOS families (H3, GDAL, libxml2,
+      # autotools and a PostgreSQL server-dev package for the vendored pgPointCloud lib)
+      - name: Install all-families dependencies
+        run: sudo apt-get install -y libh3-dev libgdal-dev libxml2-dev autoconf automake libtool pkg-config postgresql-17 postgresql-server-dev-17
+
       # Fetch and install MEOS library
       - name: Fetch MEOS sources
         run: git clone https://github.com/MobilityDB/MobilityDB.git
@@ -73,7 +96,10 @@ jobs:
         run: |
           mkdir MobilityDB/build
           cd MobilityDB/build
-          cmake .. -DMEOS=on
+          cmake .. -DMEOS=on -DALL=ON \
+            -DH3_LIBRARY=/usr/lib/x86_64-linux-gnu/libh3.so \
+            -DH3_INCLUDE_DIR=/usr/include/h3 \
+            -DPOSTGRESQL_PG_CONFIG=/usr/lib/postgresql/17/bin/pg_config
           make -j
           sudo make install
 


### PR DESCRIPTION
CI builds libmeos with `-DMEOS=ON -DALL=ON`, enabling every current and future optional family (circular buffers, H3, JSON, network points, pgPointCloud, geoposes, quadbin, raster, rigid geometries, Arrow export). The apt step installs the libraries these families need: libh3, GDAL, and libxml2 plus autotools and a PostgreSQL server-dev package for the vendored pgPointCloud static library.
