### PR TITLE
Pass the count argument the set and spanset readers write through

### DIFF
--- a/jmeos-core/src/main/java/functions/functions.java
+++ b/jmeos-core/src/main/java/functions/functions.java
@@ -367,7 +367,6 @@ public class functions {
 
 		boolean bigintset_value_n(Pointer s, int n, Pointer result);
 
-		Pointer bigintset_values(Pointer s);
 
 		long bigintspan_lower(Pointer s);
 
@@ -387,7 +386,6 @@ public class functions {
 
 		boolean dateset_value_n(Pointer s, int n, Pointer result);
 
-		Pointer dateset_values(Pointer s);
 
 		Pointer datespan_duration(Pointer s);
 
@@ -413,7 +411,6 @@ public class functions {
 
 		boolean floatset_value_n(Pointer s, int n, Pointer result);
 
-		Pointer floatset_values(Pointer s);
 
 		double floatspan_lower(Pointer s);
 
@@ -433,7 +430,6 @@ public class functions {
 
 		boolean intset_value_n(Pointer s, int n, Pointer result);
 
-		Pointer intset_values(Pointer s);
 
 		int intspan_lower(Pointer s);
 
@@ -475,7 +471,6 @@ public class functions {
 
 		Pointer spanset_span_n(Pointer ss, int i);
 
-		Pointer spanset_spanarr(Pointer ss);
 
 		Pointer spanset_start_span(Pointer ss);
 
@@ -487,7 +482,6 @@ public class functions {
 
 		boolean textset_value_n(Pointer s, int n, Pointer result);
 
-		Pointer textset_values(Pointer s);
 
 		long tstzset_end_value(Pointer s);
 
@@ -495,7 +489,6 @@ public class functions {
 
 		boolean tstzset_value_n(Pointer s, int n, Pointer result);
 
-		Pointer tstzset_values(Pointer s);
 
 		Pointer tstzspan_duration(Pointer s);
 
@@ -641,13 +634,11 @@ public class functions {
 
 		boolean spanset_ne(Pointer ss1, Pointer ss2);
 
-		Pointer set_spans(Pointer s);
 
 		Pointer set_split_each_n_spans(Pointer s, int elems_per_span, Pointer count);
 
 		Pointer set_split_n_spans(Pointer s, int span_count, Pointer count);
 
-		Pointer spanset_spans(Pointer ss);
 
 		Pointer spanset_split_each_n_spans(Pointer ss, int elems_per_span, Pointer count);
 
@@ -2755,7 +2746,6 @@ public class functions {
 
 		boolean geoset_value_n(Pointer s, int n, Pointer result);
 
-		Pointer geoset_values(Pointer s);
 
 		boolean contained_geo_set(Pointer gs, Pointer s);
 
@@ -3393,7 +3383,6 @@ public class functions {
 
 		Pointer tgeo_space_time_split(Pointer temp, double xsize, double ysize, double zsize, Pointer duration, Pointer sorigin, long torigin, boolean bitmatrix, boolean border_inc, Pointer space_bins, Pointer time_bins, Pointer count);
 
-		Pointer geo_cluster_kmeans(Pointer geoms, int ngeoms, int k);
 
 		Pointer geo_cluster_dbscan(Pointer geoms, int ngeoms, double tolerance, int minpoints, Pointer count);
 
@@ -4589,12 +4578,6 @@ public class functions {
 		return out ? result : null;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer bigintset_values(Pointer s) {
-		var _result = MeosLibrary.meos.bigintset_values(s);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static long bigintspan_lower(Pointer s) {
@@ -4662,12 +4645,6 @@ public class functions {
 		return out ? result : null;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer dateset_values(Pointer s) {
-		var _result = MeosLibrary.meos.dateset_values(s);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static Pointer datespan_duration(Pointer s) {
@@ -4759,12 +4736,6 @@ public class functions {
 		return out ? result : null;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer floatset_values(Pointer s) {
-		var _result = MeosLibrary.meos.floatset_values(s);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static double floatspan_lower(Pointer s) {
@@ -4832,12 +4803,6 @@ public class functions {
 		return out ? result : null;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer intset_values(Pointer s) {
-		var _result = MeosLibrary.meos.intset_values(s);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static int intspan_lower(Pointer s) {
@@ -4979,12 +4944,6 @@ public class functions {
 		return _result;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer spanset_spanarr(Pointer ss) {
-		var _result = MeosLibrary.meos.spanset_spanarr(ss);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static Pointer spanset_start_span(Pointer ss) {
@@ -5025,12 +4984,6 @@ public class functions {
 		return out ? new_result : null;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer textset_values(Pointer s) {
-		var _result = MeosLibrary.meos.textset_values(s);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static OffsetDateTime tstzset_end_value(Pointer s) {
@@ -5056,12 +5009,6 @@ public class functions {
 		return out ? result : null;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tstzset_values(Pointer s) {
-		var _result = MeosLibrary.meos.tstzset_values(s);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static Pointer tstzspan_duration(Pointer s) {
@@ -5575,12 +5522,6 @@ public class functions {
 		return _result;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer set_spans(Pointer s) {
-		var _result = MeosLibrary.meos.set_spans(s);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static Pointer set_split_each_n_spans(Pointer s, int elems_per_span, Pointer count) {
@@ -5596,12 +5537,6 @@ public class functions {
 		return _result;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer spanset_spans(Pointer ss) {
-		var _result = MeosLibrary.meos.spanset_spans(ss);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static Pointer spanset_split_each_n_spans(Pointer ss, int elems_per_span, Pointer count) {
@@ -13121,12 +13056,6 @@ public class functions {
 		return out ? new_result : null;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer geoset_values(Pointer s) {
-		var _result = MeosLibrary.meos.geoset_values(s);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static boolean contained_geo_set(Pointer gs, Pointer s) {
@@ -15413,12 +15342,6 @@ public class functions {
 		return _result;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer geo_cluster_kmeans(Pointer geoms, int ngeoms, int k) {
-		var _result = MeosLibrary.meos.geo_cluster_kmeans(geoms, ngeoms, k);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static Pointer geo_cluster_dbscan(Pointer geoms, int ngeoms, double tolerance, int minpoints, Pointer count) {

--- a/jmeos-core/src/main/java/types/collections/base/SpanSet.java
+++ b/jmeos-core/src/main/java/types/collections/base/SpanSet.java
@@ -1,6 +1,9 @@
 package types.collections.base;
 
 import com.google.common.primitives.Ints;
+import jnr.ffi.Runtime;
+import jnr.ffi.Memory;
+import functions.GeneratedFunctions;
 import jnr.ffi.Pointer;
 import functions.functions;
 import types.collections.number.FloatSpan;
@@ -234,8 +237,10 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
             spanset_spans
     */
     public <T> List<T> spans(Class<T> spanType) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, InvocationTargetException {
-        Pointer ps = functions.spanset_spans(this._inner);
-        int numSpans = this.num_spans();
+        Runtime runtime = Runtime.getSystemRuntime();
+        Pointer countPtr = Memory.allocate(runtime, Integer.BYTES);
+        Pointer ps = GeneratedFunctions.spanset_spans(this._inner, countPtr);
+        int numSpans = countPtr.getInt(0);
         List<T> spanList = new ArrayList<T>(numSpans);
 
         long pointerSize = getPointerSize(spanType);

--- a/jmeos-core/src/main/java/types/collections/number/FloatSet.java
+++ b/jmeos-core/src/main/java/types/collections/number/FloatSet.java
@@ -1,5 +1,8 @@
 package types.collections.number;
 import jnr.ffi.Pointer;
+import jnr.ffi.Runtime;
+import jnr.ffi.Memory;
+import functions.GeneratedFunctions;
 import types.collections.base.Base;
 import types.collections.base.Set;
 
@@ -163,9 +166,11 @@ public class FloatSet extends Set<Float> implements Number{
     }
 
     public List<Float> elements(){
-        Pointer elems = functions.floatset_values(this._inner);
+        Runtime runtime = Runtime.getSystemRuntime();
+        Pointer count = Memory.allocate(runtime, Integer.BYTES);
+        Pointer elems = GeneratedFunctions.floatset_values(this._inner, count);
         List<Float> ret = new ArrayList<Float>();
-        for (int i=0;i<this.num_elements();i++)
+        for (int i=0;i<count.getInt(0);i++)
         {
             ret.add((float) elems.getDouble((long) i * Double.BYTES));
         }

--- a/jmeos-core/src/main/java/types/collections/number/FloatSpanSet.java
+++ b/jmeos-core/src/main/java/types/collections/number/FloatSpanSet.java
@@ -1,5 +1,8 @@
 package types.collections.number;
 import com.google.common.primitives.Floats;
+import jnr.ffi.Runtime;
+import jnr.ffi.Memory;
+import functions.GeneratedFunctions;
 import jnr.ffi.Pointer;
 import types.collections.base.Base;
 import types.collections.base.SpanSet;
@@ -174,11 +177,12 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
 
 
     public List<FloatSpan> spans(){
-        Pointer ps = functions.spanset_spans(this._inner);
-        List<FloatSpan> spanList = new ArrayList<FloatSpan>(this.num_spans());
-        System.out.println(this.num_spans());
-        long pointerSize= Double.BYTES;
-        for (long i=0; i<this.num_spans(); i++){
+        Runtime runtime = Runtime.getSystemRuntime();
+        Pointer count = Memory.allocate(runtime, Integer.BYTES);
+        Pointer ps = GeneratedFunctions.spanset_spans(this._inner, count);
+        List<FloatSpan> spanList = new ArrayList<FloatSpan>(count.getInt(0));
+        long pointerSize= Long.BYTES;
+        for (long i=0; i<count.getInt(0); i++){
             Pointer p= ps.getPointer((long) i*pointerSize);
 //            System.out.println(new IntSpan(p).lower().toString());
 //            System.out.println(new IntSpan(p).upper().toString());

--- a/jmeos-core/src/main/java/types/collections/number/IntSet.java
+++ b/jmeos-core/src/main/java/types/collections/number/IntSet.java
@@ -1,5 +1,8 @@
 package types.collections.number;
 import types.collections.base.Base;
+import jnr.ffi.Runtime;
+import jnr.ffi.Memory;
+import functions.GeneratedFunctions;
 import types.collections.base.Set;
 import jnr.ffi.Pointer;
 
@@ -160,9 +163,11 @@ public class IntSet extends Set<Integer> implements Number{
     }
 
     public List<Integer> elements(){
-        Pointer elems = functions.intset_values(this._inner);
+        Runtime runtime = Runtime.getSystemRuntime();
+        Pointer count = Memory.allocate(runtime, Integer.BYTES);
+        Pointer elems = GeneratedFunctions.intset_values(this._inner, count);
         List<Integer> ret = new ArrayList<Integer>();
-        for (int i=0;i<this.num_elements();i++)
+        for (int i=0;i<count.getInt(0);i++)
         {
             ret.add(elems.getInt((long) i *Integer.BYTES));
         }

--- a/jmeos-core/src/main/java/types/collections/number/IntSpanSet.java
+++ b/jmeos-core/src/main/java/types/collections/number/IntSpanSet.java
@@ -1,5 +1,8 @@
 package types.collections.number;
 import jnr.ffi.annotations.In;
+import jnr.ffi.Runtime;
+import jnr.ffi.Memory;
+import functions.GeneratedFunctions;
 import types.collections.base.Base;
 import types.collections.base.SpanSet;
 import jnr.ffi.Pointer;
@@ -179,11 +182,12 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
 
 
     public List<IntSpan> spans(){
-        Pointer ps = functions.spanset_spans(this._inner);
+        Runtime runtime = Runtime.getSystemRuntime();
+        Pointer count = Memory.allocate(runtime, Integer.BYTES);
+        Pointer ps = GeneratedFunctions.spanset_spans(this._inner, count);
         List<IntSpan> spanList = new ArrayList<IntSpan>();
-        System.out.println(this.num_spans());
         long pointerSize= Long.BYTES;
-        for (long i=0; i<this.num_spans(); i++){
+        for (long i=0; i<count.getInt(0); i++){
             Pointer p= ps.getPointer((long) i*pointerSize);
 //            System.out.println(new IntSpan(p).lower().toString());
 //            System.out.println(new IntSpan(p).upper().toString());

--- a/jmeos-core/src/main/java/types/collections/time/dateset.java
+++ b/jmeos-core/src/main/java/types/collections/time/dateset.java
@@ -1,6 +1,9 @@
 package types.collections.time;
 
 import jnr.ffi.Pointer;
+import jnr.ffi.Runtime;
+import jnr.ffi.Memory;
+import functions.GeneratedFunctions;
 import jnr.ffi.annotations.In;
 import org.locationtech.jts.io.ParseException;
 import types.collections.base.*;
@@ -162,8 +165,10 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 */
 
     public List<LocalDate> elements() throws Exception {
-        Pointer dp= functions.dateset_values(this._inner);
-        long size= this.num_elements();
+        Runtime runtime = Runtime.getSystemRuntime();
+        Pointer count = Memory.allocate(runtime, Integer.BYTES);
+        Pointer dp= GeneratedFunctions.dateset_values(this._inner, count);
+        long size= count.getInt(0);
         List<LocalDate> datelist= new ArrayList<LocalDate>();
         for(int i=0; i<size; i++) {
             int res= dp.getInt((long) i *Integer.BYTES);

--- a/jmeos-core/src/main/java/types/collections/time/tstzset.java
+++ b/jmeos-core/src/main/java/types/collections/time/tstzset.java
@@ -1,6 +1,9 @@
 package types.collections.time;
 
 import jnr.ffi.Pointer;
+import jnr.ffi.Runtime;
+import jnr.ffi.Memory;
+import functions.GeneratedFunctions;
 import types.TemporalObject;
 import types.boxes.Box;
 import types.collections.base.Base;
@@ -231,8 +234,10 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	}
 
 	public List<LocalDateTime> elements() throws Exception {
-		Pointer dp= functions.tstzset_values(this._inner);
-		long size= this.num_elements();
+		Runtime runtime = Runtime.getSystemRuntime();
+		Pointer count = Memory.allocate(runtime, Integer.BYTES);
+		Pointer dp= GeneratedFunctions.tstzset_values(this._inner, count);
+		long size= count.getInt(0);
 		List<LocalDateTime> dateTimeList= new ArrayList<LocalDateTime>();
 		for(int i=0; i<size; i++) {
 			dateTimeList.add(ConversionUtils.timestamptz_to_datetime(OffsetDateTime.parse(dp.getPointer((long) i *Long.BYTES).toString())));


### PR DESCRIPTION
Passes the out-parameter MEOS writes the element count into, which the hand-written facade omits.

MEOS takes a count pointer and writes through it:

```c
extern DateADT *dateset_values(const Set *s, int *count);
extern Span    *set_spans(const Set *s, int *count);
extern Span    *spanset_spans(const SpanSet *ss, int *count);
extern int     *geo_cluster_kmeans(const GSERIALIZED **geoms, uint32_t ngeoms, uint32_t k, int *count);
```

`functions.MeosLibrary` declares these with the set alone. A call therefore leaves the count argument unset, and the function writes the element count through whatever that register holds — an address the caller never provided. Eleven declarations carry that shape: `bigintset_values`, `dateset_values`, `floatset_values`, `geoset_values`, `intset_values`, `textset_values`, `tstzset_values`, `set_spans`, `spanset_spans`, `spanset_spanarr` and `geo_cluster_kmeans`.

Seven call sites are live — `dateset.elements()`, `FloatSet.elements()`, `IntSet.elements()`, `tstzset.elements()`, and `spans()` on `IntSpanSet`, `FloatSpanSet` and `SpanSet`. They call the generated surface, which carries the parameter, and allocate the int it writes into.

Each then takes its length from that count rather than from a separate `num_elements()` or `num_spans()` call, so the array and its length come from one call instead of two. The eleven declarations and their wrappers go with the change; the generated surface carries all of them in the correct shape.

Against MobilityDB `7beddd553` with an all-families libmeos: `mvn clean test` is 1759 tests, 0 failures, 0 errors.