### PR TITLE
Stop passing the dropped restriction arguments to the spatial relationships

### DIFF
--- a/jmeos-core/src/main/java/types/basic/tpoint/TPoint.java
+++ b/jmeos-core/src/main/java/types/basic/tpoint/TPoint.java
@@ -21,6 +21,7 @@ import types.collections.time.Time;
 import types.collections.time.tstzset;
 import types.temporal.*;
 import functions.functions;
+import functions.GeneratedFunctions;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.geom.Point;
@@ -1017,9 +1018,9 @@ public interface TPoint extends Serializable {
 	 */
 	default TBool is_spatially_contained_in(Object other) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
-			return (TBool) Factory.create_temporal(functions.tcontains_geo_tgeo(ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint), getPointInner(),false,false), "Boolean", getTemporalType() ) ;
+			return (TBool) Factory.create_temporal(GeneratedFunctions.tcontains_geo_tgeo(ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint), getPointInner()), "Boolean", getTemporalType() ) ;
 		} else if (other instanceof STBox) {
-			return (TBool) Factory.create_temporal(functions.tcontains_geo_tgeo(functions.stbox_to_geo(((STBox) other).get_inner()), getPointInner(), false,false), "Boolean", getTemporalType()  );
+			return (TBool) Factory.create_temporal(GeneratedFunctions.tcontains_geo_tgeo(functions.stbox_to_geo(((STBox) other).get_inner()), getPointInner()), "Boolean", getTemporalType()  );
 		}  else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -1039,9 +1040,9 @@ public interface TPoint extends Serializable {
 	 */
 	default TBool disjoint(Object other) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
-			return (TBool) Factory.create_temporal(functions.tdisjoint_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint),false,false), "Boolean", getTemporalType() ) ;
+			return (TBool) Factory.create_temporal(GeneratedFunctions.tdisjoint_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint)), "Boolean", getTemporalType() ) ;
 		} else if (other instanceof STBox) {
-			return (TBool) Factory.create_temporal(functions.tdisjoint_tgeo_geo(getPointInner(),functions.stbox_to_geo(((STBox) other).get_inner()), false,false), "Boolean", getTemporalType()  );
+			return (TBool) Factory.create_temporal(GeneratedFunctions.tdisjoint_tgeo_geo(getPointInner(),functions.stbox_to_geo(((STBox) other).get_inner())), "Boolean", getTemporalType()  );
 		}  else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -1062,11 +1063,11 @@ public interface TPoint extends Serializable {
 	 */
 	default TBool within_distance(Object other, float distance) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
-			return (TBool) Factory.create_temporal(functions.tdwithin_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint), distance, false,false), "Boolean", getTemporalType() ) ;
+			return (TBool) Factory.create_temporal(GeneratedFunctions.tdwithin_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint), distance), "Boolean", getTemporalType() ) ;
 		} else if (other instanceof STBox) {
-			return (TBool) Factory.create_temporal(functions.tdwithin_tgeo_geo(getPointInner(),functions.stbox_to_geo(((STBox) other).get_inner()), distance,false,false), "Boolean", getTemporalType()  );
+			return (TBool) Factory.create_temporal(GeneratedFunctions.tdwithin_tgeo_geo(getPointInner(),functions.stbox_to_geo(((STBox) other).get_inner()), distance), "Boolean", getTemporalType()  );
 		} else if(other instanceof TPoint){
-			return (TBool) Factory.create_temporal(functions.tdwithin_tgeo_tgeo(getPointInner(),((TPoint) other).getPointInner(), distance,false,false), "Boolean", getTemporalType()  );
+			return (TBool) Factory.create_temporal(GeneratedFunctions.tdwithin_tgeo_tgeo(getPointInner(),((TPoint) other).getPointInner(), distance), "Boolean", getTemporalType()  );
 		}else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -1086,9 +1087,9 @@ public interface TPoint extends Serializable {
 	 */
 	default TBool intersects(Object other) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
-			return (TBool) Factory.create_temporal(functions.tintersects_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint),false,false), "Boolean", getTemporalType() ) ;
+			return (TBool) Factory.create_temporal(GeneratedFunctions.tintersects_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint)), "Boolean", getTemporalType() ) ;
 		} else if (other instanceof STBox) {
-			return (TBool) Factory.create_temporal(functions.tintersects_tgeo_geo(getPointInner(),functions.stbox_to_geo(((STBox) other).get_inner()), false,false), "Boolean", getTemporalType()  );
+			return (TBool) Factory.create_temporal(GeneratedFunctions.tintersects_tgeo_geo(getPointInner(),functions.stbox_to_geo(((STBox) other).get_inner())), "Boolean", getTemporalType()  );
 		}  else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -1108,9 +1109,9 @@ public interface TPoint extends Serializable {
 	 */
 	default TBool touches(Object other) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
-			return (TBool) Factory.create_temporal(functions.ttouches_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint),false,false), "Boolean", getTemporalType() ) ;
+			return (TBool) Factory.create_temporal(GeneratedFunctions.ttouches_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint)), "Boolean", getTemporalType() ) ;
 		} else if (other instanceof STBox) {
-			return (TBool) Factory.create_temporal(functions.ttouches_tgeo_geo(getPointInner(),functions.stbox_to_geo(((STBox) other).get_inner()), false,false), "Boolean", getTemporalType()  );
+			return (TBool) Factory.create_temporal(GeneratedFunctions.ttouches_tgeo_geo(getPointInner(),functions.stbox_to_geo(((STBox) other).get_inner())), "Boolean", getTemporalType()  );
 		}  else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}


### PR DESCRIPTION
Matches the argument lists the spatial relationships actually take.

MEOS takes three parameters for `tdwithin_tgeo_geo` and `tdwithin_tgeo_tgeo`, and two for `tcontains_geo_tgeo`, `tdisjoint_tgeo_geo`, `tintersects_tgeo_geo` and `ttouches_tgeo_geo`. The hand-written facade declares a trailing `boolean restr, boolean atvalue` pair on each, and `TPoint` passes `false` for both, so eleven call sites hand a five-parameter call to a three-parameter function.

The symbol resolves, so `NativeSymbolParityTest` passes: it checks that every declared name exists in libmeos, not that the parameter lists agree. That is the gap this closes by hand until the check itself compares signatures against the catalog.

The calls now go to `GeneratedFunctions`, which carries the parameter lists the catalog describes, and the two arguments are gone.

Against MobilityDB `7beddd553`, the commit `tools/meos-source-commit.txt` records, `mvn clean test` is 1756 tests, 0 failures, 0 errors, with `TGeomPointTest` and `TGeogPointTest` — the classes exercising these predicates — at 133 each.