### PR TITLE
Derive MEOS catalog in the javadoc workflow

### DIFF
--- a/.github/workflows/deploy_javadoc.yml
+++ b/.github/workflows/deploy_javadoc.yml
@@ -22,6 +22,23 @@ jobs:
       - name: Set up Maven
         run: mvn -B wrapper:wrapper
 
+      # Derive the MEOS catalog from MobilityDB in CI — it is no longer committed.
+      # Catalog-only (build-libmeos: false): javadoc compiles the sources but never
+      # runs them, so the native libmeos is not needed here.
+      - name: Provision MEOS catalog
+        id: provision
+        uses: MobilityDB/MEOS-API/.github/actions/provision-meos@master
+        with:
+          mobilitydb-ref: master
+          build-libmeos: "false"
+
+      # Stage the derived catalog where FunctionsGenerator reads it at build time.
+      # The catalog is gitignored — it only ever exists as a build artifact.
+      - name: Stage the derived catalog for the generator
+        run: |
+          mkdir -p codegen/input
+          cp "${{ steps.provision.outputs.catalog-path }}" codegen/input/meos-idl.json
+
       - name: Build sources
         run: mvn -B -DskipTests compile
         # Compiles the codegen module and generates functions/GeneratedFunctions.java, so the


### PR DESCRIPTION
The push-only `deploy_javadoc.yml` workflow broke on `main` after the catalog stopped being committed: `mvn compile` runs `generate-meos-facade`, which reads `codegen/input/meos-idl.json` and now fails with `FileNotFoundException`.

This provisions the catalog the same way `maven.yml` already does — via the shared `provision-meos` action — so the javadoc build is consistent with the main build. It runs `build-libmeos: "false"` (catalog-only) because javadoc compiles the sources but never executes them, so the native library is not needed here.

Fixes the red `Deploy Javadoc to GitHub Pages` run on `main`.