### PR TITLE
Map Oid to int rather than to a pointer

### DIFF
--- a/codegen/src/main/java/FunctionsGenerator.java
+++ b/codegen/src/main/java/FunctionsGenerator.java
@@ -340,8 +340,12 @@ public class FunctionsGenerator {
             case "char"                             -> "String";
             case "float"                            -> "float";
             case "double", "float8"                 -> "double";
+            // Oid is a PostgreSQL object identifier, a by-value unsigned int — the
+            // collation a text comparison or hash runs under. Without a case here it
+            // reaches the default branch and becomes Pointer, so the call passes an
+            // address where the library reads a 32-bit value.
             case "int", "int32", "int32_t",
-                 "uint32", "uint32_t"               -> "int";
+                 "uint32", "uint32_t", "Oid"        -> "int";
             case "short", "int16", "int16_t",
                  "uint16", "uint16_t"               -> "short";
             case "int8", "int8_t",

--- a/codegen/src/test/java/FunctionsGeneratorTest.java
+++ b/codegen/src/test/java/FunctionsGeneratorTest.java
@@ -129,6 +129,8 @@ class FunctionsGeneratorTest {
         @Test void int_() throws Exception         { assertEquals("int",     mapJava("int")); }
         @Test void int32_t() throws Exception      { assertEquals("int",     mapJava("int32_t")); }
         @Test void uint32_t() throws Exception     { assertEquals("int",     mapJava("uint32_t")); }
+        /** Oid is an unsigned int passed by value, so it maps like one rather than to Pointer. */
+        @Test void oid() throws Exception          { assertEquals("int",     mapJava("Oid")); }
         @Test void long_() throws Exception        { assertEquals("long",    mapJava("long")); }
         @Test void int64_t() throws Exception      { assertEquals("long",    mapJava("int64_t")); }
         @Test void uint64_t() throws Exception     { assertEquals("long",    mapJava("uint64_t")); }


### PR DESCRIPTION
Maps `Oid` to `int`, so the collation argument is passed as the value the library reads.

`Oid` is a PostgreSQL object identifier — `typedef unsigned int Oid;` — passed by value. `mapCTypeToJava` has no case for it, so it reaches the `default -> Pointer` branch. Three functions take one:

```c
extern int    text_cmp(const text *txt1, const text *txt2, Oid collid);
extern uint32 text_hash(const text *txt, Oid collid);
extern uint64 text_hash_extended(const text *txt, uint64 seed, Oid collid);
```

Their generated declarations give `collid` as `Pointer`, so a call hands an address to a parameter the library reads as a 32-bit integer. The collation selects how text compares and hashes, so the value reaching it decides the result.

`Oid` now maps alongside `uint32`, which is what it is:

```java
int  text_cmp(Pointer txt1, Pointer txt2, int collid);
int  text_hash(Pointer txt, int collid);
long text_hash_extended(Pointer txt, long seed, int collid);
```

A test sits beside the other type-mapping cases, so the mapping is stated rather than implied by the absence of a default.

This is the shape the by-value struct returns have as well: an unrecognised C type name becomes a pointer silently. Naming each type the catalog carries is what keeps that from happening quietly.

Derived from MobilityDB `7beddd553` with an all-families libmeos, the codegen unit suite counts 102 and the FFI suite 1759, both with 0 failures and 0 errors.