### PR TITLE
Remove Arrow support

### DIFF
--- a/codegen/src/main/java/FunctionsGenerator.java
+++ b/codegen/src/main/java/FunctionsGenerator.java
@@ -63,7 +63,7 @@ public class FunctionsGenerator {
             Map.entry("h3_generated.h", "H3"));
     private static final Set<String> OPTIONAL_FAMILIES =
             Set.of("CBUFFER", "NPOINT", "POSE", "RGEO", "H3",
-                   "QUADBIN", "POINTCLOUD", "JSON", "ARROW", "RASTER");
+                   "QUADBIN", "POINTCLOUD", "JSON", "RASTER");
 
     // Families enabled for this generation run; core headers are always emitted.
     private Set<String> enabledFamilies;
@@ -657,7 +657,7 @@ public class FunctionsGenerator {
         // A boolean function with EXACTLY ONE value out-param folds to a returned
         // Pointer: the wrapper allocates the buffer, forwards it, reads it back, and
         // returns it. Functions with two-or-more result-out params
-        // (intersection_*/synchronize_*: inter1/inter2, *_to_arrow: out_schema/out_array)
+        // (intersection_*/synchronize_*: inter1/inter2)
         // cannot collapse to a single returned buffer, so they keep those out-params as
         // caller-provided Pointer arguments.
         boolean isBoolResultPattern = fn.returnType.equals("boolean")


### PR DESCRIPTION
Drops Arrow from the JMEOS generator, matching MobilityDB/MobilityDB#1389 which removes the Arrow C Data Interface export (`meos_arrow.h`, `meos_*_to_arrow` / `_from_arrow` / `_arrow_roundtrip`).

- removes `ARROW` from the generator's optional-family set (in sync with MobilityDB's `ALL` families), so the FFI generation no longer enables an arrow family flag;
- removes the `*_to_arrow: out_schema/out_array` example from the result-out-param comment (its function no longer exists).
