### PR TITLE
Read the value at a timestamp from the pointer MEOS returns

### DIFF
--- a/jmeos-core/src/main/java/types/basic/tbool/TBool.java
+++ b/jmeos-core/src/main/java/types/basic/tbool/TBool.java
@@ -13,6 +13,7 @@ import types.collections.time.Time;
 import types.collections.time.tstzspanset;
 import types.temporal.*;
 import functions.functions;
+import functions.GeneratedFunctions;
 import utils.ConversionUtils;
 
 import java.time.LocalDateTime;
@@ -216,13 +217,9 @@ public interface TBool {
 */
 
 default boolean value_at_timestamp(LocalDateTime ts){
-    // Create a JNR-FFI runtime instance
-    Runtime runtime = Runtime.getSystemRuntime();
-    // Allocate memory for an integer (4 bytes) but do not set a value
-    Pointer boolPointer = Memory.allocate(runtime, 4);
-    boolean res= functions.tbool_value_at_timestamptz(this.getBoolInner(), ConversionUtils.datetimeToTimestampTz(ts), true, boolPointer);
-    int value= boolPointer.getInt(Integer.BYTES);
-    return value > 0;
+    Pointer value = GeneratedFunctions.tbool_value_at_timestamptz(
+            this.getBoolInner(), ConversionUtils.datetimeToTimestampTz(ts), true);
+    return value.getByte(0) != 0;
 }
 
 

--- a/jmeos-core/src/main/java/types/basic/tfloat/TFloat.java
+++ b/jmeos-core/src/main/java/types/basic/tfloat/TFloat.java
@@ -17,6 +17,7 @@ import types.collections.time.Time;
 import types.collections.time.tstzspanset;
 import types.temporal.*;
 import functions.functions;
+import functions.GeneratedFunctions;
 import utils.ConversionUtils;
 
 import java.time.LocalDateTime;
@@ -730,13 +731,9 @@ public interface TFloat extends TNumber {
             tfloat_value_at_timestamp
 */
 	default float value_at_timestamp(LocalDateTime ts){
-		// Create a JNR-FFI runtime instance
-		Runtime runtime = Runtime.getSystemRuntime();
-		// Allocate memory for an integer (4 bytes) but do not set a value
-		Pointer floatPointer = Memory.allocate(runtime, 4);
-		boolean res= functions.tfloat_value_at_timestamptz(this.getNumberInner(), ConversionUtils.datetimeToTimestampTz(ts), true, floatPointer);
-		float value= floatPointer.getFloat(Float.BYTES);
-		return value;
+		Pointer value = GeneratedFunctions.tfloat_value_at_timestamptz(
+				this.getNumberInner(), ConversionUtils.datetimeToTimestampTz(ts), true);
+		return (float) value.getDouble(0);
 	}
 /**
         Returns the derivative of `self`.

--- a/jmeos-core/src/main/java/types/basic/tint/TInt.java
+++ b/jmeos-core/src/main/java/types/basic/tint/TInt.java
@@ -1,5 +1,6 @@
 package types.basic.tint;
 import functions.functions;
+import functions.GeneratedFunctions;
 import jnr.ffi.Memory;
 import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
@@ -295,13 +296,9 @@ public interface TInt extends TNumber {
 */
 
 	default int value_at_timestamp(LocalDateTime timestamp){
-		// Create a JNR-FFI runtime instance
-		Runtime runtime = Runtime.getSystemRuntime();
-		// Allocate memory for an integer (4 bytes) but do not set a value
-		Pointer intPointer = Memory.allocate(runtime, 4);
-		boolean x= functions.tint_value_at_timestamptz(this.getNumberInner(), ConversionUtils.datetimeToTimestampTz(timestamp), true, intPointer);
-		int num= intPointer.getInt(Integer.BYTES);
-		return num;
+		Pointer value = GeneratedFunctions.tint_value_at_timestamptz(
+				this.getNumberInner(), ConversionUtils.datetimeToTimestampTz(timestamp), true);
+		return value.getInt(0);
 	}
 
     /* ------------------------- Ever and Always Comparisons ------------------- */

--- a/jmeos-core/src/main/java/types/basic/tpoint/TPoint.java
+++ b/jmeos-core/src/main/java/types/basic/tpoint/TPoint.java
@@ -273,12 +273,8 @@ public interface TPoint extends Serializable {
             tpoint_value_at_timestamp
 */
 	default Point value_at_timestamp(LocalDateTime ts, int precision) throws ParseException {
-		 // Create a JNR-FFI runtime instance
-		 Runtime runtime = Runtime.getSystemRuntime();
-		 // Allocate memory for an integer (4 bytes) but do not set a value
-		 Pointer geomPointer = Memory.allocate(runtime, 8);
-		 boolean b= functions.tgeo_value_at_timestamptz(this.getPointInner(), ConversionUtils.datetimeToTimestampTz(ts), true, geomPointer);
-		 Pointer geom= geomPointer.getPointer(Long.BYTES);
+		 Pointer geom = GeneratedFunctions.tgeo_value_at_timestamptz(
+				 this.getPointInner(), ConversionUtils.datetimeToTimestampTz(ts), true);
 		 return ConversionUtils.gserialized_to_shapely_point(geom, precision);
 	}
 

--- a/jmeos-core/src/test/java/basic/ValueAtTimestampTest.java
+++ b/jmeos-core/src/test/java/basic/ValueAtTimestampTest.java
@@ -1,0 +1,62 @@
+package basic;
+
+import functions.GeneratedFunctions;
+import functions.error_handler;
+import functions.error_handler_fn;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import types.basic.tbool.TBoolSeq;
+import types.basic.tfloat.TFloatSeq;
+import types.basic.tint.TIntSeq;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Checks the value each temporal type reports at a timestamp against the value it was built from.
+ *
+ * <p>These accessors read the value out of the native memory MEOS writes, so the read has to agree
+ * with the width and offset MEOS uses: an int occupies four bytes, a float is stored as a double,
+ * and a bool occupies one byte. A read at the wrong offset or width returns whatever the
+ * neighbouring bytes hold — a plausible number rather than an obviously wrong one, which compiles,
+ * runs, and reports a value. Asserting the value is what covers that.
+ */
+@DisplayName("Value at timestamp")
+class ValueAtTimestampTest {
+
+    static error_handler_fn errorHandler = new error_handler();
+
+    @BeforeAll
+    static void init() {
+        GeneratedFunctions.meos_initialize_timezone("UTC");
+        GeneratedFunctions.meos_initialize_error_handler(errorHandler);
+    }
+
+    private static LocalDateTime day(int d) {
+        return LocalDateTime.of(2019, 9, d, 0, 0, 0);
+    }
+
+    @Test
+    @DisplayName("tint reports the integer it holds")
+    void tintValueAtTimestamp() {
+        TIntSeq seq = new TIntSeq("[25@2019-09-01, 35@2019-09-02]");
+        assertEquals(25, seq.value_at_timestamp(day(1)));
+    }
+
+    @Test
+    @DisplayName("tfloat reports the double it holds, narrowed to float")
+    void tfloatValueAtTimestamp() {
+        TFloatSeq seq = new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]");
+        assertEquals(1.5f, seq.value_at_timestamp(day(1)), 1e-6f);
+    }
+
+    @Test
+    @DisplayName("tbool reports the boolean it holds")
+    void tboolValueAtTimestamp() {
+        TBoolSeq seq = new TBoolSeq("[true@2019-09-01, true@2019-09-02]");
+        assertTrue(seq.value_at_timestamp(day(1)));
+    }
+}


### PR DESCRIPTION
Reads each temporal type's value at a timestamp from the pointer the generated surface returns, at that type's own width.

`TInt`, `TFloat`, `TBool` and `TPoint` allocate a buffer, pass it to the hand-written facade as an output parameter, and then read it one field past its start — `intPointer.getInt(Integer.BYTES)` on a four-byte allocation, and for `TFloat` a four-byte allocation holding a value MEOS writes as a double. The read lands outside the buffer.

Restoring the previous `TInt` body under the new test makes jnr report it directly:

```
ValueAtTimestampTest.tintValueAtTimestamp:46 » ArrayIndexOutOfBounds Index 4 out of bounds for length 4
```

The generated surface returns the value pointer itself, so the accessors take it from there and read at the width MEOS uses: `getInt(0)` for an int, the stored double narrowed for a float, the single byte for a bool, and the geometry pointer as it stands.

`ValueAtTimestampTest` asserts the values the sequences are built from — 25 for a tint, 1.5 for a tfloat, true for a tbool. A native read needs the value asserted: a call that completes says nothing about the bytes it returned, which is why this went unnoticed.

Against MobilityDB `7beddd553`, the commit `tools/meos-source-commit.txt` records: `mvn clean test` is 1759 tests, 0 failures, 0 errors, and the push-only `mvn -B javadoc:javadoc` job is green.