### PR TITLE
Align the facade arities with the library and check them

### DIFF
--- a/jmeos-core/src/main/java/functions/functions.java
+++ b/jmeos-core/src/main/java/functions/functions.java
@@ -153,7 +153,7 @@ public class functions {
 
 		String text_to_cstring(Pointer txt);
 
-		int text_cmp(Pointer txt1, Pointer txt2);
+		int text_cmp(Pointer txt1, Pointer txt2, int collid);
 
 		Pointer text_copy(Pointer txt);
 
@@ -2592,7 +2592,7 @@ public class functions {
 
 		String box3d_out(Pointer box, int maxdd);
 
-		Pointer gbox_make(boolean hasz, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax);
+		Pointer gbox_make(boolean hasz, boolean hasm, boolean geodetic, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, double mmin, double mmax);
 
 		String gbox_out(Pointer box, int maxdd);
 
@@ -3787,8 +3787,8 @@ public class functions {
 	}
 
 	@SuppressWarnings("unused")
-	public static int text_cmp(Pointer txt1, Pointer txt2) {
-		var _result = MeosLibrary.meos.text_cmp(txt1, txt2);
+	public static int text_cmp(Pointer txt1, Pointer txt2, int collid) {
+		var _result = MeosLibrary.meos.text_cmp(txt1, txt2, collid);
 		MeosErrorHandler.checkError();
 		return _result;
 	}
@@ -12491,8 +12491,8 @@ public class functions {
 	}
 
 	@SuppressWarnings("unused")
-	public static Pointer gbox_make(boolean hasz, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax) {
-		var _result = MeosLibrary.meos.gbox_make(hasz, xmin, xmax, ymin, ymax, zmin, zmax);
+	public static Pointer gbox_make(boolean hasz, boolean hasm, boolean geodetic, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, double mmin, double mmax) {
+		var _result = MeosLibrary.meos.gbox_make(hasz, hasm, geodetic, xmin, xmax, ymin, ymax, zmin, zmax, mmin, mmax);
 		MeosErrorHandler.checkError();
 		return _result;
 	}

--- a/jmeos-core/src/main/java/functions/functions.java
+++ b/jmeos-core/src/main/java/functions/functions.java
@@ -3073,11 +3073,9 @@ public class functions {
 
 		Pointer tgeo_minus_value(Pointer temp, Pointer gs);
 
-		Pointer tpoint_at_geom(Pointer temp, Pointer gs, Pointer zspan);
 
 		Pointer tpoint_at_value(Pointer temp, Pointer gs);
 
-		Pointer tpoint_minus_geom(Pointer temp, Pointer gs, Pointer zspan);
 
 		Pointer tpoint_minus_value(Pointer temp, Pointer gs);
 
@@ -3303,41 +3301,23 @@ public class functions {
 
 		int etouches_tpoint_geo(Pointer temp, Pointer gs);
 
-		Pointer tcontains_geo_tgeo(Pointer gs, Pointer temp, boolean restr, boolean atvalue);
 
-		Pointer tcontains_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue);
 
-		Pointer tcontains_tgeo_tgeo(Pointer temp1, Pointer temp2, boolean restr, boolean atvalue);
 
-		Pointer tcovers_geo_tgeo(Pointer gs, Pointer temp, boolean restr, boolean atvalue);
 
-		Pointer tcovers_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue);
 
-		Pointer tcovers_tgeo_tgeo(Pointer temp1, Pointer temp2, boolean restr, boolean atvalue);
 
-		Pointer tdisjoint_geo_tgeo(Pointer gs, Pointer temp, boolean restr, boolean atvalue);
 
-		Pointer tdisjoint_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue);
 
-		Pointer tdisjoint_tgeo_tgeo(Pointer temp1, Pointer temp2, boolean restr, boolean atvalue);
 
-		Pointer tdwithin_geo_tgeo(Pointer gs, Pointer temp, double dist, boolean restr, boolean atvalue);
 
-		Pointer tdwithin_tgeo_geo(Pointer temp, Pointer gs, double dist, boolean restr, boolean atvalue);
 
-		Pointer tdwithin_tgeo_tgeo(Pointer temp1, Pointer temp2, double dist, boolean restr, boolean atvalue);
 
-		Pointer tintersects_geo_tgeo(Pointer gs, Pointer temp, boolean restr, boolean atvalue);
 
-		Pointer tintersects_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue);
 
-		Pointer tintersects_tgeo_tgeo(Pointer temp1, Pointer temp2, boolean restr, boolean atvalue);
 
-		Pointer ttouches_geo_tgeo(Pointer gs, Pointer temp, boolean restr, boolean atvalue);
 
-		Pointer ttouches_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue);
 
-		Pointer ttouches_tgeo_tgeo(Pointer temp1, Pointer temp2, boolean restr, boolean atvalue);
 
 		Pointer tdistance_tgeo_geo(Pointer temp, Pointer gs);
 
@@ -14249,12 +14229,6 @@ public class functions {
 		return _result;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_at_geom(Pointer temp, Pointer gs, Pointer zspan) {
-		var _result = MeosLibrary.meos.tpoint_at_geom(temp, gs, zspan);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static Pointer tpoint_at_value(Pointer temp, Pointer gs) {
@@ -14263,12 +14237,6 @@ public class functions {
 		return _result;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tpoint_minus_geom(Pointer temp, Pointer gs, Pointer zspan) {
-		var _result = MeosLibrary.meos.tpoint_minus_geom(temp, gs, zspan);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static Pointer tpoint_minus_value(Pointer temp, Pointer gs) {
@@ -15055,131 +15023,23 @@ public class functions {
 		return _result;
 	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tcontains_geo_tgeo(Pointer gs, Pointer temp, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tcontains_geo_tgeo(gs, temp, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tcontains_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tcontains_tgeo_geo(temp, gs, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tcontains_tgeo_tgeo(Pointer temp1, Pointer temp2, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tcontains_tgeo_tgeo(temp1, temp2, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tcovers_geo_tgeo(Pointer gs, Pointer temp, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tcovers_geo_tgeo(gs, temp, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tcovers_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tcovers_tgeo_geo(temp, gs, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tcovers_tgeo_tgeo(Pointer temp1, Pointer temp2, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tcovers_tgeo_tgeo(temp1, temp2, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tdisjoint_geo_tgeo(Pointer gs, Pointer temp, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tdisjoint_geo_tgeo(gs, temp, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tdisjoint_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tdisjoint_tgeo_geo(temp, gs, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tdisjoint_tgeo_tgeo(Pointer temp1, Pointer temp2, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tdisjoint_tgeo_tgeo(temp1, temp2, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tdwithin_geo_tgeo(Pointer gs, Pointer temp, double dist, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tdwithin_geo_tgeo(gs, temp, dist, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tdwithin_tgeo_geo(Pointer temp, Pointer gs, double dist, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tdwithin_tgeo_geo(temp, gs, dist, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tdwithin_tgeo_tgeo(Pointer temp1, Pointer temp2, double dist, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tdwithin_tgeo_tgeo(temp1, temp2, dist, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tintersects_geo_tgeo(Pointer gs, Pointer temp, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tintersects_geo_tgeo(gs, temp, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tintersects_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tintersects_tgeo_geo(temp, gs, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer tintersects_tgeo_tgeo(Pointer temp1, Pointer temp2, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.tintersects_tgeo_tgeo(temp1, temp2, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer ttouches_geo_tgeo(Pointer gs, Pointer temp, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.ttouches_geo_tgeo(gs, temp, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer ttouches_tgeo_geo(Pointer temp, Pointer gs, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.ttouches_tgeo_geo(temp, gs, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
-	@SuppressWarnings("unused")
-	public static Pointer ttouches_tgeo_tgeo(Pointer temp1, Pointer temp2, boolean restr, boolean atvalue) {
-		var _result = MeosLibrary.meos.ttouches_tgeo_tgeo(temp1, temp2, restr, atvalue);
-		MeosErrorHandler.checkError();
-		return _result;
-	}
 
 	@SuppressWarnings("unused")
 	public static Pointer tdistance_tgeo_geo(Pointer temp, Pointer gs) {

--- a/jmeos-core/src/test/java/functions/NativeSignatureParityTest.java
+++ b/jmeos-core/src/test/java/functions/NativeSignatureParityTest.java
@@ -1,0 +1,74 @@
+package functions;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import utils.TestLogger;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Asserts that the hand-written FFI facade and the generated one declare the same call shape for
+ * every function they both bind.
+ *
+ * <p>{@code GeneratedFunctions} takes its parameter lists from the MEOS-API catalog, so it states
+ * what the library accepts. {@code functions.MeosLibrary} is maintained by hand, so it drifts
+ * whenever MEOS adds, drops or reorders a parameter. A declaration carrying a stale parameter list
+ * still resolves its symbol, so a check on names alone passes while the call disagrees with the
+ * function it reaches.
+ *
+ * <p>Comparing the two interfaces needs no further input: where they name the same function, they
+ * have to agree. The check covers the hand facade for as long as it exists and holds vacuously once
+ * the surface is generated alone, which is the intended end state.
+ */
+@DisplayName("Declared native signatures agree across the two facades")
+@ExtendWith(TestLogger.class)
+class NativeSignatureParityTest {
+
+    /** Parameter lists declared by the generated interfaces, keyed by function name. */
+    private static Map<String, List<Integer>> generatedArities() {
+        Map<String, List<Integer>> byName = new TreeMap<>();
+        for (Class<?> nested : GeneratedFunctions.class.getDeclaredClasses()) {
+            if (!nested.isInterface()) {
+                continue;
+            }
+            for (Method m : nested.getDeclaredMethods()) {
+                byName.computeIfAbsent(m.getName(), k -> new ArrayList<>())
+                        .add(m.getParameterCount());
+            }
+        }
+        return byName;
+    }
+
+    @Test
+    @DisplayName("a function bound by both facades takes the same number of arguments in each")
+    void sharedFunctionsAgreeOnArity() {
+        Map<String, List<Integer>> generated = generatedArities();
+        TreeMap<String, String> disagreements = new TreeMap<>();
+        int compared = 0;
+
+        for (Method hand : functions.MeosLibrary.class.getDeclaredMethods()) {
+            List<Integer> candidates = generated.get(hand.getName());
+            if (candidates == null) {
+                continue; // bound by the hand facade alone; the symbol check covers its existence
+            }
+            compared++;
+            int handArity = hand.getParameterCount();
+            if (!candidates.contains(handArity)) {
+                disagreements.put(hand.getName(),
+                        "hand takes " + handArity + ", generated takes " + candidates);
+            }
+        }
+
+        assertTrue(compared > 0, "no shared function was compared");
+        assertTrue(disagreements.isEmpty(),
+                disagreements.size() + " of " + compared + " shared functions disagree on how many "
+                        + "arguments the library takes: " + disagreements);
+    }
+}


### PR DESCRIPTION
The first of the two commits here is the spatial relationship declaration cleanup, which
the check also requires; review it first.

The hand-written facade `functions/functions.java` declares two functions with a
parameter list the library does not take:

    gbox_make(boolean hasz, double xmin … double zmax)          // libmeos takes 11
    text_cmp(Pointer txt1, Pointer txt2)                        // libmeos takes 3

`gbox_make` carries the `hasm` and `geodetic` flags and the m bounds; `text_cmp` takes a
collation oid. Both declarations resolve their symbol, so the native symbol parity check
passes — it compares names — while a call through them disagrees with the function it
reaches. Neither has a caller.

This restates the two declarations and their wrappers as the library declares them, and
adds `NativeSignatureParityTest`, which compares the parameter counts of the two facades
for every function they both bind and fails on any disagreement. It needs no catalog at
run time: the generated interfaces carry the catalog's parameter lists, so where both
facades name the same function they have to agree. The check holds vacuously once the
surface is generated alone, which is the intended end state.

`mvn clean test` against a libmeos built from MobilityDB master: 102 code generation
tests and 1760 FFI tests, no failures. The check compares 1648 shared functions.