### PR TITLE
Call the generated surface from the object layer

### DIFF
--- a/jmeos-core/src/main/java/types/basic/tbool/TBool.java
+++ b/jmeos-core/src/main/java/types/basic/tbool/TBool.java
@@ -48,7 +48,7 @@ public interface TBool {
      * @return A new :class:`TBool` object.
      */
     default TBool from_base_temporal(boolean value, Temporal base){
-        return (TBool) Factory.create_temporal(functions.tbool_from_base_temp(value, base.getInner()),customType,base.getTemporalType());
+        return (TBool) Factory.create_temporal(GeneratedFunctions.tbool_from_base_temp(value, base.getInner()),customType,base.getTemporalType());
     }
 
     /**
@@ -69,13 +69,13 @@ public interface TBool {
      */
     static Temporal from_base_time(boolean value, Time base){
         if (base instanceof tstzspanset){
-            return new TBoolSeq(functions.tboolseqset_from_base_tstzspanset(value,((tstzspanset) base).get_inner()));
+            return new TBoolSeq(GeneratedFunctions.tboolseqset_from_base_tstzspanset(value,((tstzspanset) base).get_inner()));
 
         } else if (base instanceof tstzset) {
-            return new TBoolSeq(functions.tboolseq_from_base_tstzset(value,((tstzset) base).get_inner()));
+            return new TBoolSeq(GeneratedFunctions.tboolseq_from_base_tstzset(value,((tstzset) base).get_inner()));
 
         } else if (base instanceof tstzspan) {
-            return new TBoolSeqSet(functions.tboolseq_from_base_tstzspan(value,((tstzspan) base).get_inner()));
+            return new TBoolSeqSet(GeneratedFunctions.tboolseq_from_base_tstzspan(value,((tstzspan) base).get_inner()));
         }
 
         return null;
@@ -93,7 +93,7 @@ public interface TBool {
             tbool_from_mfjson
 */
     default TBool from_mfjson(String mfjson){
-        Pointer result= functions.tbool_from_mfjson(mfjson);
+        Pointer result= GeneratedFunctions.tbool_from_mfjson(mfjson);
         return (TBool) Factory.create_temporal(result, getCustomType(), getTemporalType());
     }
 
@@ -109,7 +109,7 @@ public interface TBool {
      * @return Returns the string representation of "this"
      */
     default String to_string(){
-        return functions.tbool_out(getBoolInner());
+        return GeneratedFunctions.tbool_out(getBoolInner());
     }
 
     /**
@@ -120,7 +120,7 @@ public interface TBool {
      * @return Returns the string representation of "this"
      */
     default String as_wkt(){
-        return functions.tbool_out(getBoolInner());
+        return GeneratedFunctions.tbool_out(getBoolInner());
     }
 
 
@@ -136,7 +136,7 @@ public interface TBool {
         Runtime runtime = Runtime.getSystemRuntime();
         // Allocate memory for an integer (4 bytes) but do not set a value
         Pointer intPointer = Memory.allocate(runtime, 4);
-        Pointer resPointer = functions.tbool_values(this.getBoolInner(), intPointer);
+        Pointer resPointer = GeneratedFunctions.tbool_values(this.getBoolInner(), intPointer);
         StringBuilder sb = null;
         sb.append("{");
         int count= intPointer.getInt(Integer.BYTES);
@@ -166,17 +166,17 @@ public interface TBool {
 
             @Override
             public Pointer createStringInner(String str) {
-                return functions.tbool_in(str);
+                return GeneratedFunctions.tbool_in(str);
             }
 
             @Override
             public Boolean start_element() throws ParseException {
-                return functions.tbool_start_value(this.get_inner());
+                return GeneratedFunctions.tbool_start_value(this.get_inner());
             }
 
             @Override
             public Boolean end_element() throws ParseException {
-                return functions.tbool_end_value(this.get_inner());
+                return GeneratedFunctions.tbool_end_value(this.get_inner());
             }
         };
     }
@@ -189,7 +189,7 @@ public interface TBool {
      * @return Returns the starting value of "this".
      */
     default boolean start_value(){
-        return functions.tbool_start_value(getBoolInner());
+        return GeneratedFunctions.tbool_start_value(getBoolInner());
     }
 
     /**
@@ -200,7 +200,7 @@ public interface TBool {
      * @return Returns the ending value of "this".
      */
     default boolean end_value(){
-        return functions.tbool_end_value(getBoolInner());
+        return GeneratedFunctions.tbool_end_value(getBoolInner());
     }
 
 /**
@@ -237,7 +237,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      * @return True if "this" is always equal to "value", False otherwise.
      */
     default boolean always_eq(boolean value){
-        int result= functions.always_eq_tbool_bool(getBoolInner(), value);
+        int result= GeneratedFunctions.always_eq_tbool_bool(getBoolInner(), value);
         return result > 0;
     }
 
@@ -253,7 +253,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      * @return True if "this" is ever equal to "value", False otherwise.
      */
     default boolean ever_eq(boolean value){
-        int result= functions.ever_eq_tbool_bool(getBoolInner(), value);
+        int result= GeneratedFunctions.ever_eq_tbool_bool(getBoolInner(), value);
         return result > 0;
     }
 
@@ -290,7 +290,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      * @return A {@link TBool} with the result of the temporal equality relation.
      */
     default TBool temporal_equal(boolean other){
-        return (TBool) Factory.create_temporal(functions.teq_tbool_bool(getBoolInner(),other), getCustomType(),getTemporalType());
+        return (TBool) Factory.create_temporal(GeneratedFunctions.teq_tbool_bool(getBoolInner(),other), getCustomType(),getTemporalType());
     }
 
 
@@ -310,7 +310,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      * @return A {@link TBool} with the result of the temporal inequality relation.
      */
     default TBool temporal_not_equal(boolean other){
-        return (TBool) Factory.create_temporal(functions.tne_tbool_bool(getBoolInner(),other), getCustomType(),getTemporalType());
+        return (TBool) Factory.create_temporal(GeneratedFunctions.tne_tbool_bool(getBoolInner(),other), getCustomType(),getTemporalType());
     }
 
 
@@ -334,7 +334,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      * @return A new temporal boolean.
      */
     default TBool at(boolean other){
-        return (TBool) Factory.create_temporal(functions.tbool_at_value(getBoolInner(),other), getCustomType(),getTemporalType());
+        return (TBool) Factory.create_temporal(GeneratedFunctions.tbool_at_value(getBoolInner(),other), getCustomType(),getTemporalType());
     }
 
 
@@ -357,7 +357,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      * @return A new temporal boolean.
      */
     default TBool minus(boolean other){
-        return (TBool) Factory.create_temporal(functions.tbool_minus_value(getBoolInner(),other), getCustomType(),getTemporalType());
+        return (TBool) Factory.create_temporal(GeneratedFunctions.tbool_minus_value(getBoolInner(),other), getCustomType(),getTemporalType());
     }
 
     /* ------------------------- Boolean Operations ---------------------------- */
@@ -377,7 +377,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      *      *             "other".
      */
     default TBool temporal_and(TBool other){
-        return (TBool) Factory.create_temporal(functions.tand_tbool_tbool(getBoolInner(),other.getBoolInner()), getCustomType(),getTemporalType());
+        return (TBool) Factory.create_temporal(GeneratedFunctions.tand_tbool_tbool(getBoolInner(),other.getBoolInner()), getCustomType(),getTemporalType());
     }
 
 /**
@@ -411,7 +411,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      *      *             "other".
      */
     default TBool temporal_and_bool(boolean other){
-        return (TBool) Factory.create_temporal(functions.tand_tbool_bool(getBoolInner(),other), getCustomType(),getTemporalType());
+        return (TBool) Factory.create_temporal(GeneratedFunctions.tand_tbool_bool(getBoolInner(),other), getCustomType(),getTemporalType());
     }
 
     /**
@@ -428,7 +428,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      *      *             "other".
      */
     default TBool temporal_or(TBool other){
-        return (TBool) Factory.create_temporal(functions.tor_tbool_tbool(getBoolInner(),other.getBoolInner()), getCustomType(),getTemporalType());
+        return (TBool) Factory.create_temporal(GeneratedFunctions.tor_tbool_tbool(getBoolInner(),other.getBoolInner()), getCustomType(),getTemporalType());
     }
 
     /**
@@ -462,7 +462,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      *      *             "other".
      */
     default TBool temporal_or_bool(boolean other){
-        return (TBool) Factory.create_temporal(functions.tor_tbool_bool(getBoolInner(),other), getCustomType(),getTemporalType());
+        return (TBool) Factory.create_temporal(GeneratedFunctions.tor_tbool_bool(getBoolInner(),other), getCustomType(),getTemporalType());
     }
 
 
@@ -475,7 +475,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      * @return A {@link TBool} with the temporal negation of "this".
      */
     default TBool temporal_not(){
-        return (TBool) Factory.create_temporal(functions.tnot_tbool(getBoolInner()),getCustomType(),getTemporalType());
+        return (TBool) Factory.create_temporal(GeneratedFunctions.tnot_tbool(getBoolInner()),getCustomType(),getTemporalType());
     }
 
 
@@ -488,7 +488,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      * @return A {@link tstzspan} with the periods where "this" is True.
      */
     default tstzspanset when_true(){
-        return new tstzspanset(functions.tbool_when_true(getBoolInner()));
+        return new tstzspanset(GeneratedFunctions.tbool_when_true(getBoolInner()));
     }
 
 
@@ -501,7 +501,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      * @return A {@link tstzspan} with the periods where "this" is False.
      */
     default tstzspanset when_false(){
-        return new tstzspanset(functions.tbool_when_true(functions.tnot_tbool(getBoolInner())));
+        return new tstzspanset(GeneratedFunctions.tbool_when_true(GeneratedFunctions.tnot_tbool(getBoolInner())));
     }
 /**
         Returns the temporal negation of `this`.
@@ -536,7 +536,7 @@ default boolean value_at_timestamp(LocalDateTime ts){
      *      tbool_out
      */
     default String asString() {
-        return functions.tbool_out(getBoolInner());
+        return GeneratedFunctions.tbool_out(getBoolInner());
     }
 	
 }

--- a/jmeos-core/src/main/java/types/basic/tbool/TBoolInst.java
+++ b/jmeos-core/src/main/java/types/basic/tbool/TBoolInst.java
@@ -3,6 +3,7 @@ package types.basic.tbool;
 import types.temporal.TInstant;
 import jnr.ffi.Pointer;
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.temporal.TemporalType;
 
 
@@ -37,7 +38,7 @@ public class TBoolInst extends TInstant<Boolean> implements TBool {
 	 */
 	public TBoolInst(String value) {
 		super(value);
-		this.inner = functions.tbool_in(value);
+		this.inner = GeneratedFunctions.tbool_in(value);
 	}
 
 	/**
@@ -75,7 +76,7 @@ public class TBoolInst extends TInstant<Boolean> implements TBool {
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.tbool_in(str);
+		return GeneratedFunctions.tbool_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tbool/TBoolSeq.java
+++ b/jmeos-core/src/main/java/types/basic/tbool/TBoolSeq.java
@@ -1,6 +1,7 @@
 package types.basic.tbool;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import jnr.ffi.Pointer;
 import types.temporal.TSequence;
 import types.temporal.TemporalType;
@@ -49,7 +50,7 @@ public class TBoolSeq extends TSequence<Boolean> implements TBool {
 	 */
 	public TBoolSeq(String value, int interpolation) {
 		super(value);
-		this.inner = functions.tbool_in(value);
+		this.inner = GeneratedFunctions.tbool_in(value);
 	}
 
 
@@ -64,7 +65,7 @@ public class TBoolSeq extends TSequence<Boolean> implements TBool {
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.tbool_in(str);
+		return GeneratedFunctions.tbool_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tbool/TBoolSeqSet.java
+++ b/jmeos-core/src/main/java/types/basic/tbool/TBoolSeqSet.java
@@ -1,6 +1,7 @@
 package types.basic.tbool;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import jnr.ffi.Pointer;
 import types.temporal.TSequenceSet;
 import types.temporal.TemporalType;
@@ -35,14 +36,14 @@ public class TBoolSeqSet extends TSequenceSet<Boolean> implements TBool{
 	 */
 	public TBoolSeqSet(String value) {
 		super(value);
-		this.inner = functions.tbool_in(value);
+		this.inner = GeneratedFunctions.tbool_in(value);
 	}
 
 
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.tbool_in(str);
+		return GeneratedFunctions.tbool_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tfloat/TFloat.java
+++ b/jmeos-core/src/main/java/types/basic/tfloat/TFloat.java
@@ -52,7 +52,7 @@ public interface TFloat extends TNumber {
 	 * @return A new {@link Float} object.
 	 */
 	default TFloat from_base_temporal(float value, Temporal base, TInterpolation interp){
-		return (TFloat) Factory.create_temporal(functions.tfloat_from_base_temp(value,base.getInner()),getCustomType(),getTemporalType());
+		return (TFloat) Factory.create_temporal(GeneratedFunctions.tfloat_from_base_temp(value,base.getInner()),getCustomType(),getTemporalType());
 	}
 
 	/**
@@ -75,11 +75,11 @@ public interface TFloat extends TNumber {
 	 */
 	static TFloat from_base_time(float value, Time base, TInterpolation interpolation){
 		if (base instanceof tstzspanset) {
-			return new TFloatSeq(functions.tfloatseqset_from_base_tstzspanset((double) value, ((tstzspanset) base).get_inner(), interpolation.getValue()));
+			return new TFloatSeq(GeneratedFunctions.tfloatseqset_from_base_tstzspanset((double) value, ((tstzspanset) base).get_inner(), interpolation.getValue()));
 		} else if (base instanceof tstzset) {
-			return new TFloatSeq(functions.tfloatseq_from_base_tstzset(value, ((tstzset) base).get_inner()));
+			return new TFloatSeq(GeneratedFunctions.tfloatseq_from_base_tstzset(value, ((tstzset) base).get_inner()));
 		} else if (base instanceof tstzspan) {
-			return new TFloatSeqSet(functions.tfloatseq_from_base_tstzspan(value, ((tstzspan) base).get_inner(), interpolation.getValue()));
+			return new TFloatSeqSet(GeneratedFunctions.tfloatseq_from_base_tstzspan(value, ((tstzspan) base).get_inner(), interpolation.getValue()));
 		}
 		throw new UnsupportedOperationException("Operation not supported with type " + base.getClass());
 	}
@@ -97,7 +97,7 @@ public interface TFloat extends TNumber {
             tfloat_from_mfjson
 */
 	default TFloat from_mfjson(String mfjson) {
-			Pointer resPointer= functions.tfloat_from_mfjson(mfjson);
+			Pointer resPointer= GeneratedFunctions.tfloat_from_mfjson(mfjson);
 			return (TFloat) Factory.create_temporal(resPointer, getCustomType(), getTemporalType());
 	}
 		
@@ -116,7 +116,7 @@ public interface TFloat extends TNumber {
 	 * @return A string representation of "this".
 	 */
 	default String to_string(int max_decimals){
-		return functions.tfloat_out(getNumberInner(), max_decimals);
+		return GeneratedFunctions.tfloat_out(getNumberInner(), max_decimals);
 	}
 
 	/**
@@ -129,7 +129,7 @@ public interface TFloat extends TNumber {
 	 * @return A string representation of "this".
 	 */
 	default String as_wkt(int max_decimals){
-		return functions.tfloat_out(getNumberInner(),max_decimals);
+		return GeneratedFunctions.tfloat_out(getNumberInner(),max_decimals);
 	}
 
 	/* ------------------------- Conversions ---------------------------------- */
@@ -149,7 +149,7 @@ public interface TFloat extends TNumber {
 	  @return A new temporal integer.
 	 */
 	default TInt to_tint(){
-		return (TInt) Factory.create_temporal(functions.tfloat_to_tint(getNumberInner()),"Integer",getTemporalType());
+		return (TInt) Factory.create_temporal(GeneratedFunctions.tfloat_to_tint(getNumberInner()),"Integer",getTemporalType());
 	}
 
 
@@ -166,7 +166,7 @@ public interface TFloat extends TNumber {
 	 * @return An {@link FloatSpan} with the value span of "this".
 	 */
 	default FloatSpan to_floatrange(){
-		return new FloatSpan(functions.tnumber_to_span(getNumberInner()));
+		return new FloatSpan(GeneratedFunctions.tnumber_to_span(getNumberInner()));
 	}
 
 
@@ -197,7 +197,7 @@ public interface TFloat extends TNumber {
 	 * @return
 	 */
 	default FloatSpanSet value_spans(){
-		return new FloatSpanSet(functions.tnumber_valuespans(getNumberInner()));
+		return new FloatSpanSet(GeneratedFunctions.tnumber_valuespans(getNumberInner()));
 	}
 
 	/**
@@ -210,7 +210,7 @@ public interface TFloat extends TNumber {
 	 * @return A {@link Float} with the start value.
 	 */
 	default float start_value(){
-		return (float) functions.tfloat_start_value(getNumberInner());
+		return (float) GeneratedFunctions.tfloat_start_value(getNumberInner());
 	}
 
 	/**
@@ -222,7 +222,7 @@ public interface TFloat extends TNumber {
 	 * @return A {@link Float} with the end value.
 	 */
 	default float end_value(){
-		return (float) functions.tfloat_end_value(getNumberInner());
+		return (float) GeneratedFunctions.tfloat_end_value(getNumberInner());
 	}
 /**
         Returns the set of values of `self`.
@@ -240,7 +240,7 @@ public interface TFloat extends TNumber {
 		Runtime runtime = Runtime.getSystemRuntime();
 		// Allocate memory for an integer (4 bytes) but do not set a value
 		Pointer intPointer = Memory.allocate(runtime, 4);
-		Pointer resPointer = functions.tfloat_values(this.getNumberInner(), intPointer);
+		Pointer resPointer = GeneratedFunctions.tfloat_values(this.getNumberInner(), intPointer);
 		StringBuilder sb = null;
 		sb.append("{");
 		int count= intPointer.getInt(Integer.BYTES);
@@ -266,7 +266,7 @@ public interface TFloat extends TNumber {
 	 * @return A {@link Float} with the minimum value.
 	 */
 	default float min_value(){
-		return (float) functions.tfloat_min_value(getNumberInner());
+		return (float) GeneratedFunctions.tfloat_min_value(getNumberInner());
 	}
 
 	/**
@@ -279,7 +279,7 @@ public interface TFloat extends TNumber {
 	 * @return A {@link Float} with the maximum value.
 	 */
 	default float max_value(){
-		return (float) functions.tfloat_max_value(getNumberInner());
+		return (float) GeneratedFunctions.tfloat_max_value(getNumberInner());
 	}
 
 
@@ -298,7 +298,7 @@ public interface TFloat extends TNumber {
 	 * 	 *             "False" otherwise.
 	 */
 	default boolean always_equal(float value){
-		return functions.always_eq_tfloat_float(getNumberInner(),value) > 0;
+		return GeneratedFunctions.always_eq_tfloat_float(getNumberInner(),value) > 0;
 	}
 
 	/**
@@ -313,7 +313,7 @@ public interface TFloat extends TNumber {
 	 * 	 *             "False" otherwise.
 	 */
 	default boolean always_not_equal(float value){
-		return (functions.always_ne_tfloat_float(getNumberInner(),value)) > 0;
+		return (GeneratedFunctions.always_ne_tfloat_float(getNumberInner(),value)) > 0;
 	}
 
 
@@ -329,7 +329,7 @@ public interface TFloat extends TNumber {
 	 * 	 *             "False" otherwise.
 	 */
 	default boolean always_less(float value){
-		return functions.always_lt_tfloat_float(getNumberInner(),value) > 0;
+		return GeneratedFunctions.always_lt_tfloat_float(getNumberInner(),value) > 0;
 	}
 
 
@@ -346,7 +346,7 @@ public interface TFloat extends TNumber {
 	 * 	 *             "value", "False" otherwise.
 	 */
 	default boolean always_less_or_equal(float value){
-		return functions.always_le_tfloat_float(getNumberInner(),value) > 0;
+		return GeneratedFunctions.always_le_tfloat_float(getNumberInner(),value) > 0;
 	}
 
 	/**
@@ -362,7 +362,7 @@ public interface TFloat extends TNumber {
 	 * 	 *             "value", "False" otherwise.
 	 */
 	default boolean always_greater_or_equal(float value){
-		return (functions.always_ge_tfloat_float(getNumberInner(),value)) > 0;
+		return (GeneratedFunctions.always_ge_tfloat_float(getNumberInner(),value)) > 0;
 	}
 
 	/**
@@ -377,7 +377,7 @@ public interface TFloat extends TNumber {
 	 * 	 *            " `False`" otherwise.
 	 */
 	default boolean always_greater(float value){
-		return (functions.always_gt_tfloat_float(getNumberInner(),value)) > 0;
+		return (GeneratedFunctions.always_gt_tfloat_float(getNumberInner(),value)) > 0;
 	}
 
 	/**
@@ -392,7 +392,7 @@ public interface TFloat extends TNumber {
 	 * 	 *             "False" otherwise.
 	 */
 	default boolean ever_less(float value){
-		return functions.ever_lt_tfloat_float(getNumberInner(),value) > 0;
+		return GeneratedFunctions.ever_lt_tfloat_float(getNumberInner(),value) > 0;
 	}
 
 
@@ -409,7 +409,7 @@ public interface TFloat extends TNumber {
 	 * 	 *             "value", "False" otherwise.
 	 */
 	default boolean ever_less_or_equal(float value){
-		return functions.ever_le_tfloat_float(getNumberInner(),value) > 0;
+		return GeneratedFunctions.ever_le_tfloat_float(getNumberInner(),value) > 0;
 	}
 
 
@@ -425,7 +425,7 @@ public interface TFloat extends TNumber {
 	 * 	 *             otherwise.
 	 */
 	default boolean ever_equal(float value){
-		return functions.ever_eq_tfloat_float(getNumberInner(),value) > 0;
+		return GeneratedFunctions.ever_eq_tfloat_float(getNumberInner(),value) > 0;
 	}
 
 	/**
@@ -440,7 +440,7 @@ public interface TFloat extends TNumber {
 	 * 	 *             "False" otherwise.
 	 */
 	default boolean ever_not_equal(float value){
-		return (functions.ever_ne_tfloat_float(getNumberInner(),value)) > 0;
+		return (GeneratedFunctions.ever_ne_tfloat_float(getNumberInner(),value)) > 0;
 	}
 
 	/**
@@ -457,7 +457,7 @@ public interface TFloat extends TNumber {
 	 * 	 *             "value", "False" otherwise.
 	 */
 	default boolean ever_greater_or_equal(float value){
-		return (functions.ever_ge_tfloat_float(getNumberInner(),value)) > 0;
+		return (GeneratedFunctions.ever_ge_tfloat_float(getNumberInner(),value)) > 0;
 	}
 
 	/**
@@ -472,7 +472,7 @@ public interface TFloat extends TNumber {
 	 * 	 *             "False" otherwise.
 	 */
 	default boolean ever_greater(float value){
-		return  (functions.ever_gt_tfloat_float(getNumberInner(),value)) > 0;
+		return  (GeneratedFunctions.ever_gt_tfloat_float(getNumberInner(),value)) > 0;
 	}
 
 	/**
@@ -587,7 +587,7 @@ public interface TFloat extends TNumber {
 	 */
 	default Temporal temporal_equal(Number other){
 		if ((other instanceof Float) || (other instanceof Integer)){
-			return Factory.create_temporal(functions.teq_tfloat_float(getNumberInner(),(float) other), getCustomType(),getTemporalType());
+			return Factory.create_temporal(GeneratedFunctions.teq_tfloat_float(getNumberInner(),(float) other), getCustomType(),getTemporalType());
 		}
 		else{
 			throw new UnsupportedOperationException("Parameter not supported");
@@ -611,7 +611,7 @@ public interface TFloat extends TNumber {
 	 */
 	default Temporal temporal_not_equal(Number other){
 		if ((other instanceof Float) || (other instanceof Integer)){
-			return Factory.create_temporal(functions.tne_tfloat_float(getNumberInner(),(float) other), getCustomType(),getTemporalType());
+			return Factory.create_temporal(GeneratedFunctions.tne_tfloat_float(getNumberInner(),(float) other), getCustomType(),getTemporalType());
 		}
 		else{
 			throw new UnsupportedOperationException("Parameter not supported");
@@ -636,7 +636,7 @@ public interface TFloat extends TNumber {
 	 */
 	default Temporal temporal_less(Number other){
 		if ((other instanceof Float) || (other instanceof Integer)){
-			return Factory.create_temporal(functions.tlt_tfloat_float(getNumberInner(),(float) other), getCustomType(),getTemporalType());
+			return Factory.create_temporal(GeneratedFunctions.tlt_tfloat_float(getNumberInner(),(float) other), getCustomType(),getTemporalType());
 		}
 		else{
 			throw new UnsupportedOperationException("Parameter not supported");
@@ -661,7 +661,7 @@ public interface TFloat extends TNumber {
 	 */
 	default Temporal temporal_less_or_equal(Number other){
 		if ((other instanceof Float) || (other instanceof Integer)){
-			return Factory.create_temporal(functions.tle_tfloat_float(getNumberInner(),(float) other), getCustomType(),getTemporalType());
+			return Factory.create_temporal(GeneratedFunctions.tle_tfloat_float(getNumberInner(),(float) other), getCustomType(),getTemporalType());
 		}
 		else{
 			throw new UnsupportedOperationException("Parameter not supported");
@@ -685,7 +685,7 @@ public interface TFloat extends TNumber {
 	 */
 	default Temporal temporal_greater_or_equal(Number other){
 		if ((other instanceof Float) || (other instanceof Integer)){
-			return Factory.create_temporal(functions.tge_tfloat_float(getNumberInner(),(float) other), getCustomType(),getTemporalType());
+			return Factory.create_temporal(GeneratedFunctions.tge_tfloat_float(getNumberInner(),(float) other), getCustomType(),getTemporalType());
 		}
 		else{
 			throw new UnsupportedOperationException("Parameter not supported");
@@ -708,7 +708,7 @@ public interface TFloat extends TNumber {
 	 */
 	default Temporal temporal_greater(Number other){
 		if ((other instanceof Float) || (other instanceof Integer)){
-			return Factory.create_temporal(functions.tgt_tfloat_float(getNumberInner(),(float) other), getCustomType(),getTemporalType());
+			return Factory.create_temporal(GeneratedFunctions.tgt_tfloat_float(getNumberInner(),(float) other), getCustomType(),getTemporalType());
 		}
 		else{
 			throw new UnsupportedOperationException("Parameter not supported");
@@ -745,7 +745,7 @@ public interface TFloat extends TNumber {
             temporal_derivative
 */
 	default TFloat derivative(){
-		return (TFloat) Factory.create_temporal(functions.temporal_derivative(this.getNumberInner()), getCustomType(), getTemporalType());
+		return (TFloat) Factory.create_temporal(GeneratedFunctions.temporal_derivative(this.getNumberInner()), getCustomType(), getTemporalType());
 	}
 
 
@@ -763,7 +763,7 @@ public interface TFloat extends TNumber {
 	 * @return A {@link TFloat} instance.
 	 */
 	default Temporal to_degrees(boolean normalize){
-		return Factory.create_temporal(functions.tfloat_degrees(getNumberInner(),normalize), getCustomType(),getTemporalType());
+		return Factory.create_temporal(GeneratedFunctions.tfloat_degrees(getNumberInner(),normalize), getCustomType(),getTemporalType());
 
 	}
 
@@ -777,7 +777,7 @@ public interface TFloat extends TNumber {
 	 * @return A new {@link TFloat} instance.
 	 */
 	default Temporal to_radians(){
-		return Factory.create_temporal(functions.tfloat_radians(getNumberInner()), getCustomType(),getTemporalType());
+		return Factory.create_temporal(GeneratedFunctions.tfloat_radians(getNumberInner()), getCustomType(),getTemporalType());
 
 	}
 
@@ -793,6 +793,6 @@ public interface TFloat extends TNumber {
 	 * @return A new {@link TFloat} instance.
 	 */
 	default Temporal round(int max_decimals){
-		return Factory.create_temporal(functions.temporal_round(getNumberInner(),max_decimals), getCustomType(),getTemporalType());
+		return Factory.create_temporal(GeneratedFunctions.temporal_round(getNumberInner(),max_decimals), getCustomType(),getTemporalType());
 	}
 }

--- a/jmeos-core/src/main/java/types/basic/tfloat/TFloatInst.java
+++ b/jmeos-core/src/main/java/types/basic/tfloat/TFloatInst.java
@@ -1,6 +1,7 @@
 package types.basic.tfloat;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import jnr.ffi.Pointer;
 import types.temporal.TInstant;
 import types.temporal.TemporalType;
@@ -36,14 +37,14 @@ public class TFloatInst extends TInstant<Float> implements TFloat{
 	 */
 	public TFloatInst(String value) {
 		super(value);
-		this.inner = functions.tfloat_in(value);
+		this.inner = GeneratedFunctions.tfloat_in(value);
 	}
 
 
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.tfloat_in(str);
+		return GeneratedFunctions.tfloat_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tfloat/TFloatSeq.java
+++ b/jmeos-core/src/main/java/types/basic/tfloat/TFloatSeq.java
@@ -1,6 +1,7 @@
 package types.basic.tfloat;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import jnr.ffi.Pointer;
 import types.temporal.TSequence;
 import types.temporal.TemporalType;
@@ -39,7 +40,7 @@ public class TFloatSeq extends TSequence<Float> implements TFloat {
 	 */
 	public TFloatSeq(String value){
 		super(value);
-		this.inner = functions.tfloat_in(value);
+		this.inner = GeneratedFunctions.tfloat_in(value);
 	}
 
 
@@ -66,7 +67,7 @@ public class TFloatSeq extends TSequence<Float> implements TFloat {
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.tfloat_in(str);
+		return GeneratedFunctions.tfloat_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tfloat/TFloatSeqSet.java
+++ b/jmeos-core/src/main/java/types/basic/tfloat/TFloatSeqSet.java
@@ -1,6 +1,7 @@
 package types.basic.tfloat;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.temporal.TSequenceSet;
 import jnr.ffi.Pointer;
 import types.temporal.TemporalType;
@@ -38,14 +39,14 @@ public class TFloatSeqSet extends TSequenceSet<Float> implements TFloat {
 	 */
 	public TFloatSeqSet(String value)  {
 		super(value);
-		this.inner = functions.tfloat_in(value);
+		this.inner = GeneratedFunctions.tfloat_in(value);
 	}
 
 
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.tfloat_in(str);
+		return GeneratedFunctions.tfloat_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tint/TInt.java
+++ b/jmeos-core/src/main/java/types/basic/tint/TInt.java
@@ -51,7 +51,7 @@ public interface TInt extends TNumber {
 	 * @return A new {@link Float} object.
 	 */
 	default TInt from_base_temporal(int value, Temporal base, TInterpolation interp){
-		return (TInt) Factory.create_temporal(functions.tint_from_base_temp(value,base.getInner()),getCustomType(),getTemporalType());
+		return (TInt) Factory.create_temporal(GeneratedFunctions.tint_from_base_temp(value,base.getInner()),getCustomType(),getTemporalType());
 	}
 
 	/**
@@ -74,15 +74,15 @@ public interface TInt extends TNumber {
 	 */
 	static TInt from_base_time(int value, Object base, TInterpolation interpolation) throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
 		if (base instanceof LocalDateTime){
-			return new TIntInst(functions.tintinst_make(value, ConversionUtils.datetimeToTimestampTz((LocalDateTime) base)));
+			return new TIntInst(GeneratedFunctions.tintinst_make(value, ConversionUtils.datetimeToTimestampTz((LocalDateTime) base)));
 		}
 		if (base instanceof tstzspanset) {
-			return new TIntSeqSet(functions.tintseqset_from_base_tstzspanset(value, ((tstzspanset) base).get_inner()));
+			return new TIntSeqSet(GeneratedFunctions.tintseqset_from_base_tstzspanset(value, ((tstzspanset) base).get_inner()));
 		} else if (base instanceof tstzset) {
-			return new TIntSeq(functions.tintseq_from_base_tstzset(value, ((tstzset) base).get_inner()));
+			return new TIntSeq(GeneratedFunctions.tintseq_from_base_tstzset(value, ((tstzset) base).get_inner()));
 		} else if (base instanceof tstzspan) {
 			tstzspanset ss= new tstzspanset(((tstzspan) base).to_spanset(tstzspanset.class).get_inner());
-			return new TIntSeq(functions.tintseqset_from_base_tstzspanset(value, ss.get_inner()));
+			return new TIntSeq(GeneratedFunctions.tintseqset_from_base_tstzspanset(value, ss.get_inner()));
 		}
 		throw new UnsupportedOperationException("Operation not supported with type " + base.getClass());
 	}
@@ -101,7 +101,7 @@ public interface TInt extends TNumber {
 */
 
 	default TInt from_mfjson(String mfjson){
-		Pointer result= functions.tint_from_mfjson(mfjson);
+		Pointer result= GeneratedFunctions.tint_from_mfjson(mfjson);
 		return (TInt) Factory.create_temporal(result, getCustomType(), getTemporalType());
 	}
 
@@ -118,7 +118,7 @@ public interface TInt extends TNumber {
 	 * @return A string representation of "this".
 	 */
 	default String to_string(){
-		return functions.tint_out(getNumberInner());
+		return GeneratedFunctions.tint_out(getNumberInner());
 	}
 
 	/**
@@ -130,7 +130,7 @@ public interface TInt extends TNumber {
 	 * @return A string representation of "this".
 	 */
 	default String as_wkt(){
-		return functions.tint_out(getNumberInner());
+		return GeneratedFunctions.tint_out(getNumberInner());
 	}
 
 
@@ -151,7 +151,7 @@ public interface TInt extends TNumber {
 	 * @return A new temporal float.
 	 */
 	default TFloat to_tfloat(){
-		return (TFloat) Factory.create_temporal(functions.tint_to_tfloat(getNumberInner()),"Float",getTemporalType());
+		return (TFloat) Factory.create_temporal(GeneratedFunctions.tint_to_tfloat(getNumberInner()),"Float",getTemporalType());
 	}
 
 
@@ -168,7 +168,7 @@ public interface TInt extends TNumber {
 	 * @return An {@link IntSpan} with the value span of "this".
 	 */
 	default IntSpan to_intspan(){
-		return new IntSpan(functions.tnumber_to_span(getNumberInner()));
+		return new IntSpan(GeneratedFunctions.tnumber_to_span(getNumberInner()));
 	}
 
 
@@ -198,7 +198,7 @@ public interface TInt extends TNumber {
 	 * @return A {@link IntSpanSet} with the value spans of "this".
 	 */
 	default IntSpanSet value_spans(){
-		return new IntSpanSet(functions.tnumber_valuespans(getNumberInner()));
+		return new IntSpanSet(GeneratedFunctions.tnumber_valuespans(getNumberInner()));
 	}
 
 	/**
@@ -211,7 +211,7 @@ public interface TInt extends TNumber {
 	 * @return A {@link Integer} with the start value.
 	 */
 	default int start_value(){
-		return functions.tint_start_value(getNumberInner());
+		return GeneratedFunctions.tint_start_value(getNumberInner());
 	}
 
 	/**
@@ -223,7 +223,7 @@ public interface TInt extends TNumber {
 	 * @return A {@link Integer} with the end value.
 	 */
 	default int end_value(){
-		return functions.tint_end_value(getNumberInner());
+		return GeneratedFunctions.tint_end_value(getNumberInner());
 	}
 
 /**
@@ -241,7 +241,7 @@ public interface TInt extends TNumber {
 		Runtime runtime = Runtime.getSystemRuntime();
 		// Allocate memory for an integer (4 bytes) but do not set a value
 		Pointer intPointer = Memory.allocate(runtime, 4);
-		Pointer res= functions.tint_values(this.getNumberInner(), intPointer);
+		Pointer res= GeneratedFunctions.tint_values(this.getNumberInner(), intPointer);
 		int count= intPointer.getInt(Integer.BYTES);
 		StringBuilder sb = new StringBuilder();
 		sb.append("{");
@@ -266,7 +266,7 @@ public interface TInt extends TNumber {
 	 * @return A {@link Integer} with the minimum value.
 	 */
 	default int min_value(){
-		return functions.tint_min_value(getNumberInner());
+		return GeneratedFunctions.tint_min_value(getNumberInner());
 	}
 
 	/**
@@ -279,7 +279,7 @@ public interface TInt extends TNumber {
 	 * @return A {@link Integer} with the maximum value.
 	 */
 	default int max_value(){
-		return functions.tint_max_value(getNumberInner());
+		return GeneratedFunctions.tint_max_value(getNumberInner());
 	}
 
 /*
@@ -316,7 +316,7 @@ public interface TInt extends TNumber {
 	 * 	 *             "False" otherwise.
 	 */
 	default boolean always_equal(int value){
-		return functions.always_eq_tint_int(getNumberInner(),value) > 0;
+		return GeneratedFunctions.always_eq_tint_int(getNumberInner(),value) > 0;
 	}
 
 	/**
@@ -331,7 +331,7 @@ public interface TInt extends TNumber {
 	 * 	 *             "False" otherwise.
 	 */
 	default boolean always_not_equal(int value){
-		return (functions.ever_ne_tint_int(getNumberInner(),value)) > 0;
+		return (GeneratedFunctions.ever_ne_tint_int(getNumberInner(),value)) > 0;
 	}
 
 
@@ -347,7 +347,7 @@ public interface TInt extends TNumber {
 	 * 	 *             "False" otherwise.
 	 */
 	default boolean always_less(int value){
-		return functions.always_lt_tint_int(getNumberInner(),value) > 0;
+		return GeneratedFunctions.always_lt_tint_int(getNumberInner(),value) > 0;
 	}
 
 
@@ -364,7 +364,7 @@ public interface TInt extends TNumber {
 	 * 	 *             "value", "False" otherwise.
 	 */
 	default boolean always_less_or_equal(int value){
-		return functions.always_le_tint_int(getNumberInner(),value) > 0;
+		return GeneratedFunctions.always_le_tint_int(getNumberInner(),value) > 0;
 	}
 
 	/**
@@ -380,7 +380,7 @@ public interface TInt extends TNumber {
 	 * 	 *             "value", "False" otherwise.
 	 */
 	default boolean always_greater_or_equal(int value){
-		return (functions.ever_lt_tint_int(getNumberInner(),value)) > 0;
+		return (GeneratedFunctions.ever_lt_tint_int(getNumberInner(),value)) > 0;
 	}
 
 	/**
@@ -395,7 +395,7 @@ public interface TInt extends TNumber {
 	 * 	 *            " `False`" otherwise.
 	 */
 	default boolean always_greater(int value){
-		return (functions.always_gt_tint_int(getNumberInner(),value)) > 0;
+		return (GeneratedFunctions.always_gt_tint_int(getNumberInner(),value)) > 0;
 	}
 
 	/**
@@ -410,7 +410,7 @@ public interface TInt extends TNumber {
 	 * 	 *             "False" otherwise.
 	 */
 	default boolean ever_less(int value){
-		return functions.ever_lt_tint_int(getNumberInner(),value) > 0;
+		return GeneratedFunctions.ever_lt_tint_int(getNumberInner(),value) > 0;
 	}
 
 
@@ -427,7 +427,7 @@ public interface TInt extends TNumber {
 	 * 	 *             "value", "False" otherwise.
 	 */
 	default boolean ever_less_or_equal(int value){
-		return functions.ever_le_tint_int(getNumberInner(),value) > 0;
+		return GeneratedFunctions.ever_le_tint_int(getNumberInner(),value) > 0;
 	}
 
 
@@ -443,7 +443,7 @@ public interface TInt extends TNumber {
 	 * 	 *             otherwise.
 	 */
 	default boolean ever_equal(int value){
-		return functions.ever_eq_tint_int(getNumberInner(),value) > 0;
+		return GeneratedFunctions.ever_eq_tint_int(getNumberInner(),value) > 0;
 	}
 
 	/**
@@ -458,7 +458,7 @@ public interface TInt extends TNumber {
 	 * 	 *             "False" otherwise.
 	 */
 	default boolean ever_not_equal(int value){
-		return (functions.ever_ne_tint_int(getNumberInner(),value)) > 0;
+		return (GeneratedFunctions.ever_ne_tint_int(getNumberInner(),value)) > 0;
 	}
 
 	/**
@@ -475,7 +475,7 @@ public interface TInt extends TNumber {
 	 * 	 *             "value", "False" otherwise.
 	 */
 	default boolean ever_greater_or_equal(int value){
-		return (functions.ever_ge_tint_int(getNumberInner(),value)) > 0;
+		return (GeneratedFunctions.ever_ge_tint_int(getNumberInner(),value)) > 0;
 	}
 
 	/**
@@ -490,7 +490,7 @@ public interface TInt extends TNumber {
 	 * 	 *             "False" otherwise.
 	 */
 	default boolean ever_greater(int value){
-		return (functions.ever_gt_tint_int(getNumberInner(),value)) > 0;
+		return (GeneratedFunctions.ever_gt_tint_int(getNumberInner(),value)) > 0;
 	}
 
 	/**
@@ -605,7 +605,7 @@ public interface TInt extends TNumber {
 	 */
 	default Temporal temporal_equal(Object other){
 		if ((other instanceof Integer)){
-			return Factory.create_temporal(functions.teq_tint_int(getNumberInner(), ((Integer) other)), getCustomType(),getTemporalType());
+			return Factory.create_temporal(GeneratedFunctions.teq_tint_int(getNumberInner(), ((Integer) other)), getCustomType(),getTemporalType());
 		}
 		else{
 			throw new UnsupportedOperationException("Parameter not supported");
@@ -629,7 +629,7 @@ public interface TInt extends TNumber {
 	 */
 	default Temporal temporal_not_equal(Integer other){
 		if ((other != null)){
-			return Factory.create_temporal(functions.tne_tint_int(getNumberInner(), other), getCustomType(),getTemporalType());
+			return Factory.create_temporal(GeneratedFunctions.tne_tint_int(getNumberInner(), other), getCustomType(),getTemporalType());
 		}
 		else{
 			throw new UnsupportedOperationException("Parameter not supported");
@@ -654,7 +654,7 @@ public interface TInt extends TNumber {
 	 */
 	default Temporal temporal_less(Integer other){
 		if ((other != null)){
-			return Factory.create_temporal(functions.tlt_tint_int(getNumberInner(), other), getCustomType(),getTemporalType());
+			return Factory.create_temporal(GeneratedFunctions.tlt_tint_int(getNumberInner(), other), getCustomType(),getTemporalType());
 		}
 		else{
 			throw new UnsupportedOperationException("Parameter not supported");
@@ -679,7 +679,7 @@ public interface TInt extends TNumber {
 	 */
 	default Temporal temporal_less_or_equal(Integer other){
 		if ((other != null)){
-			return Factory.create_temporal(functions.tle_tint_int(getNumberInner(), other), getCustomType(),getTemporalType());
+			return Factory.create_temporal(GeneratedFunctions.tle_tint_int(getNumberInner(), other), getCustomType(),getTemporalType());
 		}
 		else{
 			throw new UnsupportedOperationException("Parameter not supported");
@@ -703,7 +703,7 @@ public interface TInt extends TNumber {
 	 */
 	default Temporal temporal_greater_or_equal(Integer other){
 		if ((other != null)){
-			return Factory.create_temporal(functions.tge_tint_int(getNumberInner(), other), getCustomType(),getTemporalType());
+			return Factory.create_temporal(GeneratedFunctions.tge_tint_int(getNumberInner(), other), getCustomType(),getTemporalType());
 		}
 		else{
 			throw new UnsupportedOperationException("Parameter not supported");
@@ -726,7 +726,7 @@ public interface TInt extends TNumber {
 	 */
 	default Temporal temporal_greater(Integer other){
 		if ((other instanceof Integer)){
-			return Factory.create_temporal(functions.tgt_tint_int(getNumberInner(), other), getCustomType(),getTemporalType());
+			return Factory.create_temporal(GeneratedFunctions.tgt_tint_int(getNumberInner(), other), getCustomType(),getTemporalType());
 		}
 		else{
 			throw new UnsupportedOperationException("Parameter not supported");

--- a/jmeos-core/src/main/java/types/basic/tint/TIntInst.java
+++ b/jmeos-core/src/main/java/types/basic/tint/TIntInst.java
@@ -1,6 +1,7 @@
 package types.basic.tint;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import jnr.ffi.Pointer;
 import types.temporal.TInstant;
 import types.temporal.TemporalType;
@@ -36,14 +37,14 @@ public class TIntInst extends TInstant<Integer> implements TInt{
 	 */
 	public TIntInst(String value) {
 		super(value);
-		this.inner = functions.tint_in(value);
+		this.inner = GeneratedFunctions.tint_in(value);
 	}
 
 
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.tint_in(str);
+		return GeneratedFunctions.tint_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tint/TIntSeq.java
+++ b/jmeos-core/src/main/java/types/basic/tint/TIntSeq.java
@@ -1,6 +1,7 @@
 package types.basic.tint;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import jnr.ffi.Pointer;
 import types.basic.tfloat.TFloatInst;
 import types.basic.tfloat.TFloatSeq;
@@ -49,7 +50,7 @@ public class TIntSeq extends TSequence<Integer> implements TInt {
 	 */
 	public TIntSeq(String value, int interpolation) {
 		super(value);
-		this.inner = functions.tint_in(value);
+		this.inner = GeneratedFunctions.tint_in(value);
 	}
 
 
@@ -59,7 +60,7 @@ public class TIntSeq extends TSequence<Integer> implements TInt {
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.tint_in(str);
+		return GeneratedFunctions.tint_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tint/TIntSeqSet.java
+++ b/jmeos-core/src/main/java/types/basic/tint/TIntSeqSet.java
@@ -1,6 +1,7 @@
 package types.basic.tint;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.basic.tfloat.TFloatInst;
 import types.basic.tfloat.TFloatSeq;
 import types.basic.tfloat.TFloatSeqSet;
@@ -41,13 +42,13 @@ public class TIntSeqSet extends TSequenceSet<Integer> implements TInt{
 	 */
 	public TIntSeqSet(String value) {
 		super(value);
-		this.inner = functions.tint_in(value);
+		this.inner = GeneratedFunctions.tint_in(value);
 	}
 
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.tint_in(str);
+		return GeneratedFunctions.tint_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tnumber/TNumber.java
+++ b/jmeos-core/src/main/java/types/basic/tnumber/TNumber.java
@@ -11,6 +11,7 @@ import types.basic.tfloat.TFloatSeqSet;
 import types.basic.tint.TInt;
 import types.boxes.TBox;
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.collections.number.*;
 import types.collections.time.Time;
 import types.collections.time.tstzset;
@@ -53,7 +54,7 @@ public interface TNumber {
      * @return The bounding box of "this".
      */
     default TBox bounding_tbox() throws SQLException {
-        return new TBox(functions.tnumber_to_tbox(getNumberInner()));
+        return new TBox(GeneratedFunctions.tnumber_to_tbox(getNumberInner()));
     }
 
 
@@ -66,7 +67,7 @@ public interface TNumber {
      * @return The integral of "this".
      */
     default float integral(){
-        return (float) functions.tnumber_integral(getNumberInner());
+        return (float) GeneratedFunctions.tnumber_integral(getNumberInner());
     }
 
     /**
@@ -79,7 +80,7 @@ public interface TNumber {
      * @return The time weighted average of "this".
      */
     default float time_weighted_average(){
-        return (float) functions.tnumber_twavg(getNumberInner());
+        return (float) GeneratedFunctions.tnumber_twavg(getNumberInner());
     }
 
     /* ------------------------- Transformations ---------------------------------- */
@@ -97,10 +98,10 @@ public interface TNumber {
     default TNumber shift_value(Object delta) throws Exception {
         Pointer shifted= null;
         if(this instanceof TInt){
-            shifted= functions.tint_shift_value(this.getNumberInner(), (int) delta);
+            shifted= GeneratedFunctions.tint_shift_value(this.getNumberInner(), (int) delta);
         }
         else if (this instanceof TFloat){
-            shifted= functions.tfloat_shift_value(this.getNumberInner(), (double) delta);
+            shifted= GeneratedFunctions.tfloat_shift_value(this.getNumberInner(), (double) delta);
         }
         else{
             throw new Exception("Operation not supported for this object");
@@ -121,10 +122,10 @@ public interface TNumber {
     default TNumber scale_value(Object width) throws Exception {
         Pointer scaled= null;
         if(this instanceof TInt){
-            scaled= functions.tint_scale_value(this.getNumberInner(), (int) width);
+            scaled= GeneratedFunctions.tint_scale_value(this.getNumberInner(), (int) width);
         }
         else if (this instanceof TFloat){
-            scaled= functions.tfloat_scale_value(this.getNumberInner(), (double) width);
+            scaled= GeneratedFunctions.tfloat_scale_value(this.getNumberInner(), (double) width);
         }
         else{
             throw new Exception("Operation not supported for this object");
@@ -146,10 +147,10 @@ public interface TNumber {
     default TNumber shift_scale_value(Object shift, Object width) throws Exception {
         Pointer scaled= null;
         if(this instanceof TInt && shift!=null && width!=null){
-            scaled= functions.tint_shift_scale_value(this.getNumberInner(), (int) shift, (int) width);
+            scaled= GeneratedFunctions.tint_shift_scale_value(this.getNumberInner(), (int) shift, (int) width);
         }
         else if (this instanceof TFloat && shift!=null && width!=null){
-            scaled= functions.tfloat_shift_scale_value(this.getNumberInner(), (double) shift, (double) width);
+            scaled= GeneratedFunctions.tfloat_shift_scale_value(this.getNumberInner(), (double) shift, (double) width);
         }
         else{
             throw new Exception("Operation not supported for this object");
@@ -186,22 +187,22 @@ public interface TNumber {
      */
     default TNumber at(Object other) throws OperationNotSupportedException {
         if (other instanceof IntSet){
-            return (TNumber) Factory.create_temporal(functions.temporal_at_values(getNumberInner(),((IntSet) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.temporal_at_values(getNumberInner(),((IntSet) other).get_inner()),getCustomType(),getTemporalType());
         } else if (other instanceof FloatSet) {
-            return (TNumber) Factory.create_temporal(functions.temporal_at_values(getNumberInner(),((FloatSet) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.temporal_at_values(getNumberInner(),((FloatSet) other).get_inner()),getCustomType(),getTemporalType());
         }
          else if (other instanceof IntSpan){
-            return (TNumber) Factory.create_temporal(functions.tnumber_at_span(getNumberInner(),((IntSpan) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.tnumber_at_span(getNumberInner(),((IntSpan) other).get_inner()),getCustomType(),getTemporalType());
         } else if (other instanceof FloatSpan) {
-            return (TNumber) Factory.create_temporal(functions.tnumber_at_span(getNumberInner(),((FloatSpan) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.tnumber_at_span(getNumberInner(),((FloatSpan) other).get_inner()),getCustomType(),getTemporalType());
         }
         else if (other instanceof IntSpanSet){
-            return (TNumber) Factory.create_temporal(functions.tnumber_at_spanset(getNumberInner(),((IntSpanSet) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.tnumber_at_spanset(getNumberInner(),((IntSpanSet) other).get_inner()),getCustomType(),getTemporalType());
         } else if (other instanceof FloatSpanSet) {
-            return (TNumber) Factory.create_temporal(functions.tnumber_at_spanset(getNumberInner(),((FloatSpanSet) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.tnumber_at_spanset(getNumberInner(),((FloatSpanSet) other).get_inner()),getCustomType(),getTemporalType());
         }
         else if (other instanceof TBox){
-            return (TNumber) Factory.create_temporal(functions.tnumber_at_tbox(getNumberInner(),((TBox) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.tnumber_at_tbox(getNumberInner(),((TBox) other).get_inner()),getCustomType(),getTemporalType());
         }
         else{
             throw new OperationNotSupportedException("Operand not supported");
@@ -232,22 +233,22 @@ public interface TNumber {
      */
     default TNumber minus(Object other) throws OperationNotSupportedException {
         if (other instanceof IntSet){
-            return (TNumber) Factory.create_temporal(functions.temporal_minus_values(getNumberInner(),((IntSet) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.temporal_minus_values(getNumberInner(),((IntSet) other).get_inner()),getCustomType(),getTemporalType());
         } else if (other instanceof FloatSet) {
-            return (TNumber) Factory.create_temporal(functions.temporal_minus_values(getNumberInner(),((FloatSet) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.temporal_minus_values(getNumberInner(),((FloatSet) other).get_inner()),getCustomType(),getTemporalType());
         }
         else if (other instanceof IntSpan){
-            return (TNumber) Factory.create_temporal(functions.tnumber_minus_span(getNumberInner(),((IntSpan) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.tnumber_minus_span(getNumberInner(),((IntSpan) other).get_inner()),getCustomType(),getTemporalType());
         } else if (other instanceof FloatSpan) {
-            return (TNumber) Factory.create_temporal(functions.tnumber_minus_span(getNumberInner(),((FloatSpan) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.tnumber_minus_span(getNumberInner(),((FloatSpan) other).get_inner()),getCustomType(),getTemporalType());
         }
         else if (other instanceof IntSpanSet){
-            return (TNumber) Factory.create_temporal(functions.tnumber_minus_spanset(getNumberInner(),((IntSpanSet) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.tnumber_minus_spanset(getNumberInner(),((IntSpanSet) other).get_inner()),getCustomType(),getTemporalType());
         } else if (other instanceof FloatSpanSet) {
-            return (TNumber) Factory.create_temporal(functions.tnumber_minus_spanset(getNumberInner(),((FloatSpanSet) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.tnumber_minus_spanset(getNumberInner(),((FloatSpanSet) other).get_inner()),getCustomType(),getTemporalType());
         }
         else if (other instanceof TBox){
-            return (TNumber) Factory.create_temporal(functions.tnumber_minus_tbox(getNumberInner(),((TBox) other).get_inner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.tnumber_minus_tbox(getNumberInner(),((TBox) other).get_inner()),getCustomType(),getTemporalType());
         }
         else{
             throw new OperationNotSupportedException("Operand not supported");
@@ -344,11 +345,11 @@ public interface TNumber {
      */
     default TNumber add(Object other) throws OperationNotSupportedException {
         if ((this instanceof TInt) && (other instanceof Integer)){
-            return (TNumber) Factory.create_temporal(functions.add_tint_int(getNumberInner(),((Integer) other).intValue()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.add_tint_int(getNumberInner(),((Integer) other).intValue()),getCustomType(),getTemporalType());
         } else if ((this instanceof TFloat) && (other instanceof Float)) {
-            return (TNumber) Factory.create_temporal(functions.add_tfloat_float(getNumberInner(),((Float) other).floatValue()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.add_tfloat_float(getNumberInner(),((Float) other).floatValue()),getCustomType(),getTemporalType());
         } else if (other instanceof TNumber) {
-            return (TNumber) Factory.create_temporal(functions.add_tnumber_tnumber(getNumberInner(),((TNumber) other).getNumberInner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.add_tnumber_tnumber(getNumberInner(),((TNumber) other).getNumberInner()),getCustomType(),getTemporalType());
         }
         else{
             throw new OperationNotSupportedException("Operand not supported");
@@ -372,9 +373,9 @@ public interface TNumber {
      */
     default TNumber radd(Object other) throws OperationNotSupportedException {
         if ((this instanceof TInt) && (other instanceof Integer)){
-            return (TNumber) Factory.create_temporal(functions.add_int_tint(((Integer) other).intValue(),getNumberInner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.add_int_tint(((Integer) other).intValue(),getNumberInner()),getCustomType(),getTemporalType());
         } else if ((this instanceof TFloat) && (other instanceof Float)) {
-            return (TNumber) Factory.create_temporal(functions.add_float_tfloat(((Float) other).floatValue(),getNumberInner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.add_float_tfloat(((Float) other).floatValue(),getNumberInner()),getCustomType(),getTemporalType());
         }
         else{
             throw new OperationNotSupportedException("Operand not supported");
@@ -400,11 +401,11 @@ public interface TNumber {
      */
     default TNumber sub(Object other) throws OperationNotSupportedException {
         if ((this instanceof TInt) && (other instanceof Integer)){
-            return (TNumber) Factory.create_temporal(functions.sub_tint_int(getNumberInner(),((Integer) other).intValue()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.sub_tint_int(getNumberInner(),((Integer) other).intValue()),getCustomType(),getTemporalType());
         } else if ((this instanceof TFloat) && (other instanceof Float)) {
-            return (TNumber) Factory.create_temporal(functions.sub_tfloat_float(getNumberInner(),((Float) other).floatValue()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.sub_tfloat_float(getNumberInner(),((Float) other).floatValue()),getCustomType(),getTemporalType());
         } else if (other instanceof TNumber) {
-            return (TNumber) Factory.create_temporal(functions.sub_tnumber_tnumber(getNumberInner(),((TNumber) other).getNumberInner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.sub_tnumber_tnumber(getNumberInner(),((TNumber) other).getNumberInner()),getCustomType(),getTemporalType());
         }
         else{
             throw new OperationNotSupportedException("Operand not supported");
@@ -428,9 +429,9 @@ public interface TNumber {
      */
     default TNumber rsub(Object other) throws OperationNotSupportedException {
         if ((this instanceof TInt) && (other instanceof Integer)){
-            return (TNumber) Factory.create_temporal(functions.sub_int_tint(((Integer) other).intValue(),getNumberInner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.sub_int_tint(((Integer) other).intValue(),getNumberInner()),getCustomType(),getTemporalType());
         } else if ((this instanceof TFloat) && (other instanceof Float)) {
-            return (TNumber) Factory.create_temporal(functions.sub_float_tfloat(((Float) other).floatValue(),getNumberInner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.sub_float_tfloat(((Float) other).floatValue(),getNumberInner()),getCustomType(),getTemporalType());
         }
         else{
             throw new OperationNotSupportedException("Operand not supported");
@@ -456,11 +457,11 @@ public interface TNumber {
      */
     default TNumber mul(Object other) throws OperationNotSupportedException {
         if ((this instanceof TInt) && (other instanceof Integer)){
-            return (TNumber) Factory.create_temporal(functions.mul_tint_int(getNumberInner(),((Integer) other).intValue()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.mul_tint_int(getNumberInner(),((Integer) other).intValue()),getCustomType(),getTemporalType());
         } else if ((this instanceof TFloat) && (other instanceof Float)) {
-            return (TNumber) Factory.create_temporal(functions.mul_tfloat_float(getNumberInner(),((Float) other).floatValue()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.mul_tfloat_float(getNumberInner(),((Float) other).floatValue()),getCustomType(),getTemporalType());
         } else if (other instanceof TNumber) {
-            return (TNumber) Factory.create_temporal(functions.mul_tnumber_tnumber(getNumberInner(),((TNumber) other).getNumberInner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.mul_tnumber_tnumber(getNumberInner(),((TNumber) other).getNumberInner()),getCustomType(),getTemporalType());
         }
         else{
             throw new OperationNotSupportedException("Operand not supported");
@@ -485,9 +486,9 @@ public interface TNumber {
      */
     default TNumber rmul(Object other) throws OperationNotSupportedException {
         if ((this instanceof TInt) && (other instanceof Integer)){
-            return (TNumber) Factory.create_temporal(functions.mul_int_tint(((Integer) other).intValue(),getNumberInner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.mul_int_tint(((Integer) other).intValue(),getNumberInner()),getCustomType(),getTemporalType());
         } else if ((this instanceof TFloat) && (other instanceof Float)) {
-            return (TNumber) Factory.create_temporal(functions.mul_float_tfloat(((Float) other).floatValue(),getNumberInner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.mul_float_tfloat(((Float) other).floatValue(),getNumberInner()),getCustomType(),getTemporalType());
         }
         else{
             throw new OperationNotSupportedException("Operand not supported");
@@ -515,11 +516,11 @@ public interface TNumber {
      */
     default TNumber div(Object other) throws OperationNotSupportedException {
         if ((this instanceof TInt) && (other instanceof Integer)){
-            return (TNumber) Factory.create_temporal(functions.div_tint_int(getNumberInner(),((Integer) other).intValue()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.div_tint_int(getNumberInner(),((Integer) other).intValue()),getCustomType(),getTemporalType());
         } else if ((this instanceof TFloat) && (other instanceof Float)) {
-            return (TNumber) Factory.create_temporal(functions.div_tfloat_float(getNumberInner(),((Float) other).floatValue()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.div_tfloat_float(getNumberInner(),((Float) other).floatValue()),getCustomType(),getTemporalType());
         } else if (other instanceof TNumber) {
-            return (TNumber) Factory.create_temporal(functions.div_tnumber_tnumber(getNumberInner(),((TNumber) other).getNumberInner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.div_tnumber_tnumber(getNumberInner(),((TNumber) other).getNumberInner()),getCustomType(),getTemporalType());
         }
         else{
             throw new OperationNotSupportedException("Operand not supported");
@@ -546,9 +547,9 @@ public interface TNumber {
      */
     default TNumber rdiv(Object other) throws OperationNotSupportedException {
         if ((this instanceof TInt) && (other instanceof Integer)){
-            return (TNumber) Factory.create_temporal(functions.div_int_tint(((Integer) other).intValue(),getNumberInner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.div_int_tint(((Integer) other).intValue(),getNumberInner()),getCustomType(),getTemporalType());
         } else if ((this instanceof TFloat) && (other instanceof Float)) {
-            return (TNumber) Factory.create_temporal(functions.div_float_tfloat(((Float) other).floatValue(),getNumberInner()),getCustomType(),getTemporalType());
+            return (TNumber) Factory.create_temporal(GeneratedFunctions.div_float_tfloat(((Float) other).floatValue(),getNumberInner()),getCustomType(),getTemporalType());
         }
         else{
             throw new OperationNotSupportedException("Operand not supported");
@@ -700,7 +701,7 @@ public interface TNumber {
      * @return A new {@link TNumber} instance.
      */
     default TNumber abs(){
-        return (TNumber) Factory.create_temporal(functions.tnumber_abs(getNumberInner()),getCustomType(),getTemporalType());
+        return (TNumber) Factory.create_temporal(GeneratedFunctions.tnumber_abs(getNumberInner()),getCustomType(),getTemporalType());
     }
 
     /**
@@ -713,7 +714,7 @@ public interface TNumber {
      * @return A new {@link TNumber} instance.
      */
     default TNumber delta_value(){
-        return (TNumber) Factory.create_temporal(functions.tnumber_delta_value(getNumberInner()),getCustomType(),getTemporalType());
+        return (TNumber) Factory.create_temporal(GeneratedFunctions.tnumber_delta_value(getNumberInner()),getCustomType(),getTemporalType());
     }
 
 
@@ -737,11 +738,11 @@ public interface TNumber {
      */
     default TFloat distance(Object other) throws OperationNotSupportedException {
         if ( (other instanceof Integer)){
-            return (TFloat) Factory.create_temporal(functions.tdistance_tfloat_float(getNumberInner(),(float)((Integer) other).intValue()),getCustomType(),getTemporalType());
+            return (TFloat) Factory.create_temporal(GeneratedFunctions.tdistance_tfloat_float(getNumberInner(),(float)((Integer) other).intValue()),getCustomType(),getTemporalType());
         } else if ((other instanceof Float)) {
-            return (TFloat) Factory.create_temporal(functions.tdistance_tfloat_float(getNumberInner(),((Float) other).floatValue()),getCustomType(),getTemporalType());
+            return (TFloat) Factory.create_temporal(GeneratedFunctions.tdistance_tfloat_float(getNumberInner(),((Float) other).floatValue()),getCustomType(),getTemporalType());
         } else if (other instanceof TNumber) {
-            return (TFloat) Factory.create_temporal(functions.tdistance_tnumber_tnumber(getNumberInner(),((TNumber) other).getNumberInner()),getCustomType(),getTemporalType());
+            return (TFloat) Factory.create_temporal(GeneratedFunctions.tdistance_tnumber_tnumber(getNumberInner(),((TNumber) other).getNumberInner()),getCustomType(),getTemporalType());
         }
         else{
             throw new OperationNotSupportedException("Operand not supported");
@@ -766,13 +767,13 @@ public interface TNumber {
      */
     default float nearest_approach_distance(Object other) throws OperationNotSupportedException {
         if ( (other instanceof Integer)){
-            return (float) functions.nad_tfloat_float(getNumberInner(),(float)((Integer) other).intValue());
+            return (float) GeneratedFunctions.nad_tfloat_float(getNumberInner(),(float)((Integer) other).intValue());
         } else if ((other instanceof Float)) {
-            return (float) functions.nad_tfloat_float(getNumberInner(),((Float) other).floatValue());
+            return (float) GeneratedFunctions.nad_tfloat_float(getNumberInner(),((Float) other).floatValue());
         } else if (other instanceof TNumber) {
-            return (float) functions.nad_tfloat_tfloat(getNumberInner(),((TNumber) other).getNumberInner());
+            return (float) GeneratedFunctions.nad_tfloat_tfloat(getNumberInner(),((TNumber) other).getNumberInner());
         } else if (other instanceof TBox) {
-            return (float) functions.nad_tfloat_tfloat(getNumberInner(),((TBox) other).get_inner());
+            return (float) GeneratedFunctions.nad_tfloat_tfloat(getNumberInner(),((TBox) other).get_inner());
         }
         else{
             throw new OperationNotSupportedException("Operand not supported");
@@ -812,7 +813,7 @@ public interface TNumber {
         // Allocate memory for an integer (4 bytes) but do not set a value
         Pointer intPointer = Memory.allocate(runtime, 4);
         Pointer listPointer = createEmptyPointerArray(runtime, size);
-        Pointer result= functions.tint_value_split(this.getNumberInner(), size, start, listPointer, intPointer);
+        Pointer result= GeneratedFunctions.tint_value_split(this.getNumberInner(), size, start, listPointer, intPointer);
         List<TNumber> tempList= new ArrayList<>();
         int count= intPointer.getInt(Integer.BYTES);
         for(int i=0;i<count;i++){
@@ -844,21 +845,21 @@ public interface TNumber {
         OffsetDateTime st= null;
         Pointer dt= null;
         if(time_start != null){
-            st= functions.timestamptz_in("2000-01-03", -1);
+            st= GeneratedFunctions.timestamptz_in("2000-01-03", -1);
         }
         else{
             if(time_start instanceof LocalDateTime){
                 st= ConversionUtils.datetimeToTimestampTz((LocalDateTime) time_start);
             }
             else{
-                st= functions.timestamptz_in(time_start.toString(), -1);
+                st= GeneratedFunctions.timestamptz_in(time_start.toString(), -1);
             }
 
             if(duration instanceof Duration){
                 dt= ConversionUtils.timedelta_to_interval((Duration) duration);
             }
             else{
-                dt= functions.interval_in(duration.toString(), -1);
+                dt= GeneratedFunctions.interval_in(duration.toString(), -1);
             }
         }
         // Create a JNR-FFI runtime instance
@@ -867,7 +868,7 @@ public interface TNumber {
         Pointer intPointer = Memory.allocate(runtime, 4);
         Pointer valueListPointer = createEmptyPointerArray(runtime, value_size);
         Pointer timeListPointer = createEmptyPointerArray(runtime, value_size);
-        Pointer p= functions.tint_value_time_split(this.getNumberInner(), value_size, dt, value_start, st, valueListPointer, timeListPointer, intPointer);
+        Pointer p= GeneratedFunctions.tint_value_time_split(this.getNumberInner(), value_size, dt, value_start, st, valueListPointer, timeListPointer, intPointer);
         List<TNumber> tempList= new ArrayList<>();
         int count= intPointer.getInt(Integer.BYTES);
         for(int i=0;i<count;i++){

--- a/jmeos-core/src/main/java/types/basic/tpoint/TPoint.java
+++ b/jmeos-core/src/main/java/types/basic/tpoint/TPoint.java
@@ -57,7 +57,7 @@ public interface TPoint extends Serializable {
 	 * @return A new {@link String} representing the temporal point.
 	 */
 	default String to_string(){
-		return functions.tspatial_as_text(getPointInner(),15);
+		return GeneratedFunctions.tspatial_as_text(getPointInner(),15);
 	}
 
 
@@ -73,7 +73,7 @@ public interface TPoint extends Serializable {
 	 * @return A new {@link String} representing the temporal point.
 	 */
 	default String as_wkt(int decimals){
-		return functions.tspatial_as_text(getPointInner(),decimals);
+		return GeneratedFunctions.tspatial_as_text(getPointInner(),decimals);
 	}
 
 
@@ -89,7 +89,7 @@ public interface TPoint extends Serializable {
 	 * @return A new {@link String} representing the temporal point.
 	 */
 	default String as_ewkt(int decimals){
-		return functions.tspatial_as_ewkt(getPointInner(),decimals);
+		return GeneratedFunctions.tspatial_as_ewkt(getPointInner(),decimals);
 	}
 
 
@@ -109,11 +109,11 @@ public interface TPoint extends Serializable {
 	 * @return A new GeoJSON string representing the trajectory of the temporal point.
 	 */
 	default String as_geojson(boolean unary_union, int option, int precision, String srs){
-		return functions.geo_as_geojson(functions.tpoint_trajectory(getPointInner(), unary_union),option,precision,srs);
+		return GeneratedFunctions.geo_as_geojson(GeneratedFunctions.tpoint_trajectory(getPointInner(), unary_union),option,precision,srs);
 	}
 
 	default String as_geojson(int option, int precision, String srs){
-		return functions.geo_as_geojson(functions.tpoint_trajectory(getPointInner(), false),option,precision,srs);
+		return GeneratedFunctions.geo_as_geojson(GeneratedFunctions.tpoint_trajectory(getPointInner(), false),option,precision,srs);
 	}
 
 
@@ -146,7 +146,7 @@ public interface TPoint extends Serializable {
 	 * @return An {@link STBox} representing the bounding box.
 	 */
 	default STBox bounding_box_point(){
-		return new STBox(functions.tspatial_to_stbox(getPointInner()));
+		return new STBox(GeneratedFunctions.tspatial_to_stbox(getPointInner()));
 	}
 
 /**
@@ -163,7 +163,7 @@ public interface TPoint extends Serializable {
 		Runtime runtime = Runtime.getSystemRuntime();
 		// Allocate memory for an integer (4 bytes) but do not set a value
 		Pointer intPointer = Memory.allocate(runtime, 4);
-		Pointer resPointer= functions.temporal_instants(this.getPointInner(), intPointer);
+		Pointer resPointer= GeneratedFunctions.temporal_instants(this.getPointInner(), intPointer);
 		List<TPoint> pointList= new ArrayList<>();
 		int count= intPointer.getInt(Integer.BYTES);
 		for(int i=0; i<count; i++){
@@ -185,7 +185,7 @@ public interface TPoint extends Serializable {
 	 * @throws ParseException
 	 */
 	default Point start_value(int precision) throws ParseException {
-		return ConversionUtils.gserialized_to_shapely_point(functions.tgeo_start_value(getPointInner()),precision);
+		return ConversionUtils.gserialized_to_shapely_point(GeneratedFunctions.tgeo_start_value(getPointInner()),precision);
 	}
 
 	/**
@@ -199,7 +199,7 @@ public interface TPoint extends Serializable {
 	 * @throws ParseException
 	 */
 	default Point end_value(int precision) throws ParseException {
-		return ConversionUtils.gserialized_to_shapely_point(functions.tgeo_end_value(getPointInner()),precision);
+		return ConversionUtils.gserialized_to_shapely_point(GeneratedFunctions.tgeo_end_value(getPointInner()),precision);
 	}
 
 /**
@@ -217,7 +217,7 @@ public interface TPoint extends Serializable {
 //		 Runtime runtime = Runtime.getSystemRuntime();
 //		 // Allocate memory for an integer (4 bytes) but do not set a value
 //		 Pointer intPointer = Memory.allocate(Runtime.getRuntime(runtime), 4);
-//		 Pointer resPointer= functions.tpoint_values(this.getPointInner(), intPointer);
+//		 Pointer resPointer= GeneratedFunctions.tpoint_values(this.getPointInner(), intPointer);
 //		 List<TPoint> pointList= new ArrayList<>();
 //		 int count= intPointer.getInt(Integer.BYTES);
 //		 StringBuilder sb = null;
@@ -244,17 +244,17 @@ public interface TPoint extends Serializable {
 //
 //			 @Override
 //			 public Pointer createStringInner(String str) {
-//				 return functions.tgeom(str);
+//				 return GeneratedFunctions.tgeom(str);
 //			 }
 //
 //			 @Override
 //			 public Point start_element() throws ParseException {
-//				 return ConversionUtils.gserialized_to_shapely_point(functions.tgeo_start_value(this.get_inner()), precision);
+//				 return ConversionUtils.gserialized_to_shapely_point(GeneratedFunctions.tgeo_start_value(this.get_inner()), precision);
 //			 }
 //
 //			 @Override
 //			 public Point end_element() throws ParseException {
-//				 return ConversionUtils.gserialized_to_shapely_point(functions.tgeo_end_value(this.get_inner()), precision);
+//				 return ConversionUtils.gserialized_to_shapely_point(GeneratedFunctions.tgeo_end_value(this.get_inner()), precision);
 //			 }
 //		 };
 //	 }
@@ -289,7 +289,7 @@ public interface TPoint extends Serializable {
 	 * @return A {@link Float} with the length of the trajectory.
 	 */
 	default float length(){
-		return (float) functions.tpoint_length(getPointInner());
+		return (float) GeneratedFunctions.tpoint_length(getPointInner());
 	}
 
 
@@ -302,7 +302,7 @@ public interface TPoint extends Serializable {
 	 * @return A {@link TFloat} with the cumulative length of the trajectory.
 	 */
 	default TFloat cumulative_length(){
-		return (TFloat) Factory.create_temporal(functions.tpoint_cumulative_length(getPointInner()),"Float",getTemporalType());
+		return (TFloat) Factory.create_temporal(GeneratedFunctions.tpoint_cumulative_length(getPointInner()),"Float",getTemporalType());
 	}
 
 
@@ -315,7 +315,7 @@ public interface TPoint extends Serializable {
 	 * @return A {@link TFloat} with the speed of the temporal point.
 	 */
 	default TFloat speed(){
-		return (TFloat) Factory.create_temporal(functions.tpoint_speed(getPointInner()),"Float",getTemporalType());
+		return (TFloat) Factory.create_temporal(GeneratedFunctions.tpoint_speed(getPointInner()),"Float",getTemporalType());
 	}
 
 
@@ -328,7 +328,7 @@ public interface TPoint extends Serializable {
 	 * @return A {@link TFloat} with the x coordinate of the temporal point.
 	 */
 	default TFloat x(){
-		return (TFloat) Factory.create_temporal(functions.tpoint_get_x(getPointInner()),"Float",getTemporalType());
+		return (TFloat) Factory.create_temporal(GeneratedFunctions.tpoint_get_x(getPointInner()),"Float",getTemporalType());
 
 	}
 
@@ -342,7 +342,7 @@ public interface TPoint extends Serializable {
 	 * @return A {@link TFloat} with the y coordinate of the temporal point.
 	 */
 	default TFloat y(){
-		return (TFloat) Factory.create_temporal(functions.tpoint_get_y(getPointInner()),"Float",getTemporalType());
+		return (TFloat) Factory.create_temporal(GeneratedFunctions.tpoint_get_y(getPointInner()),"Float",getTemporalType());
 
 	}
 
@@ -356,7 +356,7 @@ public interface TPoint extends Serializable {
 	 * @return A {@link TFloat} with the z coordinate of the temporal point.
 	 */
 	default TFloat z(){
-		return (TFloat) Factory.create_temporal(functions.tpoint_get_z(getPointInner()),"Float",getTemporalType());
+		return (TFloat) Factory.create_temporal(GeneratedFunctions.tpoint_get_z(getPointInner()),"Float",getTemporalType());
 
 	}
 
@@ -388,7 +388,7 @@ public interface TPoint extends Serializable {
 		Runtime runtime = Runtime.getSystemRuntime();
 		// Allocate memory for an integer (4 bytes) but do not set a value
 		Pointer intPointer = Memory.allocate(runtime, 4);
-		Pointer resPointer= functions.tgeo_stboxes(this.getPointInner(), intPointer);
+		Pointer resPointer= GeneratedFunctions.tgeo_stboxes(this.getPointInner(), intPointer);
 		List<STBox> stBoxList= new ArrayList<>();
 		int length= intPointer.getInt(Integer.BYTES);
 		for(int i=0; i<length; i++){
@@ -410,7 +410,7 @@ public interface TPoint extends Serializable {
 	 * @return A {@link Boolean} indicating whether the temporal point is simple.
 	 */
 	default boolean is_simple(){
-		return functions.tpoint_is_simple(getPointInner());
+		return GeneratedFunctions.tpoint_is_simple(getPointInner());
 	}
 
 
@@ -427,7 +427,7 @@ public interface TPoint extends Serializable {
 	 * @return A new {@link TFloat} indicating the temporal bearing between the temporal point and "other".
 	 */
 	default TFloat bearing(TPoint other){
-		return (TFloat) Factory.create_temporal(functions.bearing_tpoint_tpoint(getPointInner(),other.getPointInner()),"Float",getTemporalType());
+		return (TFloat) Factory.create_temporal(GeneratedFunctions.bearing_tpoint_tpoint(getPointInner(),other.getPointInner()),"Float",getTemporalType());
 
 	}
 
@@ -442,7 +442,7 @@ public interface TPoint extends Serializable {
 	 * @return A new {@link TFloatSeqSet} indicating the direction of the temporal point.
 	 */
 	default TFloatSeqSet direction(){
-		return (TFloatSeqSet) Factory.create_temporal(functions.tpoint_direction(getPointInner()),"Float",getTemporalType());
+		return (TFloatSeqSet) Factory.create_temporal(GeneratedFunctions.tpoint_direction(getPointInner()),"Float",getTemporalType());
 	}
 
 
@@ -456,7 +456,7 @@ public interface TPoint extends Serializable {
 	 * @return A new {@link TFloatSeqSet} indicating the temporal azimuth of the temporal point.
 	 */
 	default TFloatSeqSet azimuth(){
-		return (TFloatSeqSet) Factory.create_temporal(functions.tpoint_azimuth(getPointInner()),"Float",getTemporalType());
+		return (TFloatSeqSet) Factory.create_temporal(GeneratedFunctions.tpoint_azimuth(getPointInner()),"Float",getTemporalType());
 	}
 
 
@@ -470,7 +470,7 @@ public interface TPoint extends Serializable {
 	 * @return A new {@link TFloatSeqSet} indicating the temporal angular_difference of the temporal point.
 	 */
 	default TFloatSeqSet angular_difference(){
-		return (TFloatSeqSet) Factory.create_temporal(functions.tpoint_angular_difference(getPointInner()),"Float", TemporalType.TEMPORAL_SEQUENCE_SET);
+		return (TFloatSeqSet) Factory.create_temporal(GeneratedFunctions.tpoint_angular_difference(getPointInner()),"Float", TemporalType.TEMPORAL_SEQUENCE_SET);
 	}
 
 
@@ -485,7 +485,7 @@ public interface TPoint extends Serializable {
 	 * @throws ParseException
 	 */
 	default Point time_weighted_centroid(int precision) throws ParseException {
-		return (Point) ConversionUtils.gserialized_to_shapely_geometry(functions.tpoint_twcentroid(getPointInner()),precision);
+		return (Point) ConversionUtils.gserialized_to_shapely_geometry(GeneratedFunctions.tpoint_twcentroid(getPointInner()),precision);
 	}
 
 
@@ -501,7 +501,7 @@ public interface TPoint extends Serializable {
 	 * @return An {@link Integer} representing the SRID.
 	 */
 	default int srid(){
-		return functions.tspatial_srid(getPointInner());
+		return GeneratedFunctions.tspatial_srid(getPointInner());
 	}
 
 
@@ -514,7 +514,7 @@ public interface TPoint extends Serializable {
 	 * @return Returns a new TPoint with the given SRID.
 	 */
 	default TPoint set_srid(int srid){
-		return (TPoint) Factory.create_temporal(functions.tspatial_set_srid(getPointInner(),srid),getCustomType(),getTemporalType());
+		return (TPoint) Factory.create_temporal(GeneratedFunctions.tspatial_set_srid(getPointInner(),srid),getCustomType(),getTemporalType());
 	}
 
 
@@ -533,7 +533,7 @@ public interface TPoint extends Serializable {
 	 * @return A new {@link TPoint} object.
 	 */
 	default TPoint round(int max_decimals){
-		return (TPoint) Factory.create_temporal(functions.temporal_round(getPointInner(),max_decimals),getCustomType(),getTemporalType());
+		return (TPoint) Factory.create_temporal(GeneratedFunctions.temporal_round(getPointInner(),max_decimals),getCustomType(),getTemporalType());
 	}
 
     /**
@@ -550,7 +550,7 @@ public interface TPoint extends Serializable {
 		Runtime runtime = Runtime.getSystemRuntime();
 		// Allocate memory for an integer (4 bytes) but do not set a value
 		Pointer intPointer = Memory.allocate(runtime, 4);
-		Pointer resPointer= functions.tpoint_make_simple(this.getPointInner(), intPointer);
+		Pointer resPointer= GeneratedFunctions.tpoint_make_simple(this.getPointInner(), intPointer);
 		int length= intPointer.getInt(Integer.BYTES);
 		List<TPoint> tPointList= new ArrayList<>();
 		TemporalType temporalType= getTemporalType();
@@ -576,7 +576,7 @@ public interface TPoint extends Serializable {
 	 * @return A new {@link STBox} instance.
 	 */
 	default STBox expand(float other){
-		return new STBox(functions.stbox_expand_space(getPointInner(),other));
+		return new STBox(GeneratedFunctions.stbox_expand_space(getPointInner(),other));
 	}
 	/**
         Returns a new :class:`TPoint` of the same subclass of ``self`` transformed to another SRID
@@ -595,10 +595,10 @@ public interface TPoint extends Serializable {
 		 AbstractMap.SimpleEntry<Integer, Integer> srids = new AbstractMap.SimpleEntry<>(this.srid(), srid);
 		 // Check and cache the projection if not already cached
 		 if (!projectionCache.containsKey(srids)) {
-			 projectionCache.put(srids, functions.lwproj_transform(srids.getKey(), srids.getValue()));
+			 projectionCache.put(srids, GeneratedFunctions.lwproj_transform(srids.getKey(), srids.getValue()));
 		 }
 		 // Perform the transformation using the cached projection
-		 Pointer result = functions.tpoint_transform_pj(this.getPointInner(), srid, projectionCache.get(srids));
+		 Pointer result = GeneratedFunctions.tpoint_transform_pj(this.getPointInner(), srid, projectionCache.get(srids));
 
 		 // Create and return a new TPoint instance
 		 return (TPoint) Factory.create_temporal(result, getCustomType(), getTemporalType());
@@ -629,11 +629,11 @@ public interface TPoint extends Serializable {
 	default TPoint at(Object other) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
 			boolean geodetic = this instanceof TGeomPoint;
-			return (TPoint) Factory.create_temporal(functions.tpoint_at_value(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, geodetic)),getCustomType(),getTemporalType());
+			return (TPoint) Factory.create_temporal(GeneratedFunctions.tpoint_at_value(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, geodetic)),getCustomType(),getTemporalType());
 		} else if (other instanceof GeoSet) {
-			return (TPoint) Factory.create_temporal(functions.temporal_at_values(getPointInner(),((GeoSet) other).get_inner()),getCustomType(),getTemporalType());
+			return (TPoint) Factory.create_temporal(GeneratedFunctions.temporal_at_values(getPointInner(),((GeoSet) other).get_inner()),getCustomType(),getTemporalType());
 		} else if (other instanceof STBox) {
-			return (TPoint) Factory.create_temporal(functions.tgeo_at_stbox(getPointInner(),((STBox) other).get_inner(),true),getCustomType(),getTemporalType());
+			return (TPoint) Factory.create_temporal(GeneratedFunctions.tgeo_at_stbox(getPointInner(),((STBox) other).get_inner(),true),getCustomType(),getTemporalType());
 		}
 		else{
 			throw new OperationNotSupportedException("Operand not supported");
@@ -661,11 +661,11 @@ public interface TPoint extends Serializable {
 	default TPoint minus(Object other) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
 			boolean geodetic = this instanceof TGeomPoint;
-			return (TPoint) Factory.create_temporal(functions.tpoint_minus_value(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, geodetic)),getCustomType(),getTemporalType());
+			return (TPoint) Factory.create_temporal(GeneratedFunctions.tpoint_minus_value(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, geodetic)),getCustomType(),getTemporalType());
 		} else if (other instanceof GeoSet) {
-			return (TPoint) Factory.create_temporal(functions.temporal_minus_values(getPointInner(),((GeoSet) other).get_inner()),getCustomType(),getTemporalType());
+			return (TPoint) Factory.create_temporal(GeneratedFunctions.temporal_minus_values(getPointInner(),((GeoSet) other).get_inner()),getCustomType(),getTemporalType());
 		} else if (other instanceof STBox) {
-			return (TPoint) Factory.create_temporal(functions.tgeo_minus_stbox(getPointInner(),((STBox) other).get_inner(),true),getCustomType(),getTemporalType());
+			return (TPoint) Factory.create_temporal(GeneratedFunctions.tgeo_minus_stbox(getPointInner(),((STBox) other).get_inner(),true),getCustomType(),getTemporalType());
 		}
 		else{
 			throw new OperationNotSupportedException("Operand not supported");
@@ -891,9 +891,9 @@ public interface TPoint extends Serializable {
 	 */
 	default boolean is_ever_contained_in(Object other) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
-			return 1 == functions.econtains_geo_tgeo(ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint), getPointInner());
+			return 1 == GeneratedFunctions.econtains_geo_tgeo(ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint), getPointInner());
 		} else if (other instanceof STBox) {
-			return 1 == functions.econtains_geo_tgeo(functions.stbox_to_geo(((STBox) other).get_inner()),getPointInner());
+			return 1 == GeneratedFunctions.econtains_geo_tgeo(GeneratedFunctions.stbox_to_geo(((STBox) other).get_inner()),getPointInner());
 		}
 		else{
 			throw new OperationNotSupportedException("Operand not supported");
@@ -914,11 +914,11 @@ public interface TPoint extends Serializable {
 	 */
 	default boolean is_ever_disjoint(Object other) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
-			return 1 == functions.edisjoint_tgeo_geo(getPointInner(), ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint));
+			return 1 == GeneratedFunctions.edisjoint_tgeo_geo(getPointInner(), ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint));
 		} else if (other instanceof STBox) {
-			return 1 == functions.edisjoint_tgeo_geo(getPointInner(), functions.stbox_to_geo(((STBox) other).get_inner()));
+			return 1 == GeneratedFunctions.edisjoint_tgeo_geo(getPointInner(), GeneratedFunctions.stbox_to_geo(((STBox) other).get_inner()));
 		} else if (other instanceof TPoint) {
-			return 1 == functions.edisjoint_tgeo_tgeo(getPointInner(), ((TPoint) other).getPointInner());
+			return 1 == GeneratedFunctions.edisjoint_tgeo_tgeo(getPointInner(), ((TPoint) other).getPointInner());
 		} else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -940,11 +940,11 @@ public interface TPoint extends Serializable {
 	 */
 	default boolean is_ever_within_distance(Object other, float distance) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
-			return 1 == functions.edwithin_tgeo_geo( getPointInner(), ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint), distance);
+			return 1 == GeneratedFunctions.edwithin_tgeo_geo( getPointInner(), ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint), distance);
 		} else if (other instanceof STBox) {
-			return 1 == functions.edwithin_tgeo_geo(getPointInner(), functions.stbox_to_geo(((STBox) other).get_inner()), distance);
+			return 1 == GeneratedFunctions.edwithin_tgeo_geo(getPointInner(), GeneratedFunctions.stbox_to_geo(((STBox) other).get_inner()), distance);
 		} else if (other instanceof TPoint) {
-			return 1 == functions.edwithin_tgeo_tgeo(getPointInner(), ((TPoint) other).getPointInner(), distance);
+			return 1 == GeneratedFunctions.edwithin_tgeo_tgeo(getPointInner(), ((TPoint) other).getPointInner(), distance);
 		} else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -965,11 +965,11 @@ public interface TPoint extends Serializable {
 	 */
 	default boolean ever_intersects(Object other) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
-			return 1 == functions.eintersects_tgeo_geo( getPointInner(), ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint));
+			return 1 == GeneratedFunctions.eintersects_tgeo_geo( getPointInner(), ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint));
 		} else if (other instanceof STBox) {
-			return 1 == functions.eintersects_tgeo_geo(getPointInner(), functions.stbox_to_geo(((STBox) other).get_inner()));
+			return 1 == GeneratedFunctions.eintersects_tgeo_geo(getPointInner(), GeneratedFunctions.stbox_to_geo(((STBox) other).get_inner()));
 		} else if (other instanceof TPoint) {
-			return 1 == functions.eintersects_tgeo_tgeo(getPointInner(), ((TPoint) other).getPointInner());
+			return 1 == GeneratedFunctions.eintersects_tgeo_tgeo(getPointInner(), ((TPoint) other).getPointInner());
 		} else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -989,9 +989,9 @@ public interface TPoint extends Serializable {
 	 */
 	default boolean ever_touches(Object other) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
-			return 1 == functions.etouches_tpoint_geo( getPointInner(), ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint));
+			return 1 == GeneratedFunctions.etouches_tpoint_geo( getPointInner(), ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint));
 		} else if (other instanceof STBox) {
-			return 1 == functions.etouches_tpoint_geo(getPointInner(), functions.stbox_to_geo(((STBox) other).get_inner()));
+			return 1 == GeneratedFunctions.etouches_tpoint_geo(getPointInner(), GeneratedFunctions.stbox_to_geo(((STBox) other).get_inner()));
 		}  else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -1016,7 +1016,7 @@ public interface TPoint extends Serializable {
 		if (other instanceof Geometry){
 			return (TBool) Factory.create_temporal(GeneratedFunctions.tcontains_geo_tgeo(ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint), getPointInner()), "Boolean", getTemporalType() ) ;
 		} else if (other instanceof STBox) {
-			return (TBool) Factory.create_temporal(GeneratedFunctions.tcontains_geo_tgeo(functions.stbox_to_geo(((STBox) other).get_inner()), getPointInner()), "Boolean", getTemporalType()  );
+			return (TBool) Factory.create_temporal(GeneratedFunctions.tcontains_geo_tgeo(GeneratedFunctions.stbox_to_geo(((STBox) other).get_inner()), getPointInner()), "Boolean", getTemporalType()  );
 		}  else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -1038,7 +1038,7 @@ public interface TPoint extends Serializable {
 		if (other instanceof Geometry){
 			return (TBool) Factory.create_temporal(GeneratedFunctions.tdisjoint_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint)), "Boolean", getTemporalType() ) ;
 		} else if (other instanceof STBox) {
-			return (TBool) Factory.create_temporal(GeneratedFunctions.tdisjoint_tgeo_geo(getPointInner(),functions.stbox_to_geo(((STBox) other).get_inner())), "Boolean", getTemporalType()  );
+			return (TBool) Factory.create_temporal(GeneratedFunctions.tdisjoint_tgeo_geo(getPointInner(),GeneratedFunctions.stbox_to_geo(((STBox) other).get_inner())), "Boolean", getTemporalType()  );
 		}  else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -1061,7 +1061,7 @@ public interface TPoint extends Serializable {
 		if (other instanceof Geometry){
 			return (TBool) Factory.create_temporal(GeneratedFunctions.tdwithin_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint), distance), "Boolean", getTemporalType() ) ;
 		} else if (other instanceof STBox) {
-			return (TBool) Factory.create_temporal(GeneratedFunctions.tdwithin_tgeo_geo(getPointInner(),functions.stbox_to_geo(((STBox) other).get_inner()), distance), "Boolean", getTemporalType()  );
+			return (TBool) Factory.create_temporal(GeneratedFunctions.tdwithin_tgeo_geo(getPointInner(),GeneratedFunctions.stbox_to_geo(((STBox) other).get_inner()), distance), "Boolean", getTemporalType()  );
 		} else if(other instanceof TPoint){
 			return (TBool) Factory.create_temporal(GeneratedFunctions.tdwithin_tgeo_tgeo(getPointInner(),((TPoint) other).getPointInner(), distance), "Boolean", getTemporalType()  );
 		}else{
@@ -1085,7 +1085,7 @@ public interface TPoint extends Serializable {
 		if (other instanceof Geometry){
 			return (TBool) Factory.create_temporal(GeneratedFunctions.tintersects_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint)), "Boolean", getTemporalType() ) ;
 		} else if (other instanceof STBox) {
-			return (TBool) Factory.create_temporal(GeneratedFunctions.tintersects_tgeo_geo(getPointInner(),functions.stbox_to_geo(((STBox) other).get_inner())), "Boolean", getTemporalType()  );
+			return (TBool) Factory.create_temporal(GeneratedFunctions.tintersects_tgeo_geo(getPointInner(),GeneratedFunctions.stbox_to_geo(((STBox) other).get_inner())), "Boolean", getTemporalType()  );
 		}  else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -1107,7 +1107,7 @@ public interface TPoint extends Serializable {
 		if (other instanceof Geometry){
 			return (TBool) Factory.create_temporal(GeneratedFunctions.ttouches_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint)), "Boolean", getTemporalType() ) ;
 		} else if (other instanceof STBox) {
-			return (TBool) Factory.create_temporal(GeneratedFunctions.ttouches_tgeo_geo(getPointInner(),functions.stbox_to_geo(((STBox) other).get_inner())), "Boolean", getTemporalType()  );
+			return (TBool) Factory.create_temporal(GeneratedFunctions.ttouches_tgeo_geo(getPointInner(),GeneratedFunctions.stbox_to_geo(((STBox) other).get_inner())), "Boolean", getTemporalType()  );
 		}  else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -1129,11 +1129,11 @@ public interface TPoint extends Serializable {
 	 */
 	default TFloat distance(Object other) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
-			return (TFloat) Factory.create_temporal(functions.tdistance_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint)), "Float", getTemporalType() ) ;
+			return (TFloat) Factory.create_temporal(GeneratedFunctions.tdistance_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint)), "Float", getTemporalType() ) ;
 		} else if (other instanceof STBox) {
-			return (TFloat) Factory.create_temporal(functions.tdistance_tgeo_geo(getPointInner(),functions.stbox_to_geo(((STBox) other).get_inner())), "Float", getTemporalType()  );
+			return (TFloat) Factory.create_temporal(GeneratedFunctions.tdistance_tgeo_geo(getPointInner(),GeneratedFunctions.stbox_to_geo(((STBox) other).get_inner())), "Float", getTemporalType()  );
 		} else if(other instanceof TPoint){
-			return (TFloat) Factory.create_temporal(functions.tdistance_tgeo_tgeo(getPointInner(),((TPoint) other).getPointInner()), "Float", getTemporalType()  );
+			return (TFloat) Factory.create_temporal(GeneratedFunctions.tdistance_tgeo_tgeo(getPointInner(),((TPoint) other).getPointInner()), "Float", getTemporalType()  );
 		}else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -1154,11 +1154,11 @@ public interface TPoint extends Serializable {
 	 */
 	default float nearest_approach_distance(Object other) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
-			return (float) functions.nad_tgeo_geo( getPointInner(), ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint));
+			return (float) GeneratedFunctions.nad_tgeo_geo( getPointInner(), ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint));
 		} else if (other instanceof STBox) {
-			return (float) functions.nad_tgeo_stbox(getPointInner(), functions.stbox_to_geo(((STBox) other).get_inner()));
+			return (float) GeneratedFunctions.nad_tgeo_stbox(getPointInner(), GeneratedFunctions.stbox_to_geo(((STBox) other).get_inner()));
 		} else if (other instanceof TPoint) {
-			return (float) functions.nad_tgeo_tgeo(getPointInner(), ((TPoint) other).getPointInner());
+			return (float) GeneratedFunctions.nad_tgeo_tgeo(getPointInner(), ((TPoint) other).getPointInner());
 		} else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -1178,9 +1178,9 @@ public interface TPoint extends Serializable {
 	 */
 	default TInstant nearest_approach_instant(Object other) throws OperationNotSupportedException {
 		if (other instanceof Geometry){
-			return (TInstant) Factory.create_temporal(functions.nai_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint)), getCustomType(), getTemporalType() ) ;
+			return (TInstant) Factory.create_temporal(GeneratedFunctions.nai_tgeo_geo(getPointInner(),ConversionUtils.geo_to_gserialized((Geometry) other, this instanceof TGeogPoint)), getCustomType(), getTemporalType() ) ;
 		} else if(other instanceof TPoint){
-			return (TInstant) Factory.create_temporal(functions.nai_tgeo_tgeo(getPointInner(),((TPoint) other).getPointInner()), getCustomType(), getTemporalType()  );
+			return (TInstant) Factory.create_temporal(GeneratedFunctions.nai_tgeo_tgeo(getPointInner(),((TPoint) other).getPointInner()), getCustomType(), getTemporalType()  );
 		}else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -1205,9 +1205,9 @@ public interface TPoint extends Serializable {
 		if (other instanceof Geometry){
 			boolean b= this instanceof TGeogPoint;
             Pointer gs= ConversionUtils.geo_to_gserialized((Geometry) other, b);
-			res= functions.shortestline_tgeo_geo(this.getPointInner(), gs);
+			res= GeneratedFunctions.shortestline_tgeo_geo(this.getPointInner(), gs);
 		} else if(other instanceof TPoint){
-			res= functions.shortestline_tgeo_geo(this.getPointInner(), ((TPoint) other).getPointInner());
+			res= GeneratedFunctions.shortestline_tgeo_geo(this.getPointInner(), ((TPoint) other).getPointInner());
 		}else{
 			throw new OperationNotSupportedException("Operand not supported");
 		}
@@ -1282,10 +1282,10 @@ public interface TPoint extends Serializable {
 		}
         else{
 			if(isTGeogPoint){
-				gs= functions.geog_in("Point (0 0 0)", -1);
+				gs= GeneratedFunctions.geog_in("Point (0 0 0)", -1);
 			}
 			else{
-				gs= functions.geom_in("Point (0 0 0)", -1);
+				gs= GeneratedFunctions.geom_in("Point (0 0 0)", -1);
 			}
 		}
 		// Create a JNR-FFI runtime instance
@@ -1333,7 +1333,7 @@ public interface TPoint extends Serializable {
 			dt= ConversionUtils.timedelta_to_interval((Duration) duration);
 		}
 		else{
-			dt= functions.interval_in(duration.toString(), -1);
+			dt= GeneratedFunctions.interval_in(duration.toString(), -1);
 		}
 
 		Pointer gs= null;
@@ -1343,23 +1343,23 @@ public interface TPoint extends Serializable {
 		}
 		else{
 			if(isTGeogPoint){
-				gs= functions.geog_in("Point (0 0 0)", -1);
+				gs= GeneratedFunctions.geog_in("Point (0 0 0)", -1);
 			}
 			else{
-				gs= functions.geom_in("Point (0 0 0)", -1);
+				gs= GeneratedFunctions.geom_in("Point (0 0 0)", -1);
 			}
 		}
 
 		OffsetDateTime st= null;
 		if(time_start!=null){
-			st= functions.timestamptz_in("2000-01-03", -1);
+			st= GeneratedFunctions.timestamptz_in("2000-01-03", -1);
 		}
 		else{
 			if(time_start instanceof LocalDateTime){
 				st= ConversionUtils.datetimeToTimestampTz((LocalDateTime) time_start);
 			}
 			else{
-				st= functions.timestamptz_in(time_start.toString(), -1);
+				st= GeneratedFunctions.timestamptz_in(time_start.toString(), -1);
 			}
 		}
 

--- a/jmeos-core/src/main/java/types/basic/tpoint/tgeog/TGeogPoint.java
+++ b/jmeos-core/src/main/java/types/basic/tpoint/tgeog/TGeogPoint.java
@@ -1,6 +1,7 @@
 package types.basic.tpoint.tgeog;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import jnr.ffi.Memory;
 import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
@@ -57,7 +58,7 @@ public interface TGeogPoint extends TPoint {
 	 * @return A new {@link TGeogPoint} object.
 	 */
 	default TGeogPoint from_base_temporal(Geometry value, Temporal base){
-		return (TGeogPoint) Factory.create_temporal(functions.tpoint_from_base_temp(ConversionUtils.geography_to_gserialized(value),base.getInner()),getCustomType(),getTemporalType());
+		return (TGeogPoint) Factory.create_temporal(GeneratedFunctions.tpoint_from_base_temp(ConversionUtils.geography_to_gserialized(value),base.getInner()),getCustomType(),getTemporalType());
 	}
 
 
@@ -79,11 +80,11 @@ public interface TGeogPoint extends TPoint {
 	 */
 	static TGeogPoint from_base_time(Geometry value, Time base, TInterpolation interp){
 		if (base instanceof tstzset){
-			return new TGeogPointSeq(functions.tpointseq_from_base_tstzset(ConversionUtils.geography_to_gserialized(value), ((tstzset) base).get_inner()));
+			return new TGeogPointSeq(GeneratedFunctions.tpointseq_from_base_tstzset(ConversionUtils.geography_to_gserialized(value), ((tstzset) base).get_inner()));
 		} else if (base instanceof tstzspan) {
-			return new TGeogPointSeqSet(functions.tpointseq_from_base_tstzspan(ConversionUtils.geography_to_gserialized(value), ((tstzspan) base).get_inner(), interp.getValue()));
+			return new TGeogPointSeqSet(GeneratedFunctions.tpointseq_from_base_tstzspan(ConversionUtils.geography_to_gserialized(value), ((tstzspan) base).get_inner(), interp.getValue()));
 		} else if (base instanceof tstzspanset) {
-			return new TGeogPointSeq(functions.tpointseqset_from_base_tstzspanset(ConversionUtils.geography_to_gserialized(value), ((tstzspanset) base).get_inner(), interp.getValue()));
+			return new TGeogPointSeq(GeneratedFunctions.tpointseqset_from_base_tstzspanset(ConversionUtils.geography_to_gserialized(value), ((tstzspanset) base).get_inner(), interp.getValue()));
 		}
 		else{
 			throw new UnsupportedOperationException("Operation not supported with type " + base.getClass());
@@ -95,7 +96,7 @@ public interface TGeogPoint extends TPoint {
 		Runtime runtime = Runtime.getSystemRuntime();
 		// Allocate memory for an integer (4 bytes) but do not set a value
 		Pointer intPointer = Memory.allocate(runtime, 4);
-		Pointer resPointer= functions.tgeo_values(this.getPointInner(), intPointer);
+		Pointer resPointer= GeneratedFunctions.tgeo_values(this.getPointInner(), intPointer);
 		List<TPoint> pointList= new ArrayList<>();
 		int count= intPointer.getInt(Integer.BYTES);
 		StringBuilder sb = null;
@@ -125,7 +126,7 @@ public interface TGeogPoint extends TPoint {
 	 * @return A new {@link TGeomPoint} object.
 	 */
 	default TGeomPoint to_geometric(){
-		return (TGeomPoint) Factory.create_temporal(functions.tgeography_to_tgeometry(getPointInner()),"Geom",getTemporalType());
+		return (TGeomPoint) Factory.create_temporal(GeneratedFunctions.tgeography_to_tgeometry(getPointInner()),"Geom",getTemporalType());
 
 	}
 
@@ -145,7 +146,7 @@ public interface TGeogPoint extends TPoint {
 	 * @return True if "this" is always equal to "value", False otherwise.
 	 */
 	default boolean always_equal(Geometry value){
-		return functions.always_eq_tgeo_geo(getPointInner(),ConversionUtils.geography_to_gserialized(value)) > 0;
+		return GeneratedFunctions.always_eq_tgeo_geo(getPointInner(),ConversionUtils.geography_to_gserialized(value)) > 0;
 
 	}
 
@@ -160,7 +161,7 @@ public interface TGeogPoint extends TPoint {
 	 * @return True if "this" is always different to "value", False otherwise.
 	 */
 	default boolean always_not_equal(Geometry value){
-		return functions.always_ne_tgeo_geo(getPointInner(),ConversionUtils.geography_to_gserialized(value)) > 0;
+		return GeneratedFunctions.always_ne_tgeo_geo(getPointInner(),ConversionUtils.geography_to_gserialized(value)) > 0;
 	}
 
 
@@ -175,7 +176,7 @@ public interface TGeogPoint extends TPoint {
 	 * @return True if "this" is ever equal to "value", False otherwise.
 	 */
 	default boolean ever_equal(Geometry value){
-		return  functions.ever_eq_tgeo_geo(getPointInner(),ConversionUtils.geography_to_gserialized(value)) > 0;
+		return  GeneratedFunctions.ever_eq_tgeo_geo(getPointInner(),ConversionUtils.geography_to_gserialized(value)) > 0;
 	}
 
 
@@ -190,7 +191,7 @@ public interface TGeogPoint extends TPoint {
 	 * @return True if "this" is ever different to "value", False otherwise.
 	 */
 	default boolean ever_not_equal(Geometry value){
-		return functions.ever_ne_tgeo_geo(getPointInner(),ConversionUtils.geography_to_gserialized(value)) > 0;
+		return GeneratedFunctions.ever_ne_tgeo_geo(getPointInner(),ConversionUtils.geography_to_gserialized(value)) > 0;
 
 	}
 
@@ -241,7 +242,7 @@ public interface TGeogPoint extends TPoint {
 	 * @return A {@link TBool} with the result of the temporal equality relation.
 	 */
 	default TBool temporal_equal(Point other){
-		return (TBool) Factory.create_temporal(functions.teq_tgeo_geo(getPointInner(), ConversionUtils.geography_to_gserialized(other)),getCustomType(),getTemporalType());
+		return (TBool) Factory.create_temporal(GeneratedFunctions.teq_tgeo_geo(getPointInner(), ConversionUtils.geography_to_gserialized(other)),getCustomType(),getTemporalType());
 	}
 
 
@@ -259,7 +260,7 @@ public interface TGeogPoint extends TPoint {
 	 * @return A {@link TBool} with the result of the temporal inequality relation.
 	 */
 	default TBool temporal_not_equal(Point other){
-		return (TBool) Factory.create_temporal(functions.tne_tgeo_geo(getPointInner(), ConversionUtils.geography_to_gserialized(other)),getCustomType(),getTemporalType());
+		return (TBool) Factory.create_temporal(GeneratedFunctions.tne_tgeo_geo(getPointInner(), ConversionUtils.geography_to_gserialized(other)),getCustomType(),getTemporalType());
 	}
 
 

--- a/jmeos-core/src/main/java/types/basic/tpoint/tgeog/TGeogPointInst.java
+++ b/jmeos-core/src/main/java/types/basic/tpoint/tgeog/TGeogPointInst.java
@@ -3,6 +3,7 @@ package types.basic.tpoint.tgeog;
 import jnr.ffi.Pointer;
 import types.basic.tpoint.TPointInst;
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.temporal.TemporalType;
 
 
@@ -36,12 +37,12 @@ public class TGeogPointInst extends TPointInst implements TGeogPoint {
 	 */
 	public TGeogPointInst(String value){
 		super(value);
-		this.inner = functions.tgeogpoint_in(value);
+		this.inner = GeneratedFunctions.tgeogpoint_in(value);
 	}
 
 	@Override
 	public Pointer createStringInner(String str) {
-		return functions.tgeogpoint_in(str);
+		return GeneratedFunctions.tgeogpoint_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tpoint/tgeog/TGeogPointSeq.java
+++ b/jmeos-core/src/main/java/types/basic/tpoint/tgeog/TGeogPointSeq.java
@@ -2,6 +2,7 @@ package types.basic.tpoint.tgeog;
 
 import jnr.ffi.Pointer;
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.basic.tpoint.TPointSeq;
 import types.temporal.TemporalType;
 
@@ -36,13 +37,13 @@ public class TGeogPointSeq extends TPointSeq implements TGeogPoint {
 	 */
 	public TGeogPointSeq(String value){
 		super(value);
-		this.inner = functions.tgeogpoint_in(value);
+		this.inner = GeneratedFunctions.tgeogpoint_in(value);
 	}
 
 
 	@Override
 	public Pointer createStringInner(String str) {
-		return functions.tgeogpoint_in(str);
+		return GeneratedFunctions.tgeogpoint_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tpoint/tgeog/TGeogPointSeqSet.java
+++ b/jmeos-core/src/main/java/types/basic/tpoint/tgeog/TGeogPointSeqSet.java
@@ -2,6 +2,7 @@ package types.basic.tpoint.tgeog;
 
 import jnr.ffi.Pointer;
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.basic.tpoint.TPointSeqSet;
 import types.temporal.TemporalType;
 
@@ -38,12 +39,12 @@ public class TGeogPointSeqSet extends TPointSeqSet implements TGeogPoint {
 	 */
 	public TGeogPointSeqSet(String value){
 		super(value);
-		this.inner = functions.tgeogpoint_in(value);
+		this.inner = GeneratedFunctions.tgeogpoint_in(value);
 	}
 
 	@Override
 	public Pointer createStringInner(String str) {
-		return functions.tgeogpoint_in(str);
+		return GeneratedFunctions.tgeogpoint_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tpoint/tgeom/TGeomPoint.java
+++ b/jmeos-core/src/main/java/types/basic/tpoint/tgeom/TGeomPoint.java
@@ -2,6 +2,7 @@ package types.basic.tpoint.tgeom;
 
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import jnr.ffi.Memory;
 import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
@@ -55,7 +56,7 @@ public interface TGeomPoint extends TPoint {
 	 * @return A new {@link TGeomPoint} object.
 	 */
 	default TGeomPoint from_base_temporal(Geometry value, Temporal base){
-		return (TGeomPoint) Factory.create_temporal(functions.tpoint_from_base_temp(ConversionUtils.geometry_to_gserialized(value),base.getInner()),getCustomType(),getTemporalType());
+		return (TGeomPoint) Factory.create_temporal(GeneratedFunctions.tpoint_from_base_temp(ConversionUtils.geometry_to_gserialized(value),base.getInner()),getCustomType(),getTemporalType());
 	}
 
 
@@ -77,11 +78,11 @@ public interface TGeomPoint extends TPoint {
 	 */
 	static TGeomPoint from_base_time(Geometry value, Time base, TInterpolation interp){
 		if (base instanceof tstzset){
-			return new TGeomPointSeq(functions.tpointseq_from_base_tstzset(ConversionUtils.geometry_to_gserialized(value), ((tstzset) base).get_inner()));
+			return new TGeomPointSeq(GeneratedFunctions.tpointseq_from_base_tstzset(ConversionUtils.geometry_to_gserialized(value), ((tstzset) base).get_inner()));
 		} else if (base instanceof tstzspan) {
-			return new TGeomPointSeqSet(functions.tpointseq_from_base_tstzspan(ConversionUtils.geometry_to_gserialized(value), ((tstzspan) base).get_inner(), interp.getValue()));
+			return new TGeomPointSeqSet(GeneratedFunctions.tpointseq_from_base_tstzspan(ConversionUtils.geometry_to_gserialized(value), ((tstzspan) base).get_inner(), interp.getValue()));
 		} else if (base instanceof tstzspanset) {
-			return new TGeomPointSeq(functions.tpointseq_from_base_tstzset(ConversionUtils.geometry_to_gserialized(value), ((tstzspanset) base).get_inner()));
+			return new TGeomPointSeq(GeneratedFunctions.tpointseq_from_base_tstzset(ConversionUtils.geometry_to_gserialized(value), ((tstzspanset) base).get_inner()));
 		}
 		else{
 			throw new UnsupportedOperationException("Operation not supported with type " + base.getClass());
@@ -103,7 +104,7 @@ public interface TGeomPoint extends TPoint {
 	 * @return A new {@link TGeogPoint} object.
 	 */
 	default TGeogPoint to_geographic(){
-		return (TGeogPoint) Factory.create_temporal(functions.tgeometry_to_tgeography(getPointInner()),getCustomType(),getTemporalType());
+		return (TGeogPoint) Factory.create_temporal(GeneratedFunctions.tgeometry_to_tgeography(getPointInner()),getCustomType(),getTemporalType());
 
 	}
 
@@ -121,7 +122,7 @@ public interface TGeomPoint extends TPoint {
 	 * @return True if "this" is always equal to "value", False otherwise.
 	 */
 	default boolean always_equal(Geometry value){
-		return functions.always_eq_tgeo_geo(getPointInner(),ConversionUtils.geometry_to_gserialized(value)) > 0;
+		return GeneratedFunctions.always_eq_tgeo_geo(getPointInner(),ConversionUtils.geometry_to_gserialized(value)) > 0;
 
 	}
 
@@ -136,7 +137,7 @@ public interface TGeomPoint extends TPoint {
 	 * @return True if "this" is always different to "value", False otherwise.
 	 */
 	default boolean always_not_equal(Geometry value){
-		return (functions.always_ne_tgeo_geo((getPointInner()),ConversionUtils.geometry_to_gserialized(value)) > 0);
+		return (GeneratedFunctions.always_ne_tgeo_geo((getPointInner()),ConversionUtils.geometry_to_gserialized(value)) > 0);
 	}
 
 
@@ -151,7 +152,7 @@ public interface TGeomPoint extends TPoint {
 	 * @return True if "this" is ever equal to "value", False otherwise.
 	 */
 	default boolean ever_equal(Geometry value){
-		return  functions.ever_eq_tgeo_geo(getPointInner(),ConversionUtils.geometry_to_gserialized(value)) > 0;
+		return  GeneratedFunctions.ever_eq_tgeo_geo(getPointInner(),ConversionUtils.geometry_to_gserialized(value)) > 0;
 	}
 
 
@@ -166,7 +167,7 @@ public interface TGeomPoint extends TPoint {
 	 * @return True if "this" is ever different to "value", False otherwise.
 	 */
 	default boolean ever_not_equal(Geometry value){
-		return functions.ever_ne_tgeo_geo(getPointInner(),ConversionUtils.geometry_to_gserialized(value)) > 0;
+		return GeneratedFunctions.ever_ne_tgeo_geo(getPointInner(),ConversionUtils.geometry_to_gserialized(value)) > 0;
 
 	}
 
@@ -216,7 +217,7 @@ public interface TGeomPoint extends TPoint {
 	 * @return A {@link TBool} with the result of the temporal equality relation.
 	 */
 	default TBool temporal_equal(Point other){
-		return (TBool) Factory.create_temporal(functions.teq_tgeo_geo(getPointInner(), ConversionUtils.geometry_to_gserialized(other)),getCustomType(),getTemporalType());
+		return (TBool) Factory.create_temporal(GeneratedFunctions.teq_tgeo_geo(getPointInner(), ConversionUtils.geometry_to_gserialized(other)),getCustomType(),getTemporalType());
 	}
 
 
@@ -234,7 +235,7 @@ public interface TGeomPoint extends TPoint {
 	 * @return A {@link TBool} with the result of the temporal inequality relation.
 	 */
 	default TBool temporal_not_equal(Point other){
-		return (TBool) Factory.create_temporal(functions.tne_tgeo_geo(getPointInner(), ConversionUtils.geometry_to_gserialized(other)),getCustomType(),getTemporalType());
+		return (TBool) Factory.create_temporal(GeneratedFunctions.tne_tgeo_geo(getPointInner(), ConversionUtils.geometry_to_gserialized(other)),getCustomType(),getTemporalType());
 	}
 
 	default GeometrySet value_set(int precision) throws ParseException {
@@ -242,7 +243,7 @@ public interface TGeomPoint extends TPoint {
 		Runtime runtime = Runtime.getSystemRuntime();
 		// Allocate memory for an integer (4 bytes) but do not set a value
 		Pointer intPointer = Memory.allocate(runtime, 4);
-		Pointer resPointer= functions.tgeo_values(this.getPointInner(), intPointer);
+		Pointer resPointer= GeneratedFunctions.tgeo_values(this.getPointInner(), intPointer);
 		List<TPoint> pointList= new ArrayList<>();
 		int count= intPointer.getInt(Integer.BYTES);
 		StringBuilder sb = null;

--- a/jmeos-core/src/main/java/types/basic/tpoint/tgeom/TGeomPointInst.java
+++ b/jmeos-core/src/main/java/types/basic/tpoint/tgeom/TGeomPointInst.java
@@ -2,6 +2,7 @@ package types.basic.tpoint.tgeom;
 
 import jnr.ffi.Pointer;
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.basic.tpoint.TPointInst;
 import types.temporal.TemporalType;
 
@@ -35,13 +36,13 @@ public class TGeomPointInst extends TPointInst implements TGeomPoint {
 	 */
 	public TGeomPointInst(String value){
 		super(value);
-		this.inner = functions.tgeompoint_in(value);
+		this.inner = GeneratedFunctions.tgeompoint_in(value);
 	}
 
 
 	@Override
 	public Pointer createStringInner(String str) {
-		return functions.tgeompoint_in(str);
+		return GeneratedFunctions.tgeompoint_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tpoint/tgeom/TGeomPointSeq.java
+++ b/jmeos-core/src/main/java/types/basic/tpoint/tgeom/TGeomPointSeq.java
@@ -2,6 +2,7 @@ package types.basic.tpoint.tgeom;
 
 import jnr.ffi.Pointer;
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.basic.tpoint.TPointSeq;
 import types.temporal.TemporalType;
 
@@ -35,13 +36,13 @@ public class TGeomPointSeq extends TPointSeq  implements TGeomPoint{
 	 */
 	public TGeomPointSeq(String value){
 		super(value);
-		this.inner = functions.tgeompoint_in(value);
+		this.inner = GeneratedFunctions.tgeompoint_in(value);
 	}
 
 
 	@Override
 	public Pointer createStringInner(String str) {
-		return functions.tgeompoint_in(str);
+		return GeneratedFunctions.tgeompoint_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/tpoint/tgeom/TGeomPointSeqSet.java
+++ b/jmeos-core/src/main/java/types/basic/tpoint/tgeom/TGeomPointSeqSet.java
@@ -2,6 +2,7 @@ package types.basic.tpoint.tgeom;
 
 import jnr.ffi.Pointer;
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.basic.tpoint.TPointSeqSet;
 import types.temporal.TemporalType;
 
@@ -35,13 +36,13 @@ public class TGeomPointSeqSet extends TPointSeqSet implements TGeomPoint{
 	 */
 	public TGeomPointSeqSet(String value){
 		super(value);
-		this.inner = functions.tgeompoint_in(value);
+		this.inner = GeneratedFunctions.tgeompoint_in(value);
 	}
 
 
 	@Override
 	public Pointer createStringInner(String str) {
-		return functions.tgeompoint_in(str);
+		return GeneratedFunctions.tgeompoint_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/ttext/TTextInst.java
+++ b/jmeos-core/src/main/java/types/basic/ttext/TTextInst.java
@@ -1,6 +1,7 @@
 package types.basic.ttext;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import jnr.ffi.Pointer;
 import types.temporal.TInstant;
 import types.temporal.TemporalType;
@@ -39,7 +40,7 @@ public class TTextInst extends TInstant<String> implements TText {
 	 */
 	public TTextInst(String value)  {
 		super(value);
-		this.inner = functions.ttext_in(value);
+		this.inner = GeneratedFunctions.ttext_in(value);
 	}
 
 	/**
@@ -61,7 +62,7 @@ public class TTextInst extends TInstant<String> implements TText {
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.ttext_in(str);
+		return GeneratedFunctions.ttext_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/ttext/TTextSeq.java
+++ b/jmeos-core/src/main/java/types/basic/ttext/TTextSeq.java
@@ -1,6 +1,7 @@
 package types.basic.ttext;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.temporal.TSequence;
 
 import java.util.List;
@@ -50,7 +51,7 @@ public class TTextSeq extends TSequence<String> implements TText{
 	 */
 	public TTextSeq(String value, int interpolation)  {
 		super(value);
-		this.inner = functions.ttext_in(value);
+		this.inner = GeneratedFunctions.ttext_in(value);
 	}
 
 
@@ -66,7 +67,7 @@ public class TTextSeq extends TSequence<String> implements TText{
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.ttext_in(str);
+		return GeneratedFunctions.ttext_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/basic/ttext/TTextSeqSet.java
+++ b/jmeos-core/src/main/java/types/basic/ttext/TTextSeqSet.java
@@ -1,6 +1,7 @@
 package types.basic.ttext;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.temporal.TSequenceSet;
 import jnr.ffi.Pointer;
 import types.temporal.TemporalType;
@@ -36,14 +37,14 @@ public class TTextSeqSet extends TSequenceSet<String> implements TText{
 	 */
 	public TTextSeqSet(String value) {
 		super(value);
-		this.inner = functions.ttext_in(value);
+		this.inner = GeneratedFunctions.ttext_in(value);
 	}
 
 
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.ttext_in(str);
+		return GeneratedFunctions.ttext_in(str);
 	}
 
 	@Override

--- a/jmeos-core/src/main/java/types/boxes/STBox.java
+++ b/jmeos-core/src/main/java/types/boxes/STBox.java
@@ -21,6 +21,7 @@ import types.collections.time.tstzset;
 import types.collections.time.tstzspan;
 import types.collections.time.tstzspanset;
 import functions.*;
+import functions.GeneratedFunctions;
 import types.temporal.Temporal;
 import utils.ConversionUtils;
 import functions.functions;
@@ -73,16 +74,16 @@ public class STBox implements Box {
 	public STBox _get_box(Object other, boolean allow_space_only, boolean allow_time_only){
 		STBox other_box=null;
 		if(allow_space_only && other instanceof Geometry){
-			other_box = new STBox(functions.geo_to_stbox(ConversionUtils.geo_to_gserialized((Geometry) other, this.geodetic())));
+			other_box = new STBox(GeneratedFunctions.geo_to_stbox(ConversionUtils.geo_to_gserialized((Geometry) other, this.geodetic())));
 		} else if (other instanceof TPoint) {
-			other_box = new STBox(functions.tspatial_to_stbox(((TPoint)other).getPointInner()));
+			other_box = new STBox(GeneratedFunctions.tspatial_to_stbox(((TPoint)other).getPointInner()));
 		} else if (allow_time_only) {
 			switch (other) {
 				case STBox st -> other_box = new STBox(st.get_inner());
-				case tstzset p -> other_box = new STBox(functions.tstzset_to_stbox(p.get_inner()));
-				case tstzspan ps -> other_box = new STBox(functions.tstzspan_to_stbox(ps.get_inner()));
-				case Temporal t -> other_box = new STBox(functions.tstzset_to_stbox(functions.temporal_to_tstzspan(t.getInner())));
-				case tstzspanset ts -> other_box = new STBox(functions.tstzspanset_to_stbox(ts.get_inner()));
+				case tstzset p -> other_box = new STBox(GeneratedFunctions.tstzset_to_stbox(p.get_inner()));
+				case tstzspan ps -> other_box = new STBox(GeneratedFunctions.tstzspan_to_stbox(ps.get_inner()));
+				case Temporal t -> other_box = new STBox(GeneratedFunctions.tstzset_to_stbox(GeneratedFunctions.temporal_to_tstzspan(t.getInner())));
+				case tstzspanset ts -> other_box = new STBox(GeneratedFunctions.tstzspanset_to_stbox(ts.get_inner()));
 				default -> throw new TypeNotPresentException(other.getClass().toString(), new Throwable("Operation not supported with this type"));
 			}
 		}
@@ -117,7 +118,7 @@ public class STBox implements Box {
 	 */
 
 	public STBox(final String value){
-		this._inner = functions.stbox_in(value);
+		this._inner = GeneratedFunctions.stbox_in(value);
 	}
 
 	/**
@@ -143,7 +144,7 @@ public class STBox implements Box {
 			tstzspan = new tstzspan(tmin, tmax, tmin_inc, tmax_inc).get_inner();
 		}
 
-		this._inner = functions.stbox_make(hasx, hasz, geodetic, srid, xmin, xmax, ymin, ymax, zmin, zmax, tstzspan);
+		this._inner = GeneratedFunctions.stbox_make(hasx, hasz, geodetic, srid, xmin, xmax, ymin, ymax, zmin, zmax, tstzspan);
 	}
 
 
@@ -196,7 +197,7 @@ public class STBox implements Box {
 	 * @return a STBox instance
 	 */
 	public STBox copy() {
-		return new STBox(functions.stbox_copy(this._inner));
+		return new STBox(GeneratedFunctions.stbox_copy(this._inner));
 	}
 
 	/**
@@ -208,7 +209,7 @@ public class STBox implements Box {
 	 * @return a new STBox instance
 	 */
 	public static STBox from_hexwkb(String hexwkb) {
-		Pointer result = functions.stbox_from_hexwkb(hexwkb);
+		Pointer result = GeneratedFunctions.stbox_from_hexwkb(hexwkb);
 		return new STBox(result);
 	}
 
@@ -224,12 +225,12 @@ public class STBox implements Box {
 	 * @return a new STBox instance
 	 */
 	public static STBox from_geometry(Geometry geom, boolean geodetic) {
-		return new STBox(functions.geo_to_stbox(ConversionUtils.geo_to_gserialized(geom,geodetic)));
+		return new STBox(GeneratedFunctions.geo_to_stbox(ConversionUtils.geo_to_gserialized(geom,geodetic)));
 	}
 
 	public static STBox from_geometry(Geometry geom) {
 		boolean geodetic = false;
-		return new STBox(functions.geo_to_stbox(ConversionUtils.geo_to_gserialized(geom,geodetic)));
+		return new STBox(GeneratedFunctions.geo_to_stbox(ConversionUtils.geo_to_gserialized(geom,geodetic)));
 	}
 
 
@@ -249,9 +250,9 @@ public class STBox implements Box {
 	public static STBox from_time(Time other) {
 		STBox returnValue;
 		switch (other){
-			case tstzset p -> returnValue = new STBox(functions.tstzset_to_stbox(p.get_inner()));
-			case tstzspan ps -> returnValue = new STBox(functions.tstzspan_to_stbox(ps.get_inner()));
-			case tstzspanset ts -> returnValue = new STBox(functions.tstzspanset_to_stbox(ts.get_inner()));
+			case tstzset p -> returnValue = new STBox(GeneratedFunctions.tstzset_to_stbox(p.get_inner()));
+			case tstzspan ps -> returnValue = new STBox(GeneratedFunctions.tstzspan_to_stbox(ps.get_inner()));
+			case tstzspanset ts -> returnValue = new STBox(GeneratedFunctions.tstzspanset_to_stbox(ts.get_inner()));
 			default -> throw new TypeNotPresentException(other.getClass().toString(), new Throwable("Operation not supported with this type"));
 		}
 		return returnValue;
@@ -259,8 +260,8 @@ public class STBox implements Box {
 	
 	/*
 	public STBox from_expanding_bounding_box_geom(Geometry value, float expansion) {
-		Pointer gs = functions.gserialized_in(value.toString(), -1);
-		Pointer result = functions.geo_expand_spatial(gs, expansion);
+		Pointer gs = GeneratedFunctions.gserialized_in(value.toString(), -1);
+		Pointer result = GeneratedFunctions.geo_expand_spatial(gs, expansion);
 		return new STBox(result);
 	}
 
@@ -303,7 +304,7 @@ public class STBox implements Box {
 	 */
 	public static STBox from_geometry_datetime(Geometry geometry, LocalDateTime datetime, boolean geodetic){
         Pointer gs = ConversionUtils.geo_to_gserialized(geometry,geodetic);
-        Pointer result = functions.geo_timestamptz_to_stbox(gs,ConversionUtils.datetimeToTimestampTz(datetime));
+        Pointer result = GeneratedFunctions.geo_timestamptz_to_stbox(gs,ConversionUtils.datetimeToTimestampTz(datetime));
         return new STBox(result);
     }
 
@@ -323,7 +324,7 @@ public class STBox implements Box {
 	 */
     public static STBox from_geometry_tstzspan(Geometry geometry, tstzset tstzset, boolean geodetic){
 		Pointer gs = ConversionUtils.geo_to_gserialized(geometry,geodetic);
-        Pointer result = functions.geo_tstzspan_to_stbox(gs,tstzset.get_inner());
+        Pointer result = GeneratedFunctions.geo_tstzspan_to_stbox(gs,tstzset.get_inner());
         return new STBox(result);
     }
 
@@ -339,7 +340,7 @@ public class STBox implements Box {
 	 * @return A new {@link STBox} instance.
 	 */
     public static STBox from_tpoint(TPoint temporal){
-        return new STBox(functions.tspatial_to_stbox(temporal.getPointInner()));
+        return new STBox(GeneratedFunctions.tspatial_to_stbox(temporal.getPointInner()));
     }
 
 
@@ -354,7 +355,7 @@ public class STBox implements Box {
 	 * @return a String instance
 	 */
 	public String toString(int max_decimals){
-		return functions.stbox_out(this._inner,max_decimals);
+		return GeneratedFunctions.stbox_out(this._inner,max_decimals);
 	}
 
 
@@ -370,7 +371,7 @@ public class STBox implements Box {
 	 * @return a new tstzset instance
 	 */
     public tstzset to_tstzspan() {
-        Pointer result = functions.stbox_to_tstzspan(this._inner);
+        Pointer result = GeneratedFunctions.stbox_to_tstzspan(this._inner);
         return new tstzset(result);
     }
 
@@ -387,7 +388,7 @@ public class STBox implements Box {
 	 * @throws ParseException
 	 */
 	public Geometry to_geometry(int precision) throws ParseException {
-		return ConversionUtils.gserialized_to_shapely_geometry(functions.stbox_to_geo(this._inner),precision);
+		return ConversionUtils.gserialized_to_shapely_geometry(GeneratedFunctions.stbox_to_geo(this._inner),precision);
 	}
 
 
@@ -401,7 +402,7 @@ public class STBox implements Box {
 	 * @return True if "this" has a spatial dimension, False otherwise.
 	 */
 	public boolean has_xy() {
-		return functions.stbox_hasx(this._inner);
+		return GeneratedFunctions.stbox_hasx(this._inner);
 	}
 
 
@@ -413,7 +414,7 @@ public class STBox implements Box {
 	 * @return True if "this" has a Z dimension, False otherwise.
 	 */
 	public boolean has_z() {
-		return functions.stbox_hasz(this._inner);
+		return GeneratedFunctions.stbox_hasz(this._inner);
 	}
 
 
@@ -425,7 +426,7 @@ public class STBox implements Box {
 	 * @return True if "this" has a time dimension, False otherwise.
 	 */
 	public boolean has_t() {
-		return functions.stbox_hast(this._inner);
+		return GeneratedFunctions.stbox_hast(this._inner);
 	}
 
 	/**
@@ -436,7 +437,7 @@ public class STBox implements Box {
 	 * @return True if "this" is geodetic, False otherwise.
 	 */
 	public boolean geodetic() {
-		return functions.stbox_isgeodetic(this._inner);
+		return GeneratedFunctions.stbox_isgeodetic(this._inner);
 	}
 
 
@@ -449,7 +450,7 @@ public class STBox implements Box {
 	 * @return A {@link Float} with the minimum X coordinate of "this".
 	 */
     public float xmin(){
-		return (float) functions.stbox_xmin(this._inner).getDouble(0);
+		return (float) GeneratedFunctions.stbox_xmin(this._inner).getDouble(0);
     }
 
 	/**
@@ -461,7 +462,7 @@ public class STBox implements Box {
 	 * @return A {@link Float} with the minimum Y coordinate of "this".
 	 */
     public float ymin(){
-		return (float) functions.stbox_ymin(this._inner).getDouble(0);
+		return (float) GeneratedFunctions.stbox_ymin(this._inner).getDouble(0);
     }
 
 	/**
@@ -473,7 +474,7 @@ public class STBox implements Box {
 	 * @return A {@link Float} with the minimum Z coordinate of "this".
 	 */
     public float zmin(){
-		return (float) functions.stbox_zmin(this._inner).getDouble(0);
+		return (float) GeneratedFunctions.stbox_zmin(this._inner).getDouble(0);
     }
 
 	/**
@@ -485,7 +486,7 @@ public class STBox implements Box {
 	 * @return A {@link Float} with the minimum T coordinate of "this".
 	 */
     public float tmin(){
-		return (float) functions.stbox_tmin(this._inner).getDouble(0);
+		return (float) GeneratedFunctions.stbox_tmin(this._inner).getDouble(0);
     }
 
 	/**
@@ -497,7 +498,7 @@ public class STBox implements Box {
 	 * @return A {@link Float} with the maximum X coordinate of "this".
 	 */
     public float xmax(){
-		return (float) functions.stbox_xmax(this._inner).getDouble(0);
+		return (float) GeneratedFunctions.stbox_xmax(this._inner).getDouble(0);
     }
 
 	/**
@@ -509,7 +510,7 @@ public class STBox implements Box {
 	 * @return A {@link Float} with the maximum Y coordinate of "this".
 	 */
     public float ymax(){
-		return (float) functions.stbox_ymax(this._inner).getDouble(0);
+		return (float) GeneratedFunctions.stbox_ymax(this._inner).getDouble(0);
     }
 
 	/**
@@ -521,7 +522,7 @@ public class STBox implements Box {
 	 * @return A {@link Float} with the maximum Z coordinate of "this".
 	 */
     public float zmax(){
-		return (float) functions.stbox_zmax(this._inner).getDouble(0);
+		return (float) GeneratedFunctions.stbox_zmax(this._inner).getDouble(0);
     }
 
 	/**
@@ -533,7 +534,7 @@ public class STBox implements Box {
 	 * @return A {@link Float} with the maximum T coordinate of "this".
 	 */
     public float tmax(){
-		return (float) functions.stbox_tmax(this._inner).getDouble(0);
+		return (float) GeneratedFunctions.stbox_tmax(this._inner).getDouble(0);
     }
 
 	public boolean get_tmin_inc(){
@@ -575,7 +576,7 @@ public class STBox implements Box {
 	 * @return an Integer with the SRID of "this"
 	 */
 	public int srid(){
-		return functions.stbox_srid(this._inner);
+		return GeneratedFunctions.stbox_srid(this._inner);
 	}
 
 
@@ -588,7 +589,7 @@ public class STBox implements Box {
 	 * @return a new STBox instance
 	 */
 	public STBox set_srid(int value) {
-		return new STBox(functions.stbox_set_srid(this._inner,value));
+		return new STBox(GeneratedFunctions.stbox_set_srid(this._inner,value));
 	}
 	
 
@@ -605,7 +606,7 @@ public class STBox implements Box {
 	 * @return A new {@link STBox} instance.
 	 */
 	public STBox get_space(){
-		return new STBox(functions.stbox_get_space(this._inner));
+		return new STBox(GeneratedFunctions.stbox_get_space(this._inner));
 	}
 
 
@@ -627,8 +628,8 @@ public class STBox implements Box {
 	 * @return A new {@link STBox} instance.
 	 */
 	public STBox expand_stbox(STBox stbox, STBox other) {
-		Pointer result = functions.stbox_copy(this._inner);
-//		functions.stbox_expand_space(other._inner, result);
+		Pointer result = GeneratedFunctions.stbox_copy(this._inner);
+//		GeneratedFunctions.stbox_expand_space(other._inner, result);
 		return new STBox(result);
 	}
 
@@ -652,7 +653,7 @@ public class STBox implements Box {
 	public STBox expand_numerical(Number value) {
 		STBox result = null;
 		if(value instanceof Integer || value instanceof Float){
-			result = new STBox(functions.stbox_expand_space(this.get_inner(), (double) value.floatValue()));
+			result = new STBox(GeneratedFunctions.stbox_expand_space(this.get_inner(), (double) value.floatValue()));
 		}
 		return result;
 	}
@@ -668,8 +669,8 @@ public class STBox implements Box {
 	 * @return a new STBox instance
 	 */
 	public STBox round(int maxdd) {
-		Pointer new_inner = functions.stbox_copy(this._inner);
-		functions.stbox_round(new_inner,maxdd);
+		Pointer new_inner = GeneratedFunctions.stbox_copy(this._inner);
+		GeneratedFunctions.stbox_round(new_inner,maxdd);
 		return new STBox(new_inner);
 	}
 
@@ -691,7 +692,7 @@ public class STBox implements Box {
 	 * @return a new STBox instance
 	 */
 	public STBox union(STBox other, boolean strict) {
-		return new STBox(functions.union_stbox_stbox(this._inner, other._inner, strict));
+		return new STBox(GeneratedFunctions.union_stbox_stbox(this._inner, other._inner, strict));
 	}
 
 
@@ -718,7 +719,7 @@ public class STBox implements Box {
 	 * @return a new STBox instance if the instersection is not empty, `None` otherwise.
 	 */
 	public STBox intersection(STBox other) {
-		return new STBox(functions.intersection_stbox_stbox(this._inner,other.get_inner()));
+		return new STBox(GeneratedFunctions.intersection_stbox_stbox(this._inner,other.get_inner()));
 	}
 
 
@@ -754,7 +755,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" and "other" are adjacent, "false" otherwise.
 	 */
 	public boolean is_adjacent(TemporalObject other) {
-		return functions.adjacent_stbox_stbox(this._inner,this._get_box(other,true,true).get_inner());
+		return GeneratedFunctions.adjacent_stbox_stbox(this._inner,this._get_box(other,true,true).get_inner());
 	}
 
 	/**
@@ -767,7 +768,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is contained in "other", "false" otherwise.
 	 */
 	public boolean is_contained_in(TemporalObject other) {
-		return functions.contained_stbox_stbox(this._inner,this._get_box(other,true,true).get_inner());
+		return GeneratedFunctions.contained_stbox_stbox(this._inner,this._get_box(other,true,true).get_inner());
 	}
 
 	/**
@@ -782,7 +783,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" contains "other", "false otherwise.
 	 */
 	public boolean contains(TemporalObject other) {
-		return functions.contains_stbox_stbox(this._inner,this._get_box(other,true,true).get_inner());
+		return GeneratedFunctions.contains_stbox_stbox(this._inner,this._get_box(other,true,true).get_inner());
 	}
 
 	/**
@@ -795,7 +796,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" overlaps "other", "false" otherwise.
 	 */
 	public boolean overlaps(TemporalObject other)  {
-		return functions.overlaps_stbox_stbox(this._inner,this._get_box(other,true,true).get_inner());
+		return GeneratedFunctions.overlaps_stbox_stbox(this._inner,this._get_box(other,true,true).get_inner());
 	}
 
 	/**
@@ -808,7 +809,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is the same as "other", "false" otherwise.
 	 */
 	public boolean is_same(TemporalObject other) {
-		return functions.same_stbox_stbox(this._inner,this._get_box(other,true,true).get_inner());
+		return GeneratedFunctions.same_stbox_stbox(this._inner,this._get_box(other,true,true).get_inner());
 	}
 
 	/**
@@ -821,7 +822,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is strictly to the left of "other", "false" otherwise.
 	 */
 	public boolean is_left(TemporalObject other) {
-		return functions.left_stbox_stbox(this._inner,this._get_box(other).get_inner());
+		return GeneratedFunctions.left_stbox_stbox(this._inner,this._get_box(other).get_inner());
 	}
 
 	/**
@@ -834,7 +835,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is to the left of "other", "false" otherwise.
 	 */
 	public boolean is_over_or_left(TemporalObject other) {
-		return functions.overleft_stbox_stbox(this._inner,this._get_box(other).get_inner());
+		return GeneratedFunctions.overleft_stbox_stbox(this._inner,this._get_box(other).get_inner());
 	}
 
 	/**
@@ -847,7 +848,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is strictly to the right of "other", "false" otherwise.
 	 */
 	public boolean is_right(TemporalObject other) {
-		return functions.right_stbox_stbox(this._inner,this._get_box(other).get_inner());
+		return GeneratedFunctions.right_stbox_stbox(this._inner,this._get_box(other).get_inner());
 	}
 
 	/**
@@ -861,7 +862,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is to the right of "other", "false" otherwise.
 	 */
 	public boolean is_over_or_right(TemporalObject other) {
-		return functions.overright_stbox_stbox(this._inner,this._get_box(other).get_inner());
+		return GeneratedFunctions.overright_stbox_stbox(this._inner,this._get_box(other).get_inner());
 	}
 
 	/**
@@ -874,7 +875,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is strictly below of "other", "false" otherwise.
 	 */
 	public boolean is_below(TemporalObject other) {
-		return functions.below_stbox_stbox(this._inner,this._get_box(other).get_inner());
+		return GeneratedFunctions.below_stbox_stbox(this._inner,this._get_box(other).get_inner());
 	}
 
 
@@ -889,7 +890,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is below "other" allowing for overlap, "false" otherwise.
 	 */
 	public boolean is_over_or_below(TemporalObject other) {
-		return functions.overbelow_stbox_stbox(this._inner,this._get_box(other).get_inner());
+		return GeneratedFunctions.overbelow_stbox_stbox(this._inner,this._get_box(other).get_inner());
 	}
 
 
@@ -903,7 +904,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is strictly above of "other", "false" otherwise.
 	 */
 	public boolean is_above(TemporalObject other) {
-		return functions.above_stbox_stbox(this._inner,this._get_box(other).get_inner());
+		return GeneratedFunctions.above_stbox_stbox(this._inner,this._get_box(other).get_inner());
 	}
 
 
@@ -918,7 +919,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is above "other" allowing for overlap, "false" otherwise.
 	 */
 	public boolean is_over_or_above(TemporalObject other) {
-		return functions.overabove_stbox_stbox(this._inner,this._get_box(other).get_inner());
+		return GeneratedFunctions.overabove_stbox_stbox(this._inner,this._get_box(other).get_inner());
 	}
 
 
@@ -932,7 +933,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is strictly in front of "other", "false" otherwise.
 	 */
 	public boolean is_front(TemporalObject other) {
-		return functions.front_stbox_stbox(this._inner,this._get_box(other).get_inner());
+		return GeneratedFunctions.front_stbox_stbox(this._inner,this._get_box(other).get_inner());
 	}
 
 
@@ -947,7 +948,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is in front of "other" allowing for overlap, "false" otherwise.
 	 */
 	public boolean is_over_or_front(TemporalObject other) {
-		return functions.overfront_stbox_stbox(this._inner,this._get_box(other).get_inner());
+		return GeneratedFunctions.overfront_stbox_stbox(this._inner,this._get_box(other).get_inner());
 	}
 
 
@@ -961,7 +962,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is strictly behind of "other", "false" otherwise.
 	 */
 	public boolean is_behind(TemporalObject other) {
-		return functions.back_stbox_stbox(this._inner,this._get_box(other).get_inner());
+		return GeneratedFunctions.back_stbox_stbox(this._inner,this._get_box(other).get_inner());
 	}
 
 
@@ -976,7 +977,7 @@ public class STBox implements Box {
 	 * @return "true" if "this" is behind of "other" allowing for overlap, "false" otherwise.
 	 */
 	public boolean is_over_or_behind(TemporalObject other) {
-		return functions.overback_stbox_stbox(this._inner,this._get_box(other).get_inner());
+		return GeneratedFunctions.overback_stbox_stbox(this._inner,this._get_box(other).get_inner());
 	}
 
 
@@ -1058,7 +1059,7 @@ public class STBox implements Box {
 	 * @return a Float instance with the distance between the nearest points of "this" and "``other``".
 	 */
 	public float nearest_approach_distance_geom(Geometry other) {
-		return (float) functions.nad_stbox_geo(this._inner, ConversionUtils.geo_to_gserialized(other, this.geodetic()));
+		return (float) GeneratedFunctions.nad_stbox_geo(this._inner, ConversionUtils.geo_to_gserialized(other, this.geodetic()));
 	}
 
 
@@ -1076,7 +1077,7 @@ public class STBox implements Box {
 	 * @return a Float instance with the distance between the nearest points of "this" and "``other``".
 	 */
 	public float nearest_approach_distance_stbox(STBox other) {
-		return (float) functions.nad_stbox_stbox(this._inner, other._inner);
+		return (float) GeneratedFunctions.nad_stbox_stbox(this._inner, other._inner);
 	}
 
 
@@ -1094,7 +1095,7 @@ public class STBox implements Box {
 	 * @return a Float instance with the distance between the nearest points of "this" and "``other``".
 	 */
 	public float nearest_approach_distance_tpoint(TPoint other) {
-		return (float) functions.nad_tgeo_stbox(this._inner, other.getPointInner());
+		return (float) GeneratedFunctions.nad_tgeo_stbox(this._inner, other.getPointInner());
 	}
 
 
@@ -1112,7 +1113,7 @@ public class STBox implements Box {
 	 */
 	public boolean eq(Box other) {
 		boolean result;
-		result = other instanceof STBox && functions.stbox_eq(this._inner, ((STBox) other).get_inner());
+		result = other instanceof STBox && GeneratedFunctions.stbox_eq(this._inner, ((STBox) other).get_inner());
 		return result;
 	}
 
@@ -1128,7 +1129,7 @@ public class STBox implements Box {
 	 */
 	public boolean notEquals(Box other) {
 		boolean result;
-		result = !(other instanceof STBox) || functions.stbox_ne(this._inner, ((STBox) other).get_inner());
+		result = !(other instanceof STBox) || GeneratedFunctions.stbox_ne(this._inner, ((STBox) other).get_inner());
 		return result;
 	}
 
@@ -1144,7 +1145,7 @@ public class STBox implements Box {
 	 */
 	public boolean lessThan(Box other) throws OperationNotSupportedException {
 		if (other instanceof STBox){
-			return functions.stbox_lt(this._inner,((STBox) other).get_inner());
+			return GeneratedFunctions.stbox_lt(this._inner,((STBox) other).get_inner());
 		}
 		else{
 			throw new OperationNotSupportedException("Operation not supported with this type.");
@@ -1164,7 +1165,7 @@ public class STBox implements Box {
 	 */
 	public boolean lessThanOrEqual(Box other) throws OperationNotSupportedException {
 		if (other instanceof STBox){
-			return functions.stbox_le(this._inner,((STBox) other).get_inner());
+			return GeneratedFunctions.stbox_le(this._inner,((STBox) other).get_inner());
 		}
 		else{
 			throw new OperationNotSupportedException("Operation not supported with this type.");
@@ -1184,7 +1185,7 @@ public class STBox implements Box {
 	 */
 	public boolean greaterThan(Box other) throws OperationNotSupportedException {
 		if (other instanceof STBox){
-			return functions.stbox_gt(this._inner,((STBox) other).get_inner());
+			return GeneratedFunctions.stbox_gt(this._inner,((STBox) other).get_inner());
 		}
 		else{
 			throw new OperationNotSupportedException("Operation not supported with this type.");
@@ -1203,7 +1204,7 @@ public class STBox implements Box {
 	 */
 	public boolean greaterThanOrEqual(Box other) throws OperationNotSupportedException {
 		if (other instanceof STBox){
-			return functions.stbox_ge(this._inner,((STBox) other).get_inner());
+			return GeneratedFunctions.stbox_ge(this._inner,((STBox) other).get_inner());
 		}
 		else{
 			throw new OperationNotSupportedException("Operation not supported with this type.");
@@ -1213,9 +1214,9 @@ public class STBox implements Box {
 	@Override
 	public tstzspan to_period(){
 		error_handler_fn errorHandler = new error_handler();
-		functions.meos_initialize_timezone("UTC");
-		functions.meos_initialize_error_handler(errorHandler);
-		return new tstzspan(functions.stbox_to_tstzspan(this._inner));
+		GeneratedFunctions.meos_initialize_timezone("UTC");
+		GeneratedFunctions.meos_initialize_error_handler(errorHandler);
+		return new tstzspan(GeneratedFunctions.stbox_to_tstzspan(this._inner));
 	}
 
 	/* ------------------------- Splitting ----------------------------------- */
@@ -1244,7 +1245,7 @@ public class STBox implements Box {
 		Runtime runtime = Runtime.getSystemRuntime();
 		// Allocate memory for an integer (4 bytes) but do not set a value
 		Pointer intPointer = Memory.allocate(runtime, 4);
-		Pointer resPointer= functions.stbox_quad_split(this.get_inner(), intPointer);
+		Pointer resPointer= GeneratedFunctions.stbox_quad_split(this.get_inner(), intPointer);
 		int count= intPointer.getInt(Integer.BYTES);
 		List<STBox> stBoxList= new ArrayList<>();
 		for(int i=0;i<count;i++){
@@ -1290,7 +1291,7 @@ public class STBox implements Box {
 		Runtime runtime = Runtime.getSystemRuntime();
 		// Allocate memory for an integer (4 bytes) but do not set a value
 		Pointer intPointer = Memory.allocate(runtime, 4);
-		Pointer resPointer= functions.stbox_quad_split(this.get_inner(), intPointer); // Populate boxes and count
+		Pointer resPointer= GeneratedFunctions.stbox_quad_split(this.get_inner(), intPointer); // Populate boxes and count
 		List<STBox> boxes= new ArrayList<>();
 		for(int i=0;i<8;i++){
 			STBox stBox= new STBox(resPointer.getPointer(i*Long.BYTES));
@@ -1355,7 +1356,7 @@ public class STBox implements Box {
 //		}
 //		else{
 //			if(duration instanceof String){
-//				dt= functions.interval_in(duration.toString(), -1);
+//				dt= GeneratedFunctions.interval_in(duration.toString(), -1);
 //			}
 //			else dt = null;
 //		}
@@ -1366,11 +1367,11 @@ public class STBox implements Box {
 //		}
 //		else{
 //			if(start instanceof String){
-//				st= functions.timestamptz_in(start.toString(), -1);
+//				st= GeneratedFunctions.timestamptz_in(start.toString(), -1);
 //			}
 //			else{
 //				if(this.has_t()){
-//					st= functions.timestamptz_in("2000-01-03", -1);
+//					st= GeneratedFunctions.timestamptz_in("2000-01-03", -1);
 //				}
 //				else{
 //					st= null;
@@ -1384,10 +1385,10 @@ public class STBox implements Box {
 //		}
 //		else{
 //			if(this.geodetic()){
-//				gs= functions.pgis_geography_in("Point(0 0 0)", -1);
+//				gs= GeneratedFunctions.pgis_geography_in("Point(0 0 0)", -1);
 //			}
 //			else{
-//				gs= functions.pgis_geometry_in("Point (0 0 0)", -1);
+//				gs= GeneratedFunctions.pgis_geometry_in("Point (0 0 0)", -1);
 //			}
 //		}
 //
@@ -1395,7 +1396,7 @@ public class STBox implements Box {
 //		Runtime runtime = Runtime.getSystemRuntime();
 //		// Allocate memory for an integer (4 bytes) but do not set a value
 //		Pointer intPointer = Memory.allocate(Runtime.getRuntime(runtime), 4);
-//		Pointer resPointer= functions.stbox_space_time_tiles(this.get_inner(), sz, sz, sz, dt, gs, st);
+//		Pointer resPointer= GeneratedFunctions.stbox_space_time_tiles(this.get_inner(), sz, sz, sz, dt, gs, st);
 //		int count= intPointer.getInt(Integer.BYTES);
 //		List<STBox> stBoxes= new ArrayList<>();
 //		for(int i=0;i<count;i++){

--- a/jmeos-core/src/main/java/types/boxes/TBox.java
+++ b/jmeos-core/src/main/java/types/boxes/TBox.java
@@ -7,6 +7,7 @@ import types.basic.tfloat.TFloat;
 import types.basic.tint.TInt;
 import types.basic.tnumber.TNumber;
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.collections.base.Span;
 import types.collections.number.FloatSpan;
 import functions.*;
@@ -78,7 +79,7 @@ public class TBox implements Box {
 	 * @param value - the string with the TBox value
 	 */
 	public TBox(String value){
-		this._inner = functions.tbox_in(value);
+		this._inner = GeneratedFunctions.tbox_in(value);
 	}
 
 
@@ -128,7 +129,7 @@ public class TBox implements Box {
 		}
         assert span != null;
         assert p != null;
-        this._inner = functions.tbox_make(span.get_inner(),p.get_inner());
+        this._inner = GeneratedFunctions.tbox_make(span.get_inner(),p.get_inner());
 	}
 
 
@@ -140,7 +141,7 @@ public class TBox implements Box {
 	 * @return a new TBox instance
 	 */
 	public TBox copy(){
-		return new TBox(functions.tbox_copy(this._inner));
+		return new TBox(GeneratedFunctions.tbox_copy(this._inner));
 	}
 
 
@@ -154,7 +155,7 @@ public class TBox implements Box {
 	 * @return a new TBox instance
 	 */
 	public static TBox from_hexwkb(String hexwkb) {
-		return new TBox(functions.tbox_from_hexwkb(hexwkb));
+		return new TBox(GeneratedFunctions.tbox_from_hexwkb(hexwkb));
 	}
 
 
@@ -162,10 +163,10 @@ public class TBox implements Box {
 	public static TBox from_value_number(Number value)  {
 		TBox tbox = null;
 		if(value instanceof Integer){
-			tbox = new TBox(functions.int_to_tbox((int)value));
+			tbox = new TBox(GeneratedFunctions.int_to_tbox((int)value));
 		}
 		else if (value instanceof Float){
-			tbox = new TBox(functions.float_to_tbox((float)value));
+			tbox = new TBox(GeneratedFunctions.float_to_tbox((float)value));
 		}
 		return tbox;
 	}
@@ -188,10 +189,10 @@ public class TBox implements Box {
 	public static TBox from_value_span(Span span) {
 		TBox tbox = null;
 		if(span instanceof IntSpan){
-			tbox = new TBox(functions.span_to_tbox(span.get_inner()));
+			tbox = new TBox(GeneratedFunctions.span_to_tbox(span.get_inner()));
 		}
 		else if (span instanceof FloatSpan){
-			tbox = new TBox(functions.span_to_tbox(span.get_inner()));
+			tbox = new TBox(GeneratedFunctions.span_to_tbox(span.get_inner()));
 		}
 		return tbox;
 	}
@@ -219,13 +220,13 @@ public class TBox implements Box {
 	public static TBox from_time(Time time) throws Exception {
 		TBox tbox = null;
 		if (time instanceof tstzset){
-			tbox = new TBox(functions.set_to_tbox(((tstzset) time).get_inner()));
+			tbox = new TBox(GeneratedFunctions.set_to_tbox(((tstzset) time).get_inner()));
 		}
 		else if (time instanceof tstzspan){
-			tbox = new TBox(functions.span_to_tbox(((tstzspan) time).get_inner()));
+			tbox = new TBox(GeneratedFunctions.span_to_tbox(((tstzspan) time).get_inner()));
 		}
 		else if (time instanceof tstzspanset){
-			tbox = new TBox(functions.spanset_to_tbox(((tstzspanset) time).get_inner()));
+			tbox = new TBox(GeneratedFunctions.spanset_to_tbox(((tstzspanset) time).get_inner()));
 		}
 		else {
 			throw new Exception("Operation not supported with this type.");
@@ -254,31 +255,31 @@ public class TBox implements Box {
 		TBox tbox = null;
 		if (value instanceof Integer) {
 			if (time instanceof LocalDateTime) {
-				tbox = new TBox(functions.int_timestamptz_to_tbox((Integer) value, ConversionUtils.datetimeToTimestampTz((LocalDateTime) time)));
+				tbox = new TBox(GeneratedFunctions.int_timestamptz_to_tbox((Integer) value, ConversionUtils.datetimeToTimestampTz((LocalDateTime) time)));
 			}
 			else if (time instanceof tstzspan) {
-				tbox = new TBox(functions.int_tstzspan_to_tbox((Integer) value, ((tstzspan) time).get_inner()));
+				tbox = new TBox(GeneratedFunctions.int_tstzspan_to_tbox((Integer) value, ((tstzspan) time).get_inner()));
 			}
 		} else if (value instanceof Float) {
 			if (time instanceof LocalDateTime) {
-				tbox = new TBox(functions.float_timestamptz_to_tbox((Float) value, ConversionUtils.datetimeToTimestampTz((LocalDateTime) time)));
+				tbox = new TBox(GeneratedFunctions.float_timestamptz_to_tbox((Float) value, ConversionUtils.datetimeToTimestampTz((LocalDateTime) time)));
 			}
 			else if (time instanceof tstzspan) {
-				tbox = new TBox(functions.float_tstzspan_to_tbox((Float) value, ((tstzspan) time).get_inner()));
+				tbox = new TBox(GeneratedFunctions.float_tstzspan_to_tbox((Float) value, ((tstzspan) time).get_inner()));
 			}
 		} else if (value instanceof IntSpan) {
 			if (time instanceof LocalDateTime) {
-				tbox = new TBox(functions.numspan_timestamptz_to_tbox(((IntSpan) value).get_inner(), ConversionUtils.datetimeToTimestampTz((LocalDateTime) time)));
+				tbox = new TBox(GeneratedFunctions.numspan_timestamptz_to_tbox(((IntSpan) value).get_inner(), ConversionUtils.datetimeToTimestampTz((LocalDateTime) time)));
 			}
 			else if (time instanceof tstzspan) {
-				tbox = new TBox(functions.numspan_tstzspan_to_tbox(((IntSpan) value).get_inner(), ((tstzspan) time).get_inner()));
+				tbox = new TBox(GeneratedFunctions.numspan_tstzspan_to_tbox(((IntSpan) value).get_inner(), ((tstzspan) time).get_inner()));
 			}
 		} else if (value instanceof FloatSpan) {
 			if (time instanceof LocalDateTime) {
-				tbox = new TBox(functions.numspan_timestamptz_to_tbox(((FloatSpan) value).get_inner(), ConversionUtils.datetimeToTimestampTz((LocalDateTime) time)));
+				tbox = new TBox(GeneratedFunctions.numspan_timestamptz_to_tbox(((FloatSpan) value).get_inner(), ConversionUtils.datetimeToTimestampTz((LocalDateTime) time)));
 			}
 			else if (time instanceof tstzspan) {
-				tbox = new TBox(functions.numspan_tstzspan_to_tbox(((FloatSpan) value).get_inner(), ((tstzspan) time).get_inner()));
+				tbox = new TBox(GeneratedFunctions.numspan_tstzspan_to_tbox(((FloatSpan) value).get_inner(), ((tstzspan) time).get_inner()));
 			}
 		}
 		return tbox;
@@ -296,7 +297,7 @@ public class TBox implements Box {
 	 * @return A new {@link TBox} instance
 	 */
 	public static TBox from_tnumber(TNumber temporal){
-		return new TBox(functions.tnumber_to_tbox(temporal.getNumberInner()));
+		return new TBox(GeneratedFunctions.tnumber_to_tbox(temporal.getNumberInner()));
 	}
 
 
@@ -323,7 +324,7 @@ public class TBox implements Box {
 	 * @return a String instance
 	 */
 	public String toString(int max_decimals){
-		return functions.tbox_out(this._inner,max_decimals);
+		return GeneratedFunctions.tbox_out(this._inner,max_decimals);
 	}
 
 
@@ -340,7 +341,7 @@ public class TBox implements Box {
 	 * @return A new {@link FloatSpan} instance
 	 */
 	public FloatSpan to_floatspan(){
-		return new FloatSpan(functions.tbox_to_floatspan(this._inner));
+		return new FloatSpan(GeneratedFunctions.tbox_to_floatspan(this._inner));
 	}
 
 
@@ -354,9 +355,9 @@ public class TBox implements Box {
 	 */
 	public tstzspan to_period(){
 		error_handler_fn errorHandler = new error_handler();
-		functions.meos_initialize_timezone("UTC");
-		functions.meos_initialize_error_handler(errorHandler);
-		return new tstzspan(functions.tbox_to_tstzspan(this._inner));
+		GeneratedFunctions.meos_initialize_timezone("UTC");
+		GeneratedFunctions.meos_initialize_error_handler(errorHandler);
+		return new tstzspan(GeneratedFunctions.tbox_to_tstzspan(this._inner));
 	}
 
     /* ------------------------- Accessors ------------------------------------- */
@@ -371,7 +372,7 @@ public class TBox implements Box {
 	 * @return True if "this" has a numeric dimension, False otherwise
 	 */
 	public boolean has_x(){
-		return functions.tbox_hasx(this._inner);
+		return GeneratedFunctions.tbox_hasx(this._inner);
 	}
 
 	/**
@@ -383,7 +384,7 @@ public class TBox implements Box {
 	 * @return True if "this" has a temporal dimension, False otherwise
 	 */
 	public boolean has_t(){
-		return functions.tbox_hast(this._inner);
+		return GeneratedFunctions.tbox_hast(this._inner);
 	}
 
 
@@ -408,13 +409,13 @@ public class TBox implements Box {
 	public TBox expand(Object obj)   {
 		Pointer result = null;
 		if(obj instanceof Duration){
-			result= functions.tbox_expand_time(this._inner, ConversionUtils.timedelta_to_interval((Duration) obj));
+			result= GeneratedFunctions.tbox_expand_time(this._inner, ConversionUtils.timedelta_to_interval((Duration) obj));
 		}
 		else if(obj instanceof Integer){
-			result = functions.tintbox_expand(this._inner,(int)obj);
+			result = GeneratedFunctions.tintbox_expand(this._inner,(int)obj);
 		}
 		else if(obj instanceof Float){
-			result = functions.tfloatbox_expand(this._inner,(float)obj);
+			result = GeneratedFunctions.tfloatbox_expand(this._inner,(float)obj);
 		}
 		return new TBox(result);
 	}
@@ -442,8 +443,8 @@ public class TBox implements Box {
 	 * @return a {@link TBox instance}
 	 */
 	public TBox round(int maxdd)  {
-		Pointer new_inner = functions.tbox_copy(this._inner);
-		new_inner= functions.tbox_round(new_inner,maxdd);
+		Pointer new_inner = GeneratedFunctions.tbox_copy(this._inner);
+		new_inner= GeneratedFunctions.tbox_round(new_inner,maxdd);
 		return new TBox(new_inner);
 	}
 
@@ -475,12 +476,12 @@ public class TBox implements Box {
 	public boolean is_adjacent_tbox(Object other) {
 		boolean result = false;
 		if (other instanceof TBox) {
-			result = functions.adjacent_tbox_tbox(this._inner, ((TBox) other).get_inner());
+			result = GeneratedFunctions.adjacent_tbox_tbox(this._inner, ((TBox) other).get_inner());
 		}
 		else if (other instanceof TNumber){
-			result = functions.adjacent_tbox_tbox(this._inner,functions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
+			result = GeneratedFunctions.adjacent_tbox_tbox(this._inner,GeneratedFunctions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
 		} else if (other instanceof FloatSpan) {
-			result = functions.adjacent_span_span(this._inner,((FloatSpan) other).get_inner());
+			result = GeneratedFunctions.adjacent_span_span(this._inner,((FloatSpan) other).get_inner());
 		}
 
 
@@ -510,9 +511,9 @@ public class TBox implements Box {
 	public boolean is_contained_in(Object other)  {
 		boolean result = false;
 		if(other instanceof TBox){
-			result = functions.contained_tbox_tbox(this._inner, ((TBox) other).get_inner());
+			result = GeneratedFunctions.contained_tbox_tbox(this._inner, ((TBox) other).get_inner());
 		} else if (other instanceof TNumber){
-			result = functions.contained_tbox_tbox(this._inner,functions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
+			result = GeneratedFunctions.contained_tbox_tbox(this._inner,GeneratedFunctions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
 		}
 		return result;
 	}
@@ -540,10 +541,10 @@ public class TBox implements Box {
 	public boolean contains(Object other) {
 		boolean result = false;
 		if(other instanceof TBox){
-			result = functions.contains_tbox_tbox(this._inner, ((TBox) other).get_inner());
+			result = GeneratedFunctions.contains_tbox_tbox(this._inner, ((TBox) other).get_inner());
 		}
 		else if(other instanceof TNumber){
-			result = functions.contains_tbox_tbox(this._inner, functions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
+			result = GeneratedFunctions.contains_tbox_tbox(this._inner, GeneratedFunctions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
 		}
 		return result;
 	}
@@ -562,9 +563,9 @@ public class TBox implements Box {
 	public boolean overlaps(Object other) {
 		boolean result = false;
 		if(other instanceof TBox){
-			result = functions.overlaps_tbox_tbox(this._inner, ((TBox) other).get_inner());
+			result = GeneratedFunctions.overlaps_tbox_tbox(this._inner, ((TBox) other).get_inner());
 		} else if(other instanceof TNumber){
-			result = functions.overlaps_tbox_tbox(this._inner, functions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
+			result = GeneratedFunctions.overlaps_tbox_tbox(this._inner, GeneratedFunctions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
 		}
 
 		return result;
@@ -584,10 +585,10 @@ public class TBox implements Box {
 	public boolean is_same(Object other)  {
 		boolean result = false;
 		if(other instanceof TBox){
-			result = functions.same_tbox_tbox(this._inner, ((TBox) other).get_inner());
+			result = GeneratedFunctions.same_tbox_tbox(this._inner, ((TBox) other).get_inner());
 		}
 		else if(other instanceof TNumber){
-			result = functions.same_tbox_tbox(this._inner, functions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
+			result = GeneratedFunctions.same_tbox_tbox(this._inner, GeneratedFunctions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
 		}
 
 		return result;
@@ -611,10 +612,10 @@ public class TBox implements Box {
 	public boolean is_left(Object other) {
 		boolean result = false;
 		if(other instanceof TBox){
-			result = functions.left_tbox_tbox(this._inner, ((TBox) other).get_inner());
+			result = GeneratedFunctions.left_tbox_tbox(this._inner, ((TBox) other).get_inner());
 		}
 		else if(other instanceof TNumber){
-			result = functions.left_tbox_tbox(this._inner, functions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
+			result = GeneratedFunctions.left_tbox_tbox(this._inner, GeneratedFunctions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
 		}
 
 		return result;
@@ -635,10 +636,10 @@ public class TBox implements Box {
 	public boolean is_over_or_left(Object other) {
 		boolean result = false;
 		if(other instanceof TBox){
-			result = functions.overleft_tbox_tbox(this._inner, ((TBox) other).get_inner());
+			result = GeneratedFunctions.overleft_tbox_tbox(this._inner, ((TBox) other).get_inner());
 		}
 		else if(other instanceof TNumber){
-			result = functions.overleft_tbox_tbox(this._inner, functions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
+			result = GeneratedFunctions.overleft_tbox_tbox(this._inner, GeneratedFunctions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
 		}
 
 		return result;
@@ -659,10 +660,10 @@ public class TBox implements Box {
 	public boolean is_right(Object other)  {
 		boolean result = false;
 		if(other instanceof TBox){
-			result = functions.right_tbox_tbox(this._inner, ((TBox) other).get_inner());
+			result = GeneratedFunctions.right_tbox_tbox(this._inner, ((TBox) other).get_inner());
 		}
 		else if(other instanceof TNumber){
-			result = functions.right_tbox_tbox(this._inner, functions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
+			result = GeneratedFunctions.right_tbox_tbox(this._inner, GeneratedFunctions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
 		}
 
 		return result;
@@ -684,10 +685,10 @@ public class TBox implements Box {
 	public boolean is_over_or_right(Object other)  {
 		boolean result = false;
 		if(other instanceof TBox){
-			result = functions.overright_tbox_tbox(this._inner, ((TBox) other).get_inner());
+			result = GeneratedFunctions.overright_tbox_tbox(this._inner, ((TBox) other).get_inner());
 		}
 		else if(other instanceof TNumber){
-			result = functions.overright_tbox_tbox(this._inner, functions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
+			result = GeneratedFunctions.overright_tbox_tbox(this._inner, GeneratedFunctions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
 		}
 
 		return result;
@@ -708,10 +709,10 @@ public class TBox implements Box {
 	public boolean is_before(Object other)  {
 		boolean result = false;
 		if(other instanceof TBox){
-			result = functions.before_tbox_tbox(this._inner, ((TBox) other).get_inner());
+			result = GeneratedFunctions.before_tbox_tbox(this._inner, ((TBox) other).get_inner());
 		}
 		else if(other instanceof TNumber){
-			result = functions.before_tbox_tbox(this._inner, functions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
+			result = GeneratedFunctions.before_tbox_tbox(this._inner, GeneratedFunctions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
 		}
 
 		return result;
@@ -733,10 +734,10 @@ public class TBox implements Box {
 	public boolean is_over_or_before(Object other)  {
 		boolean result = false;
 		if(other instanceof TBox){
-			result = functions.overbefore_tbox_tbox(this._inner, ((TBox) other).get_inner());
+			result = GeneratedFunctions.overbefore_tbox_tbox(this._inner, ((TBox) other).get_inner());
 		}
 		else if(other instanceof TNumber){
-			result = functions.overbefore_tbox_tbox(this._inner, functions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
+			result = GeneratedFunctions.overbefore_tbox_tbox(this._inner, GeneratedFunctions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
 		}
 
 		return result;
@@ -757,10 +758,10 @@ public class TBox implements Box {
 	public boolean is_after(Object other)  {
 		boolean result = false;
 		if(other instanceof TBox){
-			result = functions.after_tbox_tbox(this._inner, ((TBox) other).get_inner());
+			result = GeneratedFunctions.after_tbox_tbox(this._inner, ((TBox) other).get_inner());
 		}
 		else if(other instanceof TNumber){
-			result = functions.after_tbox_tbox(this._inner, functions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
+			result = GeneratedFunctions.after_tbox_tbox(this._inner, GeneratedFunctions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
 		}
 
 		return result;
@@ -783,11 +784,11 @@ public class TBox implements Box {
 	public boolean is_over_or_after(Object other) {
 		boolean result = false;
 		if(other instanceof TBox){
-			result = functions.overafter_tbox_tbox(this._inner, ((TBox) other).get_inner());
+			result = GeneratedFunctions.overafter_tbox_tbox(this._inner, ((TBox) other).get_inner());
 		}
 
 		else if(other instanceof TNumber){
-			result = functions.overafter_tbox_tbox(this._inner, functions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
+			result = GeneratedFunctions.overafter_tbox_tbox(this._inner, GeneratedFunctions.tnumber_to_tbox(((TNumber) other).getNumberInner()));
 		}
 
 		return result;
@@ -806,7 +807,7 @@ public class TBox implements Box {
 	 * @return a {@link TBox} instance
 	 */
 	public TBox union(TBox other, boolean strict) {
-		return new TBox(functions.union_tbox_tbox(this._inner, other._inner,strict));
+		return new TBox(GeneratedFunctions.union_tbox_tbox(this._inner, other._inner,strict));
 	}
 
 
@@ -832,7 +833,7 @@ public class TBox implements Box {
 	 * @return a {@link TBox} instance if the instersection is not empty, "null" otherwise.
 	 */
 	public TBox intersection(TBox other) {
-		return new TBox(functions.intersection_tbox_tbox(this._inner,other.get_inner()));
+		return new TBox(GeneratedFunctions.intersection_tbox_tbox(this._inner,other.get_inner()));
 	}
 
 
@@ -863,8 +864,8 @@ public class TBox implements Box {
 
 	public boolean is_float(){
 		TBox tbox= new TBox(this._inner);
-		tstzspan t= new tstzspan(functions.stbox_to_tstzspan(this._inner));
-		FloatSpan f= new FloatSpan(functions.spanset_span(tbox.get_inner()));
+		tstzspan t= new tstzspan(GeneratedFunctions.stbox_to_tstzspan(this._inner));
+		FloatSpan f= new FloatSpan(GeneratedFunctions.spanset_span(tbox.get_inner()));
         return tbox.get_inner() == t.get_inner();
 	}
 
@@ -872,17 +873,17 @@ public class TBox implements Box {
 		float result = 0.0f;
 		if(other instanceof TBox){
 			if (this.is_float()){
-				return (float) functions.nad_tboxfloat_tboxfloat(this._inner, ((TBox) other)._inner);
+				return (float) GeneratedFunctions.nad_tboxfloat_tboxfloat(this._inner, ((TBox) other)._inner);
 			}
 			else{
-				return (float) functions.nad_tboxint_tboxint(this._inner, ((TBox) other)._inner);
+				return (float) GeneratedFunctions.nad_tboxint_tboxint(this._inner, ((TBox) other)._inner);
 			}
 		}
 		else if(other instanceof TInt){
-			result = (float) functions.nad_tint_tbox(((TInt) other).getNumberInner(), this._inner);
+			result = (float) GeneratedFunctions.nad_tint_tbox(((TInt) other).getNumberInner(), this._inner);
 		}
 		else if(other instanceof TFloat){
-			result = (float) functions.nad_tfloat_tbox(((TFloat) other).getNumberInner(), this._inner);
+			result = (float) GeneratedFunctions.nad_tfloat_tbox(((TFloat) other).getNumberInner(), this._inner);
 		}
 
 		return result;
@@ -905,7 +906,7 @@ public class TBox implements Box {
 	 */
 	public boolean eq(Box other) {
 		boolean result;
-		result = other instanceof TBox && functions.tbox_eq(this._inner, ((TBox) other).get_inner());
+		result = other instanceof TBox && GeneratedFunctions.tbox_eq(this._inner, ((TBox) other).get_inner());
 		return result;
 	}
 
@@ -922,7 +923,7 @@ public class TBox implements Box {
 	 */
 	public boolean notEquals(Box other) {
 		boolean result;
-		result = !(other instanceof TBox) || functions.stbox_ne(this._inner, ((TBox) other).get_inner());
+		result = !(other instanceof TBox) || GeneratedFunctions.stbox_ne(this._inner, ((TBox) other).get_inner());
 		return result;
 	}
 
@@ -942,7 +943,7 @@ public class TBox implements Box {
 	 */
 	public boolean lessThan(Box other) throws Exception {
 		if (other instanceof TBox){
-			return functions.tbox_lt(this._inner,((TBox) other).get_inner());
+			return GeneratedFunctions.tbox_lt(this._inner,((TBox) other).get_inner());
 		}
 		else{
 			throw new Exception("Operation not supported with this type.");
@@ -965,7 +966,7 @@ public class TBox implements Box {
 	 */
 	public boolean lessThanOrEqual(Box other) throws Exception {
 		if (other instanceof TBox){
-			return functions.tbox_le(this._inner,((TBox) other).get_inner());
+			return GeneratedFunctions.tbox_le(this._inner,((TBox) other).get_inner());
 		}
 		else{
 			throw new Exception("Operation not supported with this type.");
@@ -988,7 +989,7 @@ public class TBox implements Box {
 	 */
 	public boolean greaterThan(Box other) throws Exception {
 		if (other instanceof TBox){
-			return functions.tbox_gt(this._inner,((TBox) other).get_inner());
+			return GeneratedFunctions.tbox_gt(this._inner,((TBox) other).get_inner());
 		}
 		else{
 			throw new Exception("Operation not supported with this type.");
@@ -1010,7 +1011,7 @@ public class TBox implements Box {
 	 */
 	public boolean greaterThanOrEqual(Box other) throws Exception {
 		if (other instanceof TBox){
-			return functions.tbox_ge(this._inner,((TBox) other).get_inner());
+			return GeneratedFunctions.tbox_ge(this._inner,((TBox) other).get_inner());
 		}
 		else{
 			throw new Exception("Operation not supported with this type.");

--- a/jmeos-core/src/main/java/types/collections/base/Set.java
+++ b/jmeos-core/src/main/java/types/collections/base/Set.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import functions.functions;
+import functions.GeneratedFunctions;
 
 /**
  * Abstract class that represents a set of temporal object
@@ -44,7 +45,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     /*
     public SpanSet to_spanset(){
-        return new SpanSet(functions.set_to_spanset(this._inner));
+        return new SpanSet(GeneratedFunctions.set_to_spanset(this._inner));
     }
 
      */
@@ -58,7 +59,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     /*
     public Span to_span(){
-        return new Span(functions.set_span(this._inner));
+        return new Span(GeneratedFunctions.set_span(this._inner));
     }
 
      */
@@ -73,7 +74,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
 
     public Pointer copy() {
-        return functions.set_copy(this._inner);
+        return GeneratedFunctions.set_copy(this._inner);
     }
 
     /**
@@ -82,7 +83,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
 
     public <T> T from_wkb(Pointer wkb, long size, Class<T> spansetType) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Pointer spanPointer = functions.set_from_wkb(wkb, size);
+        Pointer spanPointer = GeneratedFunctions.set_from_wkb(wkb, size);
         Constructor<T> constructor = spansetType.getConstructor(Pointer.class);
         return constructor.newInstance(spanPointer);
     }
@@ -93,7 +94,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
 
     public <T> T from_hexwkb(String hexwkb, Class<T> spansetType) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Pointer spanPointer = functions.set_from_hexwkb(hexwkb);
+        Pointer spanPointer = GeneratedFunctions.set_from_hexwkb(hexwkb);
         Constructor<T> constructor = spansetType.getConstructor(Pointer.class);
         return constructor.newInstance(spanPointer);
     }
@@ -103,7 +104,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      * @return Pointer type
      */
     public Pointer as_wkb() {
-        return functions.set_as_wkb(this._inner, (byte) 4);
+        return GeneratedFunctions.set_as_wkb(this._inner, (byte) 4);
     }
 
     /**
@@ -111,7 +112,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      * @return String type
      */
     public String as_hexwkb() {
-        String[] result= new String[]{functions.set_as_hexwkb(this._inner, (byte) -1)};
+        String[] result= new String[]{GeneratedFunctions.set_as_hexwkb(this._inner, (byte) -1)};
         System.out.println(result[0]);
         return result[0];
     }
@@ -124,7 +125,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      *     @return A new {@link Span} instance
      */
     public <T> T to_span(Class<T> spanType) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Pointer spanPointer = functions.set_to_span(this._inner);
+        Pointer spanPointer = GeneratedFunctions.set_to_span(this._inner);
         Constructor<T> constructor = spanType.getConstructor(Pointer.class);
         return constructor.newInstance(spanPointer);
     }
@@ -138,7 +139,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
 
     public <T> T to_spanset(Class<T> spansetType) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Pointer spanPointer = functions.set_to_spanset(this._inner);
+        Pointer spanPointer = GeneratedFunctions.set_to_spanset(this._inner);
         Constructor<T> constructor = spansetType.getConstructor(Pointer.class);
         return constructor.newInstance(spanPointer);
     }
@@ -152,7 +153,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      * @return An {@link Integer}
      */
     public int num_elements(){
-        return functions.set_num_values(this._inner);
+        return GeneratedFunctions.set_num_values(this._inner);
     }
 
     /**
@@ -217,7 +218,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      * @return A new {@link Integer} instance
      */
     public long hash(){
-        return functions.set_hash(this._inner);
+        return GeneratedFunctions.set_hash(this._inner);
     }
 
 
@@ -244,7 +245,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     public boolean is_contained_in(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return functions.contained_set_set(this._inner, ((Set<?>) other)._inner);
+            return GeneratedFunctions.contained_set_set(this._inner, ((Set<?>) other)._inner);
         }
         else{
             throw new Exception("Operation not supported with this type");
@@ -267,7 +268,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     public boolean contains(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return functions.contains_set_set(this._inner, ((Set<?>) other)._inner);
+            return GeneratedFunctions.contains_set_set(this._inner, ((Set<?>) other)._inner);
         }
         else{
             throw new Exception("Operation not supported with this type");
@@ -292,7 +293,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     public boolean overlaps(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return functions.overlaps_set_set(this._inner, ((Set<?>) other)._inner);
+            return GeneratedFunctions.overlaps_set_set(this._inner, ((Set<?>) other)._inner);
         }
         else{
             throw new Exception("Operation not supported with this type");
@@ -321,7 +322,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     public boolean is_left(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return functions.left_set_set(this._inner, ((Set<?>) other)._inner);
+            return GeneratedFunctions.left_set_set(this._inner, ((Set<?>) other)._inner);
         }
         else{
             throw new Exception("Operation not supported with this type");
@@ -345,7 +346,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     public boolean is_over_or_left(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return functions.overleft_set_set(this._inner, ((Set<?>) other)._inner);
+            return GeneratedFunctions.overleft_set_set(this._inner, ((Set<?>) other)._inner);
         }
         else{
             throw new Exception("Operation not supported with this type");
@@ -371,7 +372,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     public boolean is_over_or_right(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return functions.overright_set_set(this._inner, ((Set<?>) other)._inner);
+            return GeneratedFunctions.overright_set_set(this._inner, ((Set<?>) other)._inner);
         }
         else{
             throw new Exception("Operation not supported with this type");
@@ -398,7 +399,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     public boolean is_right(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return functions.right_set_set(this._inner, ((Set<?>) other)._inner);
+            return GeneratedFunctions.right_set_set(this._inner, ((Set<?>) other)._inner);
         }
         else{
             throw new Exception("Operation not supported with this type");
@@ -424,11 +425,11 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
 //    public float distance(Base other) throws Exception {
 //        if (other instanceof Set<?>){
-//            return (float) functions.distance_floatset_floatset(this._inner, ((Set<?>) other)._inner);
+//            return (float) GeneratedFunctions.distance_floatset_floatset(this._inner, ((Set<?>) other)._inner);
 //        } else if (other instanceof Span<?>) {
-//            return (float) functions.distance_floatspan_floatspan(functions.set_to_span(this._inner), ((Span<?>) other).get_inner());
+//            return (float) GeneratedFunctions.distance_floatspan_floatspan(GeneratedFunctions.set_to_span(this._inner), ((Span<?>) other).get_inner());
 //        } else if (other instanceof SpanSet<?>) {
-//            return (float) functions.distance_floatspanset_floatspan(this._inner,((SpanSet<?>) other).get_inner());
+//            return (float) GeneratedFunctions.distance_floatspanset_floatspan(this._inner,((SpanSet<?>) other).get_inner());
 //        }
 //        else {
 //            throw new Exception("Operation not supported with this type");
@@ -437,7 +438,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
 
 
 //    public <T> T distance(Object other) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-////        Pointer spanPointer = functions.set_to_spanset(this._inner);
+////        Pointer spanPointer = GeneratedFunctions.set_to_spanset(this._inner);
 ////        Constructor<T> constructor = spansetType.getConstructor(Pointer.class);
 //        return constructor.newInstance(spanPointer);
 //    }
@@ -469,9 +470,9 @@ public abstract class Set<T extends Object> implements Collection, Base {
 
     public boolean is_adjacent(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.adjacent_span_span(this._inner, ((Span<?>) other).get_inner());
+            return GeneratedFunctions.adjacent_span_span(this._inner, ((Span<?>) other).get_inner());
         } else if (other instanceof SpanSet<?>) {
-            return functions.adjacent_spanset_span(((SpanSet<?>) other).get_inner(),this._inner);
+            return GeneratedFunctions.adjacent_spanset_span(((SpanSet<?>) other).get_inner(),this._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -496,7 +497,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     private Base intersection(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.intersection_set_set(this._inner, ((Set<?>) other)._inner));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.intersection_set_set(this._inner, ((Set<?>) other)._inner));
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -527,7 +528,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
     */
     private Base minus(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.minus_set_set(this._inner, ((Set<?>) other).get_inner()));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.minus_set_set(this._inner, ((Set<?>) other).get_inner()));
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -587,7 +588,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
     */
     private Base union(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.union_set_set(this._inner, ((Set<?>) other)._inner));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.union_set_set(this._inner, ((Set<?>) other)._inner));
         }
         else {
             throw new Exception("Operation not supported with " + other + " type");
@@ -621,7 +622,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     public boolean eq(Base other){
         if (other instanceof Set<?>){
-            return functions.set_eq(this._inner,((Set<?>) other)._inner);
+            return GeneratedFunctions.set_eq(this._inner,((Set<?>) other)._inner);
         }
         else {
             return false;
@@ -641,7 +642,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     public boolean notEquals(Base other){
         if (other instanceof Set<?>){
-            return functions.set_ne(this._inner,((Set<?>) other)._inner);
+            return GeneratedFunctions.set_ne(this._inner,((Set<?>) other)._inner);
         }
         else {
             return true;
@@ -662,7 +663,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     public boolean lessThan(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return functions.set_lt(this._inner,((Set<?>) other)._inner);
+            return GeneratedFunctions.set_lt(this._inner,((Set<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -684,7 +685,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     public boolean lessThanOrEqual(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return functions.set_le(this._inner,((Set<?>) other)._inner);
+            return GeneratedFunctions.set_le(this._inner,((Set<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -706,7 +707,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     public boolean greaterThan(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return functions.set_gt(this._inner,((Set<?>) other)._inner);
+            return GeneratedFunctions.set_gt(this._inner,((Set<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -728,7 +729,7 @@ public abstract class Set<T extends Object> implements Collection, Base {
      */
     public boolean greaterThanOrEqual(Base other) throws Exception {
         if (other instanceof Set<?>){
-            return functions.set_ge(this._inner,((Set<?>) other)._inner);
+            return GeneratedFunctions.set_ge(this._inner,((Set<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");

--- a/jmeos-core/src/main/java/types/collections/base/Span.java
+++ b/jmeos-core/src/main/java/types/collections/base/Span.java
@@ -2,6 +2,7 @@ package types.collections.base;
 
 import jnr.ffi.Pointer;
 import functions.functions;
+import functions.GeneratedFunctions;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -80,7 +81,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public T copy(Class<T> span) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException
     {
-        Pointer spanPointer = functions.span_copy(this._inner);
+        Pointer spanPointer = GeneratedFunctions.span_copy(this._inner);
         return span.getConstructor(Pointer.class).newInstance(spanPointer);
     }
 
@@ -89,7 +90,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      * @return Pointer type
      */
     public <T> T from_wkb(Pointer wkb, long size, Class<T> spansetType) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Pointer spanPointer = functions.span_from_wkb(wkb, size);
+        Pointer spanPointer = GeneratedFunctions.span_from_wkb(wkb, size);
         Constructor<T> constructor = spansetType.getConstructor(Pointer.class);
         return constructor.newInstance(spanPointer);
     }
@@ -100,10 +101,10 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
 //    public static T from_hexwkb(String hexwkb)
 //    {
-//        return functions.span_from_hexwkb(hexwkb);
+//        return GeneratedFunctions.span_from_hexwkb(hexwkb);
 //    }
     public static <T> T from_hexwkb(String hexwkb, Class<T> spanType) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Pointer spanPointer = functions.span_from_hexwkb(hexwkb);
+        Pointer spanPointer = GeneratedFunctions.span_from_hexwkb(hexwkb);
         Constructor<T> constructor = spanType.getConstructor(Pointer.class);
         return constructor.newInstance(spanPointer);
     }
@@ -113,7 +114,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      * @return Pointer type
      */
     public Pointer as_wkb() {
-        return functions.span_as_wkb(this._inner, (byte) 4);
+        return GeneratedFunctions.span_as_wkb(this._inner, (byte) 4);
     }
 
     /**
@@ -121,7 +122,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      * @return String type
      */
     public String as_hexwkb() {
-        String[] result= new String[]{functions.span_as_hexwkb(this._inner, (byte) -1)};
+        String[] result= new String[]{GeneratedFunctions.span_as_hexwkb(this._inner, (byte) -1)};
 //        System.out.println(result[0]);
         return result[0];
     }
@@ -131,12 +132,12 @@ public abstract class Span<T extends Object> implements Collection, Base{
      * @return String type
      */
 //    public T to_spanset(Class<T> spansettype) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-//        Pointer spanPointer = functions.span_to_spanset(this._inner);
+//        Pointer spanPointer = GeneratedFunctions.span_to_spanset(this._inner);
 //        return spansettype.getConstructor(Pointer.class).newInstance(spanPointer);
 //    }
 
     public <T> T to_spanset(Class<T> spansetType) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Pointer spanPointer = functions.span_to_spanset(this._inner);
+        Pointer spanPointer = GeneratedFunctions.span_to_spanset(this._inner);
         Constructor<T> constructor = spansetType.getConstructor(Pointer.class);
         return constructor.newInstance(spanPointer);
     }
@@ -149,7 +150,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      * @return True if the lower bound of the period is inclusive and False otherwise
      */
     public boolean lower_inc(){
-        return functions.span_lower_inc(this._inner);
+        return GeneratedFunctions.span_lower_inc(this._inner);
     }
 
 
@@ -161,7 +162,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      * @return True if the upper bound of the period is inclusive and False otherwise
      */
     public boolean upper_inc(){
-        return functions.span_upper_inc(this._inner);
+        return GeneratedFunctions.span_upper_inc(this._inner);
     }
 
 
@@ -173,7 +174,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      * @return Returns a {@link Float} representing the duration of the period in seconds
      */
     public float width(){
-        return (float) functions.floatspan_width(this._inner);
+        return (float) GeneratedFunctions.floatspan_width(this._inner);
     }
 
     /**
@@ -184,7 +185,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      * @return A new {@link Integer} instance
      */
     public long hash(){
-        return functions.span_hash(this._inner);
+        return GeneratedFunctions.span_hash(this._inner);
     }
 
 
@@ -207,9 +208,9 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean is_adjacent(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.adjacent_span_span(this._inner, ((Span<?>) other)._inner);
+            return GeneratedFunctions.adjacent_span_span(this._inner, ((Span<?>) other)._inner);
         } else if (other instanceof SpanSet<?>) {
-            return functions.adjacent_spanset_span(((SpanSet<?>) other).get_inner(),this._inner);
+            return GeneratedFunctions.adjacent_spanset_span(((SpanSet<?>) other).get_inner(),this._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -233,9 +234,9 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean is_contained_in(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.contained_span_span(this._inner, ((Span<?>) other)._inner);
+            return GeneratedFunctions.contained_span_span(this._inner, ((Span<?>) other)._inner);
         } else if (other instanceof SpanSet<?>) {
-            return functions.contained_span_spanset(this._inner, ((SpanSet<?>) other).get_inner());
+            return GeneratedFunctions.contained_span_spanset(this._inner, ((SpanSet<?>) other).get_inner());
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -262,9 +263,9 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean contains(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.contains_span_span(this._inner, ((Span<?>) other)._inner);
+            return GeneratedFunctions.contains_span_span(this._inner, ((Span<?>) other)._inner);
         } else if (other instanceof SpanSet<?>) {
-            return functions.contains_span_spanset(this._inner, ((SpanSet<?>) other).get_inner());
+            return GeneratedFunctions.contains_span_spanset(this._inner, ((SpanSet<?>) other).get_inner());
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -288,9 +289,9 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean overlaps(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.overlaps_span_span(this._inner, ((Span<?>) other)._inner);
+            return GeneratedFunctions.overlaps_span_span(this._inner, ((Span<?>) other)._inner);
         } else if (other instanceof SpanSet<?>) {
-            return functions.overlaps_spanset_span(((SpanSet<?>) other).get_inner(),this._inner);
+            return GeneratedFunctions.overlaps_spanset_span(((SpanSet<?>) other).get_inner(),this._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -300,9 +301,9 @@ public abstract class Span<T extends Object> implements Collection, Base{
 
     public boolean is_same(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.span_eq(this._inner, ((Span<?>) other)._inner);
+            return GeneratedFunctions.span_eq(this._inner, ((Span<?>) other)._inner);
         } else if (other instanceof SpanSet<?>) {
-            return functions.span_eq(this._inner,functions.spanset_span(((SpanSet<?>) other).get_inner()));
+            return GeneratedFunctions.span_eq(this._inner,GeneratedFunctions.spanset_span(((SpanSet<?>) other).get_inner()));
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -328,9 +329,9 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean is_left(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.left_span_span(this._inner, ((Span<?>) other)._inner);
+            return GeneratedFunctions.left_span_span(this._inner, ((Span<?>) other)._inner);
         } else if (other instanceof SpanSet<?>) {
-            return functions.left_span_spanset(this._inner, ((SpanSet<?>) other).get_inner());
+            return GeneratedFunctions.left_span_spanset(this._inner, ((SpanSet<?>) other).get_inner());
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -354,9 +355,9 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean is_over_or_left(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.overleft_span_span(this._inner, ((Span<?>) other)._inner);
+            return GeneratedFunctions.overleft_span_span(this._inner, ((Span<?>) other)._inner);
         } else if (other instanceof SpanSet<?>) {
-            return functions.overleft_span_spanset(this._inner, ((SpanSet<?>) other).get_inner());
+            return GeneratedFunctions.overleft_span_spanset(this._inner, ((SpanSet<?>) other).get_inner());
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -380,9 +381,9 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean is_right(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.right_span_span(this._inner, ((Span<?>) other)._inner);
+            return GeneratedFunctions.right_span_span(this._inner, ((Span<?>) other)._inner);
         } else if (other instanceof SpanSet<?>) {
-            return functions.right_span_spanset(this._inner, ((SpanSet<?>) other).get_inner());
+            return GeneratedFunctions.right_span_spanset(this._inner, ((SpanSet<?>) other).get_inner());
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -411,9 +412,9 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean is_over_or_right(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.overright_span_span(this._inner, ((Span<?>) other)._inner);
+            return GeneratedFunctions.overright_span_span(this._inner, ((Span<?>) other)._inner);
         } else if (other instanceof SpanSet<?>) {
-            return functions.overright_span_spanset(this._inner, ((SpanSet<?>) other).get_inner());
+            return GeneratedFunctions.overright_span_spanset(this._inner, ((SpanSet<?>) other).get_inner());
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -441,9 +442,9 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
 //    public float distance(Base other) throws Exception {
 //        if (other instanceof Span<?>){
-//            return (float) functions.distance_floatspan_floatspan(this._inner, ((Span<?>) other)._inner);
+//            return (float) GeneratedFunctions.distance_floatspan_floatspan(this._inner, ((Span<?>) other)._inner);
 //        } else if (other instanceof SpanSet<?>) {
-//            return (float) functions.distance_floatspanset_floatspan(((SpanSet<?>) other).get_inner(),this._inner);
+//            return (float) GeneratedFunctions.distance_floatspanset_floatspan(((SpanSet<?>) other).get_inner(),this._inner);
 //        }
 //        else {
 //            throw new Exception("Operation not supported with this type");
@@ -475,9 +476,9 @@ public abstract class Span<T extends Object> implements Collection, Base{
 
     private Base intersection(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.intersection_span_span(this._inner, ((Span<?>) other)._inner));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.intersection_span_span(this._inner, ((Span<?>) other)._inner));
         } else if (other instanceof SpanSet<?>) {
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.intersection_spanset_span(((SpanSet<?>) other).get_inner(),this._inner));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.intersection_spanset_span(((SpanSet<?>) other).get_inner(),this._inner));
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -491,7 +492,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
 
     protected Base minus(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.minus_span_span(this._inner, ((Span<?>) other).get_inner()));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.minus_span_span(this._inner, ((Span<?>) other).get_inner()));
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -513,9 +514,9 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     protected Base union(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.union_span_span(this._inner, ((Span<?>) other)._inner));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.union_span_span(this._inner, ((Span<?>) other)._inner));
         } else if (other instanceof SpanSet<?>) {
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.union_spanset_span(((SpanSet<?>) other).get_inner(),this._inner));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.union_spanset_span(((SpanSet<?>) other).get_inner(),this._inner));
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -543,7 +544,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean eq(Base other){
         if (other instanceof Span<?>){
-            return functions.span_eq(this._inner,((Span<?>) other)._inner);
+            return GeneratedFunctions.span_eq(this._inner,((Span<?>) other)._inner);
         }
         else {
             return false;
@@ -563,7 +564,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean notEquals(Base other){
         if (other instanceof Span<?>){
-            return functions.span_ne(this._inner,((Span<?>) other)._inner);
+            return GeneratedFunctions.span_ne(this._inner,((Span<?>) other)._inner);
         }
         else {
             return true;
@@ -585,7 +586,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean lessThan(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.span_lt(this._inner,((Span<?>) other)._inner);
+            return GeneratedFunctions.span_lt(this._inner,((Span<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -607,7 +608,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean lessThanOrEqual(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.span_le(this._inner,((Span<?>) other)._inner);
+            return GeneratedFunctions.span_le(this._inner,((Span<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -629,7 +630,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean greaterThan(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.span_gt(this._inner,((Span<?>) other)._inner);
+            return GeneratedFunctions.span_gt(this._inner,((Span<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -650,7 +651,7 @@ public abstract class Span<T extends Object> implements Collection, Base{
      */
     public boolean greaterThanOrEqual(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.span_ge(this._inner,((Span<?>) other)._inner);
+            return GeneratedFunctions.span_ge(this._inner,((Span<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");

--- a/jmeos-core/src/main/java/types/collections/base/SpanSet.java
+++ b/jmeos-core/src/main/java/types/collections/base/SpanSet.java
@@ -6,6 +6,7 @@ import jnr.ffi.Memory;
 import functions.GeneratedFunctions;
 import jnr.ffi.Pointer;
 import functions.functions;
+import functions.GeneratedFunctions;
 import types.collections.number.FloatSpan;
 import types.collections.number.FloatSpanSet;
 import types.collections.number.IntSpan;
@@ -62,7 +63,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
 
     public Pointer copy() {
-        return functions.spanset_copy(this._inner);
+        return GeneratedFunctions.spanset_copy(this._inner);
     }
 
     /**
@@ -70,7 +71,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      * @return Pointer type
      */
     public <T> T from_wkb(Pointer wkb, long size, Class<T> spansetType) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Pointer spanPointer = functions.spanset_from_wkb(wkb, size);
+        Pointer spanPointer = GeneratedFunctions.spanset_from_wkb(wkb, size);
         Constructor<T> constructor = spansetType.getConstructor(Pointer.class);
         return constructor.newInstance(spanPointer);
     }
@@ -81,7 +82,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      * @return T type
      */
     public static <T> T from_hexwkb(String hexwkb, Class<T> spansetType) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Pointer spanPointer = functions.spanset_from_hexwkb(hexwkb);
+        Pointer spanPointer = GeneratedFunctions.spanset_from_hexwkb(hexwkb);
         Constructor<T> constructor = spansetType.getConstructor(Pointer.class);
         return constructor.newInstance(spanPointer);
     }
@@ -92,7 +93,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
          * @return Pointer type
          */
         public Pointer as_wkb() {
-            return functions.spanset_as_wkb(this._inner, (byte) 4);
+            return GeneratedFunctions.spanset_as_wkb(this._inner, (byte) 4);
         }
 
     /**
@@ -100,7 +101,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      * @return String type
      */
     public String as_hexwkb() {
-        String[] result= new String[]{functions.spanset_as_hexwkb(this._inner, (byte) -1)};
+        String[] result= new String[]{GeneratedFunctions.spanset_as_hexwkb(this._inner, (byte) -1)};
 //        System.out.println(result[0]);
         return result[0];
     }
@@ -111,12 +112,12 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      * @return String type
      */
 //    public T to_span(Class<T> spantype) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-//        Pointer spanPointer = functions.spanset_span(this._inner);
+//        Pointer spanPointer = GeneratedFunctions.spanset_span(this._inner);
 //        return spantype.getConstructor(Pointer.class).newInstance(spanPointer);
 //    }
 
     public <T> T to_span(Class<T> spansetType) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Pointer spanPointer = functions.spanset_span(this._inner);
+        Pointer spanPointer = GeneratedFunctions.spanset_span(this._inner);
         Constructor<T> constructor = spansetType.getConstructor(Pointer.class);
         return constructor.newInstance(spanPointer);
     }
@@ -127,12 +128,12 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      * @return String type
      */
 //    public T to_spans(Class<T> spantype) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-//        Pointer[] spanPointer = functions.spanset_spans(this._inner);
+//        Pointer[] spanPointer = GeneratedFunctions.spanset_spans(this._inner);
 //        return spantype.getConstructor(Pointer.class).newInstance((Object) spanPointer);
 //    }
 
 //    public List<T> to_spans(){
-//        Pointer ps = functions.spanset_spans(this._inner);
+//        Pointer ps = GeneratedFunctions.spanset_spans(this._inner);
 //        List<T> spanList = new ArrayList<T>(this.num_spans());
 //        System.out.println(this.num_spans());
 //        long pointerSize= Long.BYTES;
@@ -156,7 +157,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public int num_spans()
     {
-        return functions.spanset_num_spans(this._inner);
+        return GeneratedFunctions.spanset_num_spans(this._inner);
     }
 
     /*
@@ -169,7 +170,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
     @return A {@link Span} instance
     */
     public T start_span(Class<T> start_span) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Pointer startSpanPointer = functions.spanset_start_span(this._inner);
+        Pointer startSpanPointer = GeneratedFunctions.spanset_start_span(this._inner);
         return start_span.getConstructor(Pointer.class).newInstance(startSpanPointer);
     }
 
@@ -181,7 +182,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      *     @return A {@link Span} instance
      */
     public T end_span(Class<T> end_span) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Pointer endSpanPointer= functions.spanset_end_span(this._inner);
+        Pointer endSpanPointer= GeneratedFunctions.spanset_end_span(this._inner);
         return end_span.getConstructor(Pointer.class).newInstance(endSpanPointer);
     }
 
@@ -194,7 +195,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      * @return A {@link Span} instance
      */
     public T span_n(Class<T>span_n, int n) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Pointer spanNPointer= functions.spanset_span_n(this._inner, n+1);
+        Pointer spanNPointer= GeneratedFunctions.spanset_span_n(this._inner, n+1);
         return span_n.getConstructor(Pointer.class).newInstance(spanNPointer);
     }
 
@@ -202,7 +203,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
     spanset spans
      */
 //    public T spans(Class<T>spans) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-//        Pointer[] spansPointer= functions.spanset_spans(this._inner);
+//        Pointer[] spansPointer= GeneratedFunctions.spanset_spans(this._inner);
 //        return spans.getConstructor(Pointer.class).newInstance(spansPointer);
 //    }
 
@@ -266,7 +267,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      * @return A new :class:`int` instance
      */
     public long hash(){
-        return functions.spanset_hash(this._inner);
+        return GeneratedFunctions.spanset_hash(this._inner);
     }
 
     /* ------------------------- Transformations ------------------------------- */
@@ -291,9 +292,9 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean is_adjacent(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.adjacent_spanset_span(this._inner, ((Span<?>) other).get_inner());
+            return GeneratedFunctions.adjacent_spanset_span(this._inner, ((Span<?>) other).get_inner());
         } else if (other instanceof SpanSet<?>) {
-            return functions.adjacent_spanset_spanset(this._inner,((SpanSet<?>) other).get_inner());
+            return GeneratedFunctions.adjacent_spanset_spanset(this._inner,((SpanSet<?>) other).get_inner());
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -317,9 +318,9 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean is_contained_in(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.contained_spanset_span(this._inner, ((Span<?>) other).get_inner());
+            return GeneratedFunctions.contained_spanset_span(this._inner, ((Span<?>) other).get_inner());
         } else if (other instanceof SpanSet<?>) {
-            return functions.contained_spanset_spanset(this._inner, ((SpanSet<?>) other).get_inner());
+            return GeneratedFunctions.contained_spanset_spanset(this._inner, ((SpanSet<?>) other).get_inner());
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -342,9 +343,9 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean contains(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.contains_spanset_span(this._inner, ((Span<?>) other).get_inner());
+            return GeneratedFunctions.contains_spanset_span(this._inner, ((Span<?>) other).get_inner());
         } else if (other instanceof SpanSet<?>) {
-            return functions.contains_spanset_spanset(this._inner, ((SpanSet<?>) other)._inner);
+            return GeneratedFunctions.contains_spanset_spanset(this._inner, ((SpanSet<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -367,9 +368,9 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean overlaps(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.overlaps_spanset_span(this._inner, ((Span<?>) other).get_inner());
+            return GeneratedFunctions.overlaps_spanset_span(this._inner, ((Span<?>) other).get_inner());
         } else if (other instanceof SpanSet<?>) {
-            return functions.overlaps_spanset_spanset(this._inner,((SpanSet<?>) other).get_inner());
+            return GeneratedFunctions.overlaps_spanset_spanset(this._inner,((SpanSet<?>) other).get_inner());
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -387,9 +388,9 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean is_same(Base other) throws Exception {
         if (other instanceof SpanSet<?>){
-            return functions.spanset_eq(this._inner, ((SpanSet<?>) other)._inner);
+            return GeneratedFunctions.spanset_eq(this._inner, ((SpanSet<?>) other)._inner);
         } else if (other instanceof Span<?>) {
-            return functions.spanset_eq(this._inner,functions.span_to_spanset(((Span<?>) other).get_inner()));
+            return GeneratedFunctions.spanset_eq(this._inner,GeneratedFunctions.span_to_spanset(((Span<?>) other).get_inner()));
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -416,9 +417,9 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean is_left(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.left_spanset_span(this._inner, ((Span<?>) other).get_inner());
+            return GeneratedFunctions.left_spanset_span(this._inner, ((Span<?>) other).get_inner());
         } else if (other instanceof SpanSet<?>) {
-            return functions.left_spanset_spanset(this._inner, ((SpanSet<?>) other)._inner);
+            return GeneratedFunctions.left_spanset_spanset(this._inner, ((SpanSet<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -442,9 +443,9 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean is_over_or_left(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.overleft_spanset_span(this._inner, ((Span<?>) other).get_inner());
+            return GeneratedFunctions.overleft_spanset_span(this._inner, ((Span<?>) other).get_inner());
         } else if (other instanceof SpanSet<?>) {
-            return functions.overleft_spanset_spanset(this._inner, ((SpanSet<?>) other)._inner);
+            return GeneratedFunctions.overleft_spanset_spanset(this._inner, ((SpanSet<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -468,9 +469,9 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean is_right(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.right_spanset_span(this._inner, ((Span<?>) other).get_inner());
+            return GeneratedFunctions.right_spanset_span(this._inner, ((Span<?>) other).get_inner());
         } else if (other instanceof SpanSet<?>) {
-            return functions.right_spanset_spanset(this._inner, ((SpanSet<?>) other)._inner);
+            return GeneratedFunctions.right_spanset_spanset(this._inner, ((SpanSet<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -494,9 +495,9 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean is_over_or_right(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return functions.overright_spanset_span(this._inner, ((Span<?>) other).get_inner());
+            return GeneratedFunctions.overright_spanset_span(this._inner, ((Span<?>) other).get_inner());
         } else if (other instanceof SpanSet<?>) {
-            return functions.overright_spanset_spanset(this._inner, ((SpanSet<?>) other).get_inner());
+            return GeneratedFunctions.overright_spanset_spanset(this._inner, ((SpanSet<?>) other).get_inner());
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -522,9 +523,9 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
 //    public float distance(Base other) throws Exception {
 //        if (other instanceof Span<?>) {
-//            return (float) functions.distance_floatspanset_floatspan(this._inner, ((Span<?>) other).get_inner());
+//            return (float) GeneratedFunctions.distance_floatspanset_floatspan(this._inner, ((Span<?>) other).get_inner());
 //        } else if (other instanceof SpanSet<?>) {
-//            return (float) functions.distance_floatspanset_floatspanset(this._inner,((SpanSet<?>) other)._inner);
+//            return (float) GeneratedFunctions.distance_floatspanset_floatspanset(this._inner,((SpanSet<?>) other)._inner);
 //        }
 //        else {
 //            throw new Exception("Operation not supported with this type");
@@ -552,9 +553,9 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     protected Base intersection(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.intersection_spanset_span(this._inner, ((Span<?>) other).get_inner()));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.intersection_spanset_span(this._inner, ((Span<?>) other).get_inner()));
         } else if (other instanceof SpanSet<?>) {
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.intersection_spanset_spanset(this._inner,((SpanSet<?>) other).get_inner()));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.intersection_spanset_spanset(this._inner,((SpanSet<?>) other).get_inner()));
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -577,9 +578,9 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     protected Base minus(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.minus_spanset_span(this._inner, ((Span<?>) other).get_inner()));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.minus_spanset_span(this._inner, ((Span<?>) other).get_inner()));
         } else if (other instanceof SpanSet<?>) {
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.minus_spanset_spanset(this._inner,((SpanSet<?>) other).get_inner()));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.minus_spanset_spanset(this._inner,((SpanSet<?>) other).get_inner()));
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -608,9 +609,9 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     protected Base union(Base other) throws Exception {
         if (other instanceof Span<?>){
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.union_spanset_span(this._inner, ((Span<?>) other).get_inner()));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.union_spanset_span(this._inner, ((Span<?>) other).get_inner()));
         } else if (other instanceof SpanSet<?>) {
-            return this.getClass().getConstructor(Pointer.class).newInstance(functions.union_spanset_spanset(((SpanSet<?>) other).get_inner(),this._inner));
+            return this.getClass().getConstructor(Pointer.class).newInstance(GeneratedFunctions.union_spanset_spanset(((SpanSet<?>) other).get_inner(),this._inner));
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -637,7 +638,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean eq(Base other){
         if (other instanceof SpanSet<?>){
-            return functions.spanset_eq(this._inner,((SpanSet<?>) other)._inner);
+            return GeneratedFunctions.spanset_eq(this._inner,((SpanSet<?>) other)._inner);
         }
         else {
             return false;
@@ -658,7 +659,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean notEquals(Base other){
         if (other instanceof SpanSet<?>){
-            return functions.spanset_ne(this._inner,((SpanSet<?>) other)._inner);
+            return GeneratedFunctions.spanset_ne(this._inner,((SpanSet<?>) other)._inner);
         }
         else {
             return true;
@@ -680,7 +681,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean lessThan(Base other) throws Exception {
         if (other instanceof SpanSet<?>){
-            return functions.spanset_lt(this._inner,((SpanSet<?>) other)._inner);
+            return GeneratedFunctions.spanset_lt(this._inner,((SpanSet<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -702,7 +703,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean lessThanOrEqual(Base other) throws Exception {
         if (other instanceof SpanSet<?>){
-            return functions.spanset_le(this._inner,((SpanSet<?>) other)._inner);
+            return GeneratedFunctions.spanset_le(this._inner,((SpanSet<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -724,7 +725,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean greaterThan(Base other) throws Exception {
         if (other instanceof SpanSet<?>){
-            return functions.spanset_gt(this._inner,((SpanSet<?>) other)._inner);
+            return GeneratedFunctions.spanset_gt(this._inner,((SpanSet<?>) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -745,7 +746,7 @@ public abstract class SpanSet<T extends Object> implements Collection, Base {
      */
     public boolean greaterThanOrEqual(Base other) throws Exception {
         if (other instanceof SpanSet<?>) {
-            return functions.spanset_ge(this._inner, ((SpanSet<?>) other)._inner);
+            return GeneratedFunctions.spanset_ge(this._inner, ((SpanSet<?>) other)._inner);
         } else {
             throw new Exception("Operation not supported with this type");
         }

--- a/jmeos-core/src/main/java/types/collections/geo/GeoSet.java
+++ b/jmeos-core/src/main/java/types/collections/geo/GeoSet.java
@@ -6,6 +6,7 @@ import org.locationtech.jts.io.ParseException;
 import types.collections.base.Set;
 import utils.ConversionUtils;
 import functions.functions;
+import functions.GeneratedFunctions;
 
 
 /**
@@ -67,7 +68,7 @@ public abstract class GeoSet extends Set<Geometry> {
      */
     public String toString(){
         int max_decimals = 15;
-        return functions.tspatial_out(this._inner,max_decimals);
+        return GeneratedFunctions.tspatial_out(this._inner,max_decimals);
     }
 
 
@@ -82,7 +83,7 @@ public abstract class GeoSet extends Set<Geometry> {
      */
     protected String as_ewkt(){
         int max_decimals = 15;
-        return functions.tspatial_as_ewkt(this._inner,max_decimals);
+        return GeneratedFunctions.tspatial_as_ewkt(this._inner,max_decimals);
     }
 
     /**
@@ -95,7 +96,7 @@ public abstract class GeoSet extends Set<Geometry> {
      */
     protected String as_wkt(){
         int max_decimals = 15;
-        return functions.tspatial_as_text(this._inner,max_decimals);
+        return GeneratedFunctions.tspatial_as_text(this._inner,max_decimals);
     }
 
     /**
@@ -108,7 +109,7 @@ public abstract class GeoSet extends Set<Geometry> {
      */
     protected String as_text(){
         int max_decimals = 15;
-        return functions.tspatial_as_text(this._inner,max_decimals);
+        return GeneratedFunctions.tspatial_as_text(this._inner,max_decimals);
     }
 
     /* ------------------------- Accessors ------------------------------------- */
@@ -126,7 +127,7 @@ public abstract class GeoSet extends Set<Geometry> {
      */
     @Override
     public Geometry start_element() throws ParseException {
-        return ConversionUtils.gserialized_to_shapely_geometry(functions.geoset_start_value(this._inner),15);
+        return ConversionUtils.gserialized_to_shapely_geometry(GeneratedFunctions.geoset_start_value(this._inner),15);
     }
 
 
@@ -140,7 +141,7 @@ public abstract class GeoSet extends Set<Geometry> {
      */
     @Override
     public Geometry end_element() throws ParseException {
-        return ConversionUtils.gserialized_to_shapely_geometry(functions.geoset_end_value(this._inner),15);
+        return ConversionUtils.gserialized_to_shapely_geometry(GeneratedFunctions.geoset_end_value(this._inner),15);
     }
 
 
@@ -153,7 +154,7 @@ public abstract class GeoSet extends Set<Geometry> {
      * @return An integer
      */
     protected int srid(){
-        return functions.tspatial_srid(this._inner);
+        return GeneratedFunctions.tspatial_srid(this._inner);
     }
 
 
@@ -179,7 +180,7 @@ public abstract class GeoSet extends Set<Geometry> {
      */
     public Geometry intersection_geom(Geometry geom) throws ParseException {
         return ConversionUtils.gserialized_to_shapely_geometry(
-                functions.intersection_set_geo(this._inner, ConversionUtils.geometry_to_gserialized(geom)),15);
+                GeneratedFunctions.intersection_set_geo(this._inner, ConversionUtils.geometry_to_gserialized(geom)),15);
     }
 
     /**
@@ -195,7 +196,7 @@ public abstract class GeoSet extends Set<Geometry> {
      * @throws ParseException
      */
     public GeoSet intersection_geoset(GeoSet geo, String type){
-        return factory(type,functions.intersection_set_set(this._inner, geo._inner));
+        return factory(type,GeneratedFunctions.intersection_set_set(this._inner, geo._inner));
     }
 
 
@@ -214,9 +215,9 @@ public abstract class GeoSet extends Set<Geometry> {
      */
     public GeoSet minus(Object geo, String type){
         if(geo instanceof Geometry){
-            return factory(type, functions.minus_set_geo(this._inner, ConversionUtils.geometry_to_gserialized((Geometry) geo)));
+            return factory(type, GeneratedFunctions.minus_set_geo(this._inner, ConversionUtils.geometry_to_gserialized((Geometry) geo)));
         } else if (geo instanceof GeoSet) {
-            return factory(type, functions.minus_set_set(this._inner, ((GeoSet)geo)._inner));
+            return factory(type, GeneratedFunctions.minus_set_set(this._inner, ((GeoSet)geo)._inner));
         }
         return null;
     }
@@ -237,7 +238,7 @@ public abstract class GeoSet extends Set<Geometry> {
             :meth:`minus`
 */
     public Geometry subtract_from(Object geo, String type) throws ParseException {
-        Pointer result= functions.minus_geo_set(ConversionUtils.geometry_to_gserialized((Geometry) geo), this._inner);
+        Pointer result= GeneratedFunctions.minus_geo_set(ConversionUtils.geometry_to_gserialized((Geometry) geo), this._inner);
         if(result != null) {
             return ConversionUtils.gserialized_to_shapely_geometry(result, 15);
         }
@@ -260,9 +261,9 @@ public abstract class GeoSet extends Set<Geometry> {
      */
     public GeoSet union(Object geo, String type){
         if(geo instanceof Geometry){
-            return factory(type, functions.union_set_geo(this._inner, ConversionUtils.geometry_to_gserialized((Geometry) geo)));
+            return factory(type, GeneratedFunctions.union_set_geo(this._inner, ConversionUtils.geometry_to_gserialized((Geometry) geo)));
         } else if (geo instanceof GeoSet) {
-            return factory(type, functions.union_set_set(this._inner, ((GeoSet)geo)._inner));
+            return factory(type, GeneratedFunctions.union_set_set(this._inner, ((GeoSet)geo)._inner));
         }
         return null;
     }
@@ -284,7 +285,7 @@ public abstract class GeoSet extends Set<Geometry> {
      * @return A new {@link GeoSet} object of the same subtype of "this".
      */
     public GeoSet round(int decimals, String type){
-        return factory(type, functions.temporal_round(this._inner,decimals));
+        return factory(type, GeneratedFunctions.temporal_round(this._inner,decimals));
     }
 
 

--- a/jmeos-core/src/main/java/types/collections/geo/GeographySet.java
+++ b/jmeos-core/src/main/java/types/collections/geo/GeographySet.java
@@ -1,5 +1,6 @@
 package types.collections.geo;
 import functions.functions;
+import functions.GeneratedFunctions;
 import jnr.ffi.Pointer;
 
 
@@ -32,7 +33,7 @@ public class GeographySet extends GeoSet{
      */
     public GeographySet(String str){
         super(str);
-        this._inner = functions.geogset_in(str);
+        this._inner = GeneratedFunctions.geogset_in(str);
     }
 
     public String getType(){return type;}
@@ -44,7 +45,7 @@ public class GeographySet extends GeoSet{
 
     @Override
     public Pointer createStringInner(String str){
-        return functions.geogset_in(str);
+        return GeneratedFunctions.geogset_in(str);
     }
 
     @Override

--- a/jmeos-core/src/main/java/types/collections/geo/GeometrySet.java
+++ b/jmeos-core/src/main/java/types/collections/geo/GeometrySet.java
@@ -1,5 +1,6 @@
 package types.collections.geo;
 import functions.functions;
+import functions.GeneratedFunctions;
 import jnr.ffi.Pointer;
 
 /**
@@ -31,7 +32,7 @@ public class GeometrySet extends GeoSet{
      */
     public GeometrySet(String str){
         super(str);
-        this._inner = functions.geomset_in(str);
+        this._inner = GeneratedFunctions.geomset_in(str);
     }
 
     public String getType(){return type;}
@@ -43,7 +44,7 @@ public class GeometrySet extends GeoSet{
 
     @Override
     public Pointer createStringInner(String str){
-        return functions.geomset_in(str);
+        return GeneratedFunctions.geomset_in(str);
     }
 
     @Override

--- a/jmeos-core/src/main/java/types/collections/number/FloatSet.java
+++ b/jmeos-core/src/main/java/types/collections/number/FloatSet.java
@@ -9,6 +9,7 @@ import types.collections.base.Set;
 import java.util.ArrayList;
 import java.util.List;
 import functions.functions;
+import functions.GeneratedFunctions;
 
 
 /**
@@ -35,12 +36,12 @@ public class FloatSet extends Set<Float> implements Number{
 
     public FloatSet(String str){
         super(str);
-        _inner = functions.floatset_in(str);
+        _inner = GeneratedFunctions.floatset_in(str);
     }
 
     @Override
     public Pointer createStringInner(String str){
-        return functions.floatset_in(str);
+        return GeneratedFunctions.floatset_in(str);
     }
 
     @Override
@@ -66,7 +67,7 @@ public class FloatSet extends Set<Float> implements Number{
      * @return A new {@link String} instance
      */
     public String toString(int max_decimals){
-        return functions.floatset_out(this._inner, max_decimals);
+        return GeneratedFunctions.floatset_out(this._inner, max_decimals);
     }
 
 
@@ -84,7 +85,7 @@ public class FloatSet extends Set<Float> implements Number{
      * @return A new {@link FloatSpanSet} instance
      */
     public FloatSpanSet to_spanset(){
-        return new FloatSpanSet(functions.set_to_spanset(this._inner));
+        return new FloatSpanSet(GeneratedFunctions.set_to_spanset(this._inner));
     }
 
 
@@ -100,7 +101,7 @@ public class FloatSet extends Set<Float> implements Number{
      * @return A new {@link FloatSpan} instance
      */
     public FloatSpan to_span(){
-        return new FloatSpan(functions.set_to_span(this._inner));
+        return new FloatSpan(GeneratedFunctions.set_to_span(this._inner));
     }
 
     public IntSet to_intset(){
@@ -130,7 +131,7 @@ public class FloatSet extends Set<Float> implements Number{
      * @return A {@link Float} instance
      */
     public Float start_element(){
-        return (float) functions.floatset_start_value(this._inner);
+        return (float) GeneratedFunctions.floatset_start_value(this._inner);
     }
 
 
@@ -145,7 +146,7 @@ public class FloatSet extends Set<Float> implements Number{
      * @return A {@link Float} instance
      */
     public Float end_element(){
-        return (float) functions.floatset_end_value(this._inner);
+        return (float) GeneratedFunctions.floatset_end_value(this._inner);
     }
 
     /**
@@ -232,7 +233,7 @@ public class FloatSet extends Set<Float> implements Number{
      */
 
     public FloatSet shift_scale(float delta, float new_width){
-        return new FloatSet(functions.floatset_shift_scale(this._inner,delta,new_width,delta != 0, new_width != 0));
+        return new FloatSet(GeneratedFunctions.floatset_shift_scale(this._inner,delta,new_width,delta != 0, new_width != 0));
     }
 
 
@@ -255,7 +256,7 @@ public class FloatSet extends Set<Float> implements Number{
 
     public boolean contains(Object other) throws Exception {
         if (other instanceof Float){
-            return functions.contains_set_float(this._inner, (float) other);
+            return GeneratedFunctions.contains_set_float(this._inner, (float) other);
         }
         else{
             return super.contains((Base)other);
@@ -282,7 +283,7 @@ public class FloatSet extends Set<Float> implements Number{
      */
     public boolean is_left(Object other) throws Exception {
         if (other instanceof Float){
-            return functions.left_set_float(this._inner, (float) other);
+            return GeneratedFunctions.left_set_float(this._inner, (float) other);
         }
         else{
             return super.is_left((Base) other);
@@ -305,7 +306,7 @@ public class FloatSet extends Set<Float> implements Number{
      */
     public boolean is_over_or_left(Object other) throws Exception {
         if (other instanceof Float){
-            return functions.overleft_set_float(this._inner, (float) other);
+            return GeneratedFunctions.overleft_set_float(this._inner, (float) other);
         }
         else{
             return super.is_over_or_left((Base) other);
@@ -329,7 +330,7 @@ public class FloatSet extends Set<Float> implements Number{
      */
     public boolean is_right(Object other) throws Exception {
         if (other instanceof Float){
-            return functions.right_set_float(this._inner, (float) other);
+            return GeneratedFunctions.right_set_float(this._inner, (float) other);
         }
         else{
             return super.is_right((Base) other);
@@ -353,7 +354,7 @@ public class FloatSet extends Set<Float> implements Number{
      */
     public boolean is_over_or_right(Object other) throws Exception {
         if (other instanceof Float){
-            return functions.overright_set_float(this._inner, (float) other);
+            return GeneratedFunctions.overright_set_float(this._inner, (float) other);
         }
         else{
             return super.is_over_or_right((Base) other);
@@ -381,10 +382,10 @@ public class FloatSet extends Set<Float> implements Number{
     public FloatSet intersection(Object other) throws Exception{
         Pointer result = null;
         if ((other instanceof Float) || (other instanceof Integer)){
-            result= functions.intersection_set_float(this._inner, (float) other);
+            result= GeneratedFunctions.intersection_set_float(this._inner, (float) other);
         }
         else if(other instanceof FloatSet){
-            result= functions.intersection_set_set(this._inner, ((FloatSet) other)._inner);
+            result= GeneratedFunctions.intersection_set_set(this._inner, ((FloatSet) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -408,10 +409,10 @@ public class FloatSet extends Set<Float> implements Number{
     public FloatSet minus(Object other) throws Exception {
         Pointer result = null;
         if (other instanceof Float){
-            result = functions.minus_set_float(this._inner, (float) other);
+            result = GeneratedFunctions.minus_set_float(this._inner, (float) other);
         }
         else if(other instanceof FloatSet){
-            result = functions.minus_set_set(this._inner, ((FloatSet) other)._inner);
+            result = GeneratedFunctions.minus_set_set(this._inner, ((FloatSet) other)._inner);
         }
 
         return new FloatSet(result);
@@ -432,7 +433,7 @@ public class FloatSet extends Set<Float> implements Number{
      * @return A {@link Float} instance or "None" if the difference is empty.
      */
     public Pointer subtract_from(float other){
-        return functions.minus_float_set(other,this._inner);
+        return GeneratedFunctions.minus_float_set(other,this._inner);
 
     }
 
@@ -453,10 +454,10 @@ public class FloatSet extends Set<Float> implements Number{
     public FloatSet union(Object other) throws Exception {
         Pointer result = null;
         if (other instanceof Float){
-            result = functions.union_set_float(this._inner, (float) other);
+            result = GeneratedFunctions.union_set_float(this._inner, (float) other);
         }
         else if(other instanceof FloatSet){
-            result = functions.union_set_set(this._inner, ((FloatSet) other)._inner);
+            result = GeneratedFunctions.union_set_set(this._inner, ((FloatSet) other)._inner);
         }
 
         return new FloatSet(result);
@@ -483,10 +484,10 @@ public class FloatSet extends Set<Float> implements Number{
     public float distance(Object other) throws Exception {
         float answer=0;
         if ((other instanceof Float) || (other instanceof Integer)){
-            answer= (float) functions.distance_set_float(this._inner, (float) other);
+            answer= (float) GeneratedFunctions.distance_set_float(this._inner, (float) other);
         }
         else if(other instanceof FloatSet){
-            answer= (float) functions.distance_floatset_floatset(this._inner, ((FloatSet) other)._inner);
+            answer= (float) GeneratedFunctions.distance_floatset_floatset(this._inner, ((FloatSet) other)._inner);
         }
         else if(other instanceof FloatSpan){
             answer= this.to_spanset().distance(other);

--- a/jmeos-core/src/main/java/types/collections/number/FloatSpan.java
+++ b/jmeos-core/src/main/java/types/collections/number/FloatSpan.java
@@ -3,6 +3,7 @@ import jnr.ffi.Pointer;
 import types.collections.base.Base;
 import types.collections.base.Span;
 import functions.functions;
+import functions.GeneratedFunctions;
 
 /**
  * Class for representing sets of contiguous float values between a lower and
@@ -36,37 +37,37 @@ public class FloatSpan extends Span<Float> implements Number{
 
     public FloatSpan(String str){
         super(str);
-        this._inner = functions.floatspan_in(str);
+        this._inner = GeneratedFunctions.floatspan_in(str);
     }
 
 
     public FloatSpan(float lower, float upper, boolean lower_inc, boolean upper_inc){
         super(lower,upper,lower_inc,upper_inc);
-        _inner = functions.floatspan_make((double) lower, (double) upper,lower_inc,upper_inc);
+        _inner = GeneratedFunctions.floatspan_make((double) lower, (double) upper,lower_inc,upper_inc);
     }
 
     public FloatSpan(float lower, String upper, boolean lower_inc, boolean upper_inc){
         super(lower,upper,lower_inc,upper_inc);
         double new_upper = Double.parseDouble(upper);
-        _inner = functions.floatspan_make(lower,new_upper,lower_inc,upper_inc);
+        _inner = GeneratedFunctions.floatspan_make(lower,new_upper,lower_inc,upper_inc);
     }
 
     public FloatSpan(String lower, String upper, boolean lower_inc, boolean upper_inc){
         super(lower,upper,lower_inc,upper_inc);
         double new_upper = Double.parseDouble(upper);
         double new_lower = Double.parseDouble(lower);
-        _inner = functions.floatspan_make(new_lower,new_upper,lower_inc,upper_inc);
+        _inner = GeneratedFunctions.floatspan_make(new_lower,new_upper,lower_inc,upper_inc);
     }
 
     public FloatSpan(String lower, float upper, boolean lower_inc, boolean upper_inc){
         super(lower,upper,lower_inc,upper_inc);
         double new_lower = Double.parseDouble(lower);
-        _inner = functions.floatspan_make(new_lower,(double) upper,lower_inc,upper_inc);
+        _inner = GeneratedFunctions.floatspan_make(new_lower,(double) upper,lower_inc,upper_inc);
     }
 
     public FloatSpan(float lower, float upper){
         super(lower,upper,true,false);
-        _inner = functions.floatspan_make((double) lower,(double) upper,true,false);
+        _inner = GeneratedFunctions.floatspan_make((double) lower,(double) upper,true,false);
     }
 
 
@@ -74,7 +75,7 @@ public class FloatSpan extends Span<Float> implements Number{
 
     @Override
     public Pointer createStringInner(String str){
-        return functions.floatspan_in(str);
+        return GeneratedFunctions.floatspan_in(str);
     }
 
     @Override
@@ -85,27 +86,27 @@ public class FloatSpan extends Span<Float> implements Number{
 
     @Override
     public Pointer createIntInt(java.lang.Number lower, java.lang.Number upper, boolean lower_inc, boolean upper_inc){
-        return functions.floatspan_make(lower.floatValue(),upper.floatValue(),lower_inc,upper_inc);
+        return GeneratedFunctions.floatspan_make(lower.floatValue(),upper.floatValue(),lower_inc,upper_inc);
     }
     @Override
     public Pointer createIntStr(java.lang.Number lower, String upper, boolean lower_inc, boolean upper_inc){
         double new_upper = Double.parseDouble(upper);
-        return functions.floatspan_make(lower.floatValue(),new_upper,lower_inc,upper_inc);
+        return GeneratedFunctions.floatspan_make(lower.floatValue(),new_upper,lower_inc,upper_inc);
     }
     @Override
     public Pointer createStrStr(String lower, String upper, boolean lower_inc, boolean upper_inc){
         double new_upper = Double.parseDouble(upper);
         double new_lower = Double.parseDouble(lower);
-        return functions.floatspan_make(new_lower,new_upper,lower_inc,upper_inc);
+        return GeneratedFunctions.floatspan_make(new_lower,new_upper,lower_inc,upper_inc);
     }
     @Override
     public Pointer createStrInt(String lower, java.lang.Number upper, boolean lower_inc, boolean upper_inc){
         int new_lower = Integer.parseInt(lower);
-        return functions.floatspan_make(new_lower,upper.floatValue(),lower_inc,upper_inc);
+        return GeneratedFunctions.floatspan_make(new_lower,upper.floatValue(),lower_inc,upper_inc);
     }
     @Override
     public Pointer createIntIntNb(java.lang.Number lower, java.lang.Number upper){
-        return functions.floatspan_make(lower.floatValue(),upper.floatValue(),true,false);
+        return GeneratedFunctions.floatspan_make(lower.floatValue(),upper.floatValue(),true,false);
     }
 
 
@@ -124,7 +125,7 @@ public class FloatSpan extends Span<Float> implements Number{
      * @return A new {@link String} instance
      */
     public String toString(int max_decimals){
-        return functions.floatspan_out(this._inner, max_decimals);
+        return GeneratedFunctions.floatspan_out(this._inner, max_decimals);
     }
 
 
@@ -143,7 +144,7 @@ public class FloatSpan extends Span<Float> implements Number{
      * @return A new {@link FloatSpanSet} instance
      */
     public FloatSpanSet to_spanset(){
-        return new FloatSpanSet(functions.span_to_spanset(this._inner));
+        return new FloatSpanSet(GeneratedFunctions.span_to_spanset(this._inner));
     }
 
 
@@ -158,7 +159,7 @@ public class FloatSpan extends Span<Float> implements Number{
      * @return A new {@link IntSpan} instance
      */
     public IntSpan to_intspan(){
-        return new IntSpan(functions.floatspan_to_intspan(this._inner));
+        return new IntSpan(GeneratedFunctions.floatspan_to_intspan(this._inner));
     }
 
 
@@ -182,7 +183,7 @@ public class FloatSpan extends Span<Float> implements Number{
      * @return The lower bound of the span as a {@link Float}
      */
     public Float lower(){
-        return (float) functions.floatspan_lower(this._inner);
+        return (float) GeneratedFunctions.floatspan_lower(this._inner);
     }
 
 
@@ -198,7 +199,7 @@ public class FloatSpan extends Span<Float> implements Number{
      * @return The lower bound of the span as a {@link Float}
      */
     public Float upper(){
-        return (float) functions.floatspan_upper(this._inner);
+        return (float) GeneratedFunctions.floatspan_upper(this._inner);
     }
 
 
@@ -213,7 +214,7 @@ public class FloatSpan extends Span<Float> implements Number{
      * @return Returns a "float" representing the width of the span
      */
     public float width(){
-        return (float) functions.floatspan_width(this._inner);
+        return (float) GeneratedFunctions.floatspan_width(this._inner);
     }
 
 
@@ -268,7 +269,7 @@ public class FloatSpan extends Span<Float> implements Number{
      * @return a new {@link FloatSpan} instance
      */
     public FloatSpan shift_scale(int delta, int width){
-        return new FloatSpan(functions.floatspan_shift_scale(this._inner,delta,width,delta != 0, width != 0));
+        return new FloatSpan(GeneratedFunctions.floatspan_shift_scale(this._inner,delta,width,delta != 0, width != 0));
     }
 
 
@@ -291,7 +292,7 @@ public class FloatSpan extends Span<Float> implements Number{
      */
     public boolean is_adjacent(Object other) throws Exception {
         if ((other instanceof Integer) || (other instanceof Float)){
-            return functions.adjacent_span_float(this._inner, (float) other);
+            return GeneratedFunctions.adjacent_span_float(this._inner, (float) other);
         }
         else {
             return super.is_adjacent((Base) other);
@@ -314,7 +315,7 @@ public class FloatSpan extends Span<Float> implements Number{
      */
     public boolean contains(Object other) throws Exception {
         if ((other instanceof Integer) || (other instanceof Float)){
-            return functions.contains_span_float(this._inner, (float) other);
+            return GeneratedFunctions.contains_span_float(this._inner, (float) other);
         }
         else {
             return super.contains((Base) other);
@@ -337,7 +338,7 @@ public class FloatSpan extends Span<Float> implements Number{
      */
     public boolean is_same(Object other) throws Exception {
         if ((other instanceof Integer) || (other instanceof Float)){
-            return functions.span_eq(this._inner, functions.float_to_span((float)other));
+            return GeneratedFunctions.span_eq(this._inner, GeneratedFunctions.float_to_span((float)other));
         }
         else {
             return super.is_same((Base) other);
@@ -364,7 +365,7 @@ public class FloatSpan extends Span<Float> implements Number{
      */
     public boolean is_left(Object other) throws Exception {
         if ((other instanceof Integer) || (other instanceof Float)){
-            return functions.left_span_float(this._inner, (float) other);
+            return GeneratedFunctions.left_span_float(this._inner, (float) other);
         }
         else {
             return super.is_left((Base) other);
@@ -389,7 +390,7 @@ public class FloatSpan extends Span<Float> implements Number{
      */
     public boolean is_over_or_left(Object other) throws Exception {
         if ((other instanceof Integer) || (other instanceof Float)){
-            return functions.overleft_span_float(this._inner, (float) other);
+            return GeneratedFunctions.overleft_span_float(this._inner, (float) other);
         }
         else {
             return super.is_over_or_left((Base) other);
@@ -413,7 +414,7 @@ public class FloatSpan extends Span<Float> implements Number{
      */
     public boolean is_right(Object other) throws Exception {
         if ((other instanceof Integer) || (other instanceof Float)){
-            return functions.right_span_float(this._inner, (float) other);
+            return GeneratedFunctions.right_span_float(this._inner, (float) other);
         }
         else {
             return super.is_right((Base) other);
@@ -438,7 +439,7 @@ public class FloatSpan extends Span<Float> implements Number{
      */
     public boolean is_over_or_right(Object other) throws Exception {
         if ((other instanceof Integer) || (other instanceof Float)){
-            return functions.overright_span_float(this._inner, (float) other);
+            return GeneratedFunctions.overright_span_float(this._inner, (float) other);
         }
         else {
             return super.is_over_or_right((Base) other);
@@ -465,16 +466,16 @@ public class FloatSpan extends Span<Float> implements Number{
     public Float distance(Object other) throws Exception {
         float answer= 0;
         if ((other instanceof Integer) || (other instanceof Float)){
-            answer= (float) functions.distance_span_float(this._inner, (float) other);
+            answer= (float) GeneratedFunctions.distance_span_float(this._inner, (float) other);
         }
         else if ((other instanceof FloatSet)){
-            answer= (float) functions.distance_floatset_floatset(this._inner, ((FloatSet) other).get_inner());
+            answer= (float) GeneratedFunctions.distance_floatset_floatset(this._inner, ((FloatSet) other).get_inner());
         }
         else if ((other instanceof FloatSpanSet)){
-            answer= (float) functions.distance_floatspanset_floatspan(this._inner, ((FloatSpanSet) other).get_inner());
+            answer= (float) GeneratedFunctions.distance_floatspanset_floatspan(this._inner, ((FloatSpanSet) other).get_inner());
         }
         else if ((other instanceof FloatSpan)){
-            answer= (float) functions.distance_floatspan_floatspan(this._inner, ((FloatSpan) other)._inner);
+            answer= (float) GeneratedFunctions.distance_floatspan_floatspan(this._inner, ((FloatSpan) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with " + other + " type");
@@ -500,16 +501,16 @@ public class FloatSpan extends Span<Float> implements Number{
     public FloatSpan intersection(Object other) throws Exception {
         Pointer result = null;
         if ((other instanceof Integer) || (other instanceof Float)){
-            result= functions.intersection_span_float(this._inner, (float) other);
+            result= GeneratedFunctions.intersection_span_float(this._inner, (float) other);
         }
         else if (other instanceof FloatSpan){
-            result= functions.intersection_span_span(this._inner, ((FloatSpan) other)._inner);
+            result= GeneratedFunctions.intersection_span_span(this._inner, ((FloatSpan) other)._inner);
         }
         else if (other instanceof FloatSpanSet){
-            result= functions.intersection_spanset_span(this._inner, ((FloatSpanSet) other).get_inner());
+            result= GeneratedFunctions.intersection_spanset_span(this._inner, ((FloatSpanSet) other).get_inner());
         }
         else if ((other instanceof FloatSet)){
-            result= functions.intersection_set_set(this._inner, ((FloatSet) other).get_inner());
+            result= GeneratedFunctions.intersection_set_set(this._inner, ((FloatSet) other).get_inner());
         }
         else {
             throw new Exception("Operation not supported with " + other + " type");
@@ -532,13 +533,13 @@ public class FloatSpan extends Span<Float> implements Number{
     public FloatSpanSet minus(Object other){
         Pointer result = null;
         if ((other instanceof Integer) || (other instanceof Float)){
-            result = functions.minus_span_float(this._inner, (double)other);
+            result = GeneratedFunctions.minus_span_float(this._inner, (double)other);
         }
         else if (other instanceof FloatSpan) {
-            result = functions.minus_span_span(this._inner,((FloatSpan) other).get_inner());
+            result = GeneratedFunctions.minus_span_span(this._inner,((FloatSpan) other).get_inner());
         }
         else if (other instanceof FloatSpanSet) {
-            result = functions.minus_spanset_span(((FloatSpanSet) other).get_inner(), this._inner);
+            result = GeneratedFunctions.minus_spanset_span(((FloatSpanSet) other).get_inner(), this._inner);
         }
         else {
             //result = super.minus(other);
@@ -563,13 +564,13 @@ public class FloatSpan extends Span<Float> implements Number{
     public FloatSpanSet union(Object other) throws Exception {
         Pointer result = null;
         if (other instanceof Integer || other instanceof Double || other instanceof Float){
-            result = functions.union_span_float(this._inner, (double) other);
+            result = GeneratedFunctions.union_span_float(this._inner, (double) other);
         }
         else if (other instanceof FloatSpan) {
-            result = functions.union_span_span(this._inner,((FloatSpan) other).get_inner());
+            result = GeneratedFunctions.union_span_span(this._inner,((FloatSpan) other).get_inner());
         }
         else if (other instanceof FloatSpanSet) {
-            result = functions.union_spanset_span(((FloatSpanSet) other).get_inner(), this._inner);
+            result = GeneratedFunctions.union_spanset_span(((FloatSpanSet) other).get_inner(), this._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");

--- a/jmeos-core/src/main/java/types/collections/number/FloatSpanSet.java
+++ b/jmeos-core/src/main/java/types/collections/number/FloatSpanSet.java
@@ -7,6 +7,7 @@ import jnr.ffi.Pointer;
 import types.collections.base.Base;
 import types.collections.base.SpanSet;
 import functions.functions;
+import functions.GeneratedFunctions;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,12 +41,12 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
 
     public FloatSpanSet(String str){
         super(str);
-        _inner = functions.floatspanset_in(str);
+        _inner = GeneratedFunctions.floatspanset_in(str);
     }
 
     @Override
     public Pointer createStringInner(String str){
-        return functions.floatspanset_in(str);
+        return GeneratedFunctions.floatspanset_in(str);
     }
 
     @Override
@@ -74,7 +75,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
      * @return A new {@link String} instance
      */
     public String toString(int max_decimals){
-        return functions.floatspanset_out(this._inner, max_decimals);
+        return GeneratedFunctions.floatspanset_out(this._inner, max_decimals);
     }
 
 
@@ -92,7 +93,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
      * @return A new {@link FloatSpan} instance
      */
     public FloatSpan to_span(){
-        return new FloatSpan(functions.spanset_span(this._inner));
+        return new FloatSpan(GeneratedFunctions.spanset_span(this._inner));
     }
 
 
@@ -107,7 +108,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
      * @return A new {@link IntSpanSet} instance
      */
     public IntSpanSet to_intspanset(){
-        return new IntSpanSet(functions.floatspanset_to_intspanset( this._inner));
+        return new IntSpanSet(GeneratedFunctions.floatspanset_to_intspanset( this._inner));
     }
 
 
@@ -135,7 +136,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
      * @return A `float` representing the duration of the spanset
      */
     public float width(boolean ignore_gaps){
-        return (float) functions.floatspanset_width(this._inner, ignore_gaps);
+        return (float) GeneratedFunctions.floatspanset_width(this._inner, ignore_gaps);
     }
 
     /*
@@ -148,7 +149,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
      */
 
     public FloatSpan start_span(){
-        return new FloatSpan(functions.spanset_start_span(this._inner));
+        return new FloatSpan(GeneratedFunctions.spanset_start_span(this._inner));
     }
 
     /*
@@ -160,7 +161,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
       @return A {@link FloatSpan} instance
      */
     public FloatSpan end_span(){
-        return new FloatSpan(functions.spanset_end_span(this._inner));
+        return new FloatSpan(GeneratedFunctions.spanset_end_span(this._inner));
     }
 
     /*
@@ -172,7 +173,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
       @return A {@link FloatSpan} instance
      */
     public FloatSpan span_n(int n){
-        return new FloatSpan(functions.spanset_span_n(this._inner, n));
+        return new FloatSpan(GeneratedFunctions.spanset_span_n(this._inner, n));
     }
 
 
@@ -242,7 +243,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
      * @return a new {@link FloatSpanSet} instance
      */
     public FloatSpanSet shift_scale(int delta, int width){
-        return new FloatSpanSet(functions.floatspanset_shift_scale(this._inner,delta,width,delta != 0, width != 0));
+        return new FloatSpanSet(GeneratedFunctions.floatspanset_shift_scale(this._inner,delta,width,delta != 0, width != 0));
     }
 
 
@@ -269,7 +270,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
     public boolean is_adjacent(Object other) throws Exception {
         boolean answer = false;
         if (other instanceof Float){
-            answer = functions.adjacent_spanset_float(this._inner, (float) other);
+            answer = GeneratedFunctions.adjacent_spanset_float(this._inner, (float) other);
         }
         else{
             answer = super.is_adjacent((Base)other);
@@ -293,7 +294,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
      */
     public boolean contains(Object other) throws Exception {
         if (other instanceof Float){
-            return functions.contains_spanset_float(this._inner, (float) other);
+            return GeneratedFunctions.contains_spanset_float(this._inner, (float) other);
         }
         else{
             return super.contains((Base)other);
@@ -315,7 +316,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
      */
     public boolean is_same(Object other) throws Exception {
         if (other instanceof Float){
-            return functions.spanset_eq(this._inner,functions.float_to_spanset((float) other));
+            return GeneratedFunctions.spanset_eq(this._inner,GeneratedFunctions.float_to_spanset((float) other));
         }
         else{
             return super.is_same((Base)other);
@@ -344,7 +345,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
     public boolean is_left(Object other) throws Exception {
         boolean answer = false;
         if (other instanceof Float){
-            answer = functions.left_spanset_float(this._inner,(float) other);
+            answer = GeneratedFunctions.left_spanset_float(this._inner,(float) other);
         }
         else{
             answer = super.is_left((Base)other);
@@ -371,7 +372,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
     public boolean is_over_or_left(Object other) throws Exception {
         boolean answer = false;
         if (other instanceof Float){
-            answer = functions.overleft_spanset_float(this._inner,(float) other);
+            answer = GeneratedFunctions.overleft_spanset_float(this._inner,(float) other);
         }
         else{
             answer = super.is_over_or_left((Base)other);
@@ -398,7 +399,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
     public boolean is_right(Object other) throws Exception {
         boolean answer = false;
         if (other instanceof Float){
-            answer = functions.right_spanset_float(this._inner,(float) other);
+            answer = GeneratedFunctions.right_spanset_float(this._inner,(float) other);
         }
         else{
             answer = super.is_right((Base)other);
@@ -426,7 +427,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
     public boolean is_over_or_right(Object other) throws Exception {
         boolean answer = false;
         if (other instanceof Float){
-            answer = functions.overright_spanset_float(this._inner,(float) other);
+            answer = GeneratedFunctions.overright_spanset_float(this._inner,(float) other);
         }
         else{
             answer = super.is_over_or_right((Base)other);
@@ -454,14 +455,14 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
     public float distance(Object other) throws Exception {
         float answer = 0;
         if (other instanceof Float) {
-            answer = (float) functions.distance_spanset_float(this._inner, (int) other);
+            answer = (float) GeneratedFunctions.distance_spanset_float(this._inner, (int) other);
         } else if (other instanceof FloatSet) {
             FloatSpan fs = ((FloatSet) other).to_span(FloatSpan.class);
-            answer = (float) functions.distance_intspanset_intspan(this._inner, (fs).get_inner());
+            answer = (float) GeneratedFunctions.distance_intspanset_intspan(this._inner, (fs).get_inner());
         } else if (other instanceof FloatSpan) {
-            answer = (float) functions.distance_intspanset_intspan(this._inner, ((FloatSpan) other).get_inner());
+            answer = (float) GeneratedFunctions.distance_intspanset_intspan(this._inner, ((FloatSpan) other).get_inner());
         } else if (other instanceof FloatSpanSet) {
-            answer = (float) functions.distance_intspanset_intspanset(this._inner, ((FloatSpanSet) other).get_inner());
+            answer = (float) GeneratedFunctions.distance_intspanset_intspanset(this._inner, ((FloatSpanSet) other).get_inner());
         } else {
             throw new Exception("Operation not supported with " + other + " type");
         }
@@ -486,7 +487,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
     public FloatSpanSet intersection(Object other) throws Exception {
         Pointer result = null;
         if ((other instanceof Float) || (other instanceof Integer)){
-            result= functions.intersection_spanset_float(this._inner, (float) other);
+            result= GeneratedFunctions.intersection_spanset_float(this._inner, (float) other);
         }
         else{
             FloatSpanSet tmp= (FloatSpanSet) super.intersection((Base) other);
@@ -516,7 +517,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
     public FloatSpanSet minus(Object other) throws Exception {
         Pointer result = null;
         if ((other instanceof Integer) || (other instanceof Float)){
-            result = functions.minus_spanset_float(this._inner, (float) other);
+            result = GeneratedFunctions.minus_spanset_float(this._inner, (float) other);
         }
         else{
             FloatSpanSet tmp = (FloatSpanSet) super.minus((Base) other);
@@ -546,7 +547,7 @@ public class FloatSpanSet extends SpanSet<Float> implements Number{
     public FloatSpanSet union(Object other) throws Exception {
         Pointer result = null;
         if ((other instanceof Integer) || (other instanceof Float)) {
-            result = functions.union_spanset_float(this._inner, (float) other);
+            result = GeneratedFunctions.union_spanset_float(this._inner, (float) other);
         } else {
             FloatSpanSet tmp = (FloatSpanSet) super.union((Base) other);
             result = tmp.get_inner();

--- a/jmeos-core/src/main/java/types/collections/number/IntSet.java
+++ b/jmeos-core/src/main/java/types/collections/number/IntSet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import functions.functions;
+import functions.GeneratedFunctions;
 
 /**
  * Class for representing a set of text values.
@@ -35,12 +36,12 @@ public class IntSet extends Set<Integer> implements Number{
 
     public IntSet(String str){
         super(str);
-        _inner = functions.intset_in(str);
+        _inner = GeneratedFunctions.intset_in(str);
     }
 
     @Override
     public Pointer createStringInner(String str){
-        return functions.intset_in(str);
+        return GeneratedFunctions.intset_in(str);
     }
 
     @Override
@@ -64,7 +65,7 @@ public class IntSet extends Set<Integer> implements Number{
      * @return A new {@link String} instance
      */
     public String toString(){
-        return functions.intset_out(this._inner);
+        return GeneratedFunctions.intset_out(this._inner);
     }
 
     /* ------------------------- Conversions ----------------------------------- */
@@ -81,7 +82,7 @@ public class IntSet extends Set<Integer> implements Number{
      * @return A new {@link IntSpanSet} instance
      */
     public IntSpanSet to_spanset(){
-        return new IntSpanSet(functions.set_to_spanset(this._inner));
+        return new IntSpanSet(GeneratedFunctions.set_to_spanset(this._inner));
     }
 
 
@@ -96,7 +97,7 @@ public class IntSet extends Set<Integer> implements Number{
      * @return A {@link IntSpan} instance
      */
     public IntSpan to_span(){
-        return new IntSpan(functions.set_to_span(this._inner));
+        return new IntSpan(GeneratedFunctions.set_to_span(this._inner));
     }
 
     public FloatSet to_floatset(){
@@ -126,7 +127,7 @@ public class IntSet extends Set<Integer> implements Number{
      * @return A {@link Integer} instance
      */
     public Integer start_element(){
-        return functions.intset_start_value(this._inner);
+        return GeneratedFunctions.intset_start_value(this._inner);
     }
 
 
@@ -141,7 +142,7 @@ public class IntSet extends Set<Integer> implements Number{
      * @return A {@link Integer} instance
      */
     public Integer end_element(){
-        return functions.intset_end_value(this._inner);
+        return GeneratedFunctions.intset_end_value(this._inner);
     }
 
     /*
@@ -159,7 +160,7 @@ public class IntSet extends Set<Integer> implements Number{
 
     public Integer element_n(int n) throws Exception {
         super.element_n(n);
-        return Objects.requireNonNull(functions.intset_value_n(this._inner, n + 1)).getInt(Integer.BYTES);
+        return Objects.requireNonNull(GeneratedFunctions.intset_value_n(this._inner, n + 1)).getInt(Integer.BYTES);
     }
 
     public List<Integer> elements(){
@@ -225,7 +226,7 @@ public class IntSet extends Set<Integer> implements Number{
      * @return A new {@link IntSet} instance
      */
     public IntSet shift_scale(int delta, int width){
-        return new IntSet(functions.intset_shift_scale(this._inner, delta,width,delta != 0, width != 0));
+        return new IntSet(GeneratedFunctions.intset_shift_scale(this._inner, delta,width,delta != 0, width != 0));
     }
 
 
@@ -236,7 +237,7 @@ public class IntSet extends Set<Integer> implements Number{
 
     public boolean contains(Object other) throws Exception {
         if ((other instanceof Integer) || (other instanceof Float)){
-            return functions.contains_set_int(this._inner, (int) other);
+            return GeneratedFunctions.contains_set_int(this._inner, (int) other);
         }
         else {
             return super.contains((Base) other);
@@ -269,7 +270,7 @@ public class IntSet extends Set<Integer> implements Number{
      */
     public boolean is_left(Object other) throws Exception {
         if (other instanceof Integer){
-            return functions.left_set_int(this._inner, (int) other);
+            return GeneratedFunctions.left_set_int(this._inner, (int) other);
         }
         else{
             return super.is_left((Base) other);
@@ -292,7 +293,7 @@ public class IntSet extends Set<Integer> implements Number{
      */
     public boolean is_over_or_left(Object other) throws Exception {
         if (other instanceof Integer){
-            return functions.overleft_set_int(this._inner, (int) other);
+            return GeneratedFunctions.overleft_set_int(this._inner, (int) other);
         }
         else{
             return super.is_over_or_left((Base) other);
@@ -316,7 +317,7 @@ public class IntSet extends Set<Integer> implements Number{
      */
     public boolean is_right(Object other) throws Exception {
         if (other instanceof Integer){
-            return functions.right_set_int(this._inner, (int) other);
+            return GeneratedFunctions.right_set_int(this._inner, (int) other);
         }
         else{
             return super.is_right((Base) other);
@@ -340,7 +341,7 @@ public class IntSet extends Set<Integer> implements Number{
      */
     public boolean is_over_or_right(Object other) throws Exception {
         if (other instanceof Integer){
-            return functions.overright_set_int(this._inner, (int) other);
+            return GeneratedFunctions.overright_set_int(this._inner, (int) other);
         }
         else{
             return super.is_over_or_right((Base) other);
@@ -368,10 +369,10 @@ public class IntSet extends Set<Integer> implements Number{
     public IntSet intersection(Object other) throws Exception{
         Pointer result = null;
         if (other instanceof Integer){
-            result= functions.intersection_set_int(this._inner, (int) other);
+            result= GeneratedFunctions.intersection_set_int(this._inner, (int) other);
         }
         else if(other instanceof IntSet){
-            result= functions.intersection_set_set(this._inner, ((IntSet) other)._inner);
+            result= GeneratedFunctions.intersection_set_set(this._inner, ((IntSet) other)._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");
@@ -395,10 +396,10 @@ public class IntSet extends Set<Integer> implements Number{
     public IntSet minus(Object other) throws Exception {
         Pointer result = null;
         if (other instanceof Integer){
-            result = functions.minus_set_int(this._inner, (int) other);
+            result = GeneratedFunctions.minus_set_int(this._inner, (int) other);
         }
         else if(other instanceof IntSet){
-            result = functions.minus_set_set(this._inner, ((IntSet) other)._inner);
+            result = GeneratedFunctions.minus_set_set(this._inner, ((IntSet) other)._inner);
         }
 
         return new IntSet(result);
@@ -417,7 +418,7 @@ public class IntSet extends Set<Integer> implements Number{
      * @return A {@link Integer} instance or "None" if the difference is empty.
      */
     public Pointer subtract_from(int other){
-        return functions.minus_int_set(other,this._inner);
+        return GeneratedFunctions.minus_int_set(other,this._inner);
     }
 
 
@@ -437,10 +438,10 @@ public class IntSet extends Set<Integer> implements Number{
     public IntSet union(Object other) throws Exception {
         Pointer result = null;
         if (other instanceof Integer){
-            result = functions.union_set_int(this._inner, (int) other);
+            result = GeneratedFunctions.union_set_int(this._inner, (int) other);
         }
         else if(other instanceof IntSet){
-            result = functions.union_set_set(this._inner, ((IntSet) other)._inner);
+            result = GeneratedFunctions.union_set_set(this._inner, ((IntSet) other)._inner);
         }
         return new IntSet(result);
     }
@@ -468,10 +469,10 @@ public class IntSet extends Set<Integer> implements Number{
     public float distance(Object other) throws Exception {
         float answer=0;
         if (other instanceof Integer){
-            answer= (float) functions.distance_set_int(this._inner, (int) other);
+            answer= (float) GeneratedFunctions.distance_set_int(this._inner, (int) other);
         }
         else if(other instanceof IntSet){
-            answer= functions.distance_intset_intset(this._inner, ((IntSet) other)._inner);
+            answer= GeneratedFunctions.distance_intset_intset(this._inner, ((IntSet) other)._inner);
         }
         else if(other instanceof IntSpan){
             answer= this.to_spanset().distance(other);

--- a/jmeos-core/src/main/java/types/collections/number/IntSpan.java
+++ b/jmeos-core/src/main/java/types/collections/number/IntSpan.java
@@ -3,6 +3,7 @@ import types.collections.base.Base;
 import types.collections.base.Span;
 import jnr.ffi.Pointer;
 import functions.functions;
+import functions.GeneratedFunctions;
 
 /**
  * Class for representing sets of contiguous integer values between a lower and
@@ -35,41 +36,41 @@ public class IntSpan extends Span<Integer> implements Number{
 
     public IntSpan(String str){
         super(str);
-        _inner = functions.intspan_in(str);
+        _inner = GeneratedFunctions.intspan_in(str);
     }
 
     public IntSpan(int lower, int upper, boolean lower_inc, boolean upper_inc){
         super(lower,upper,lower_inc,upper_inc);
-        _inner = functions.intspan_make(lower,upper,lower_inc,upper_inc);
+        _inner = GeneratedFunctions.intspan_make(lower,upper,lower_inc,upper_inc);
     }
 
     public IntSpan(int lower, String upper, boolean lower_inc, boolean upper_inc){
         super(lower,upper,lower_inc,upper_inc);
         int new_upper = Integer.parseInt(upper);
-        _inner = functions.intspan_make(lower,new_upper,lower_inc,upper_inc);
+        _inner = GeneratedFunctions.intspan_make(lower,new_upper,lower_inc,upper_inc);
     }
 
     public IntSpan(String lower, String upper, boolean lower_inc, boolean upper_inc){
         super(lower,upper,lower_inc,upper_inc);
         int new_upper = Integer.parseInt(upper);
         int new_lower = Integer.parseInt(lower);
-        _inner = functions.intspan_make(new_lower,new_upper,lower_inc,upper_inc);
+        _inner = GeneratedFunctions.intspan_make(new_lower,new_upper,lower_inc,upper_inc);
     }
 
     public IntSpan(String lower, int upper, boolean lower_inc, boolean upper_inc){
         super(lower,upper,lower_inc,upper_inc);
         int new_lower = Integer.parseInt(lower);
-        _inner = functions.intspan_make(new_lower,upper,lower_inc,upper_inc);
+        _inner = GeneratedFunctions.intspan_make(new_lower,upper,lower_inc,upper_inc);
     }
 
     public IntSpan(int lower, int upper){
         super(lower,upper,true,false);
-        _inner = functions.intspan_make(lower,upper,true,false);
+        _inner = GeneratedFunctions.intspan_make(lower,upper,true,false);
     }
 
     @Override
     public Pointer createStringInner(String str){
-        return functions.intspan_in(str);
+        return GeneratedFunctions.intspan_in(str);
     }
 
     @Override
@@ -79,27 +80,27 @@ public class IntSpan extends Span<Integer> implements Number{
 
     @Override
     public Pointer createIntInt(java.lang.Number lower, java.lang.Number upper, boolean lower_inc, boolean upper_inc){
-        return functions.intspan_make(lower.intValue(),upper.intValue(),lower_inc,upper_inc);
+        return GeneratedFunctions.intspan_make(lower.intValue(),upper.intValue(),lower_inc,upper_inc);
     }
     @Override
     public Pointer createIntStr(java.lang.Number lower, String upper, boolean lower_inc, boolean upper_inc){
         int new_upper = Integer.parseInt(upper);
-        return functions.intspan_make(lower.intValue(),new_upper,lower_inc,upper_inc);
+        return GeneratedFunctions.intspan_make(lower.intValue(),new_upper,lower_inc,upper_inc);
     }
     @Override
     public Pointer createStrStr(String lower, String upper, boolean lower_inc, boolean upper_inc){
         int new_upper = Integer.parseInt(upper);
         int new_lower = Integer.parseInt(lower);
-        return functions.intspan_make(new_lower,new_upper,lower_inc,upper_inc);
+        return GeneratedFunctions.intspan_make(new_lower,new_upper,lower_inc,upper_inc);
     }
     @Override
     public Pointer createStrInt(String lower, java.lang.Number upper, boolean lower_inc, boolean upper_inc){
         int new_lower = Integer.parseInt(lower);
-        return functions.intspan_make(new_lower,upper.intValue(),lower_inc,upper_inc);
+        return GeneratedFunctions.intspan_make(new_lower,upper.intValue(),lower_inc,upper_inc);
     }
     @Override
     public Pointer createIntIntNb(java.lang.Number lower, java.lang.Number upper){
-        return functions.intspan_make(lower.intValue(),upper.intValue(),true,false);
+        return GeneratedFunctions.intspan_make(lower.intValue(),upper.intValue(),true,false);
     }
 
     /**
@@ -111,11 +112,11 @@ public class IntSpan extends Span<Integer> implements Number{
      * @return a new IntSpan instance
      */
     public IntSpan copy(){
-        return new IntSpan(functions.span_copy(this._inner));
+        return new IntSpan(GeneratedFunctions.span_copy(this._inner));
     }
     /*
     public IntSpan from_wkb(Byte b){
-        return new IntSpan(functions.span_from_wkb(b));
+        return new IntSpan(GeneratedFunctions.span_from_wkb(b));
     }
 
      */
@@ -132,7 +133,7 @@ public class IntSpan extends Span<Integer> implements Number{
      * @return
      */
     public IntSpan from_hexwkb(String str){
-        return new IntSpan(functions.span_from_hexwkb(str));
+        return new IntSpan(GeneratedFunctions.span_from_hexwkb(str));
     }
 
     /* ------------------------- Output ---------------------------------------- */
@@ -148,7 +149,7 @@ public class IntSpan extends Span<Integer> implements Number{
      * @return A new {@link String} instance
      */
     public String toString(){
-        return functions.intspan_out(this._inner);
+        return GeneratedFunctions.intspan_out(this._inner);
     }
 
 
@@ -167,7 +168,7 @@ public class IntSpan extends Span<Integer> implements Number{
      * @return A new {@link IntSpanSet} instance
      */
     public IntSpanSet to_spanset(){
-        return new IntSpanSet(functions.span_to_spanset(this._inner));
+        return new IntSpanSet(GeneratedFunctions.span_to_spanset(this._inner));
     }
 
 
@@ -183,7 +184,7 @@ public class IntSpan extends Span<Integer> implements Number{
      */
 
     public FloatSpan tofloatspan(){
-        return new FloatSpan(functions.intspan_to_floatspan(this._inner));
+        return new FloatSpan(GeneratedFunctions.intspan_to_floatspan(this._inner));
     }
 
 
@@ -208,7 +209,7 @@ public class IntSpan extends Span<Integer> implements Number{
      * @return The lower bound of the span as a {@link Integer}
      */
     public Integer lower(){
-        return functions.intspan_lower(this._inner);
+        return GeneratedFunctions.intspan_lower(this._inner);
     }
 
 
@@ -224,7 +225,7 @@ public class IntSpan extends Span<Integer> implements Number{
      * @return The lower bound of the span as a {@link Integer}
      */
     public Integer upper(){
-        return functions.intspan_upper(this._inner);
+        return GeneratedFunctions.intspan_upper(this._inner);
     }
 
 
@@ -239,7 +240,7 @@ public class IntSpan extends Span<Integer> implements Number{
      * @return Returns a "float" representing the width of the span
      */
     public float width(){
-        return (float) functions.intspan_width(this._inner);
+        return (float) GeneratedFunctions.intspan_width(this._inner);
     }
 
     /* ------------------------- Transformations ------------------------------- */
@@ -295,7 +296,7 @@ public class IntSpan extends Span<Integer> implements Number{
      */
 
     public IntSpan shift_scale(int delta, int width){
-        return new IntSpan(functions.intspanset_shift_scale(this._inner,delta,width,delta != 0,width!=0));
+        return new IntSpan(GeneratedFunctions.intspanset_shift_scale(this._inner,delta,width,delta != 0,width!=0));
     }
 
 
@@ -319,7 +320,7 @@ public class IntSpan extends Span<Integer> implements Number{
      */
     public boolean is_adjacent(Object other) throws Exception {
         if (other instanceof Integer){
-            return functions.adjacent_span_int(this._inner, (int) other);
+            return GeneratedFunctions.adjacent_span_int(this._inner, (int) other);
         }
         else {
             return super.is_adjacent((Base) other);
@@ -342,7 +343,7 @@ public class IntSpan extends Span<Integer> implements Number{
      */
     public boolean contains(Object other) throws Exception {
         if (other instanceof Integer){
-            return functions.contains_span_int(this._inner, (int) other);
+            return GeneratedFunctions.contains_span_int(this._inner, (int) other);
         }
         else {
             return super.contains((Base) other);
@@ -365,7 +366,7 @@ public class IntSpan extends Span<Integer> implements Number{
      */
     public boolean is_same(Object other) throws Exception {
         if (other instanceof Integer){
-            return functions.span_eq(this._inner, functions.int_to_span((int)other));
+            return GeneratedFunctions.span_eq(this._inner, GeneratedFunctions.int_to_span((int)other));
         }
         else {
             return super.is_same((Base) other);
@@ -394,7 +395,7 @@ public class IntSpan extends Span<Integer> implements Number{
      */
     public boolean is_left(Object other) throws Exception {
         if (other instanceof Integer){
-            return functions.left_span_int(this._inner, (int) other);
+            return GeneratedFunctions.left_span_int(this._inner, (int) other);
         }
         else {
             return super.is_left((Base) other);
@@ -419,7 +420,7 @@ public class IntSpan extends Span<Integer> implements Number{
      */
     public boolean is_over_or_left(Object other) throws Exception {
         if (other instanceof Integer){
-            return functions.overleft_span_int(this._inner, (int) other);
+            return GeneratedFunctions.overleft_span_int(this._inner, (int) other);
         }
         else {
             return super.is_over_or_left((Base) other);
@@ -443,7 +444,7 @@ public class IntSpan extends Span<Integer> implements Number{
      */
     public boolean is_right(Object other) throws Exception {
         if (other instanceof Integer){
-            return functions.right_span_int(this._inner, (int) other);
+            return GeneratedFunctions.right_span_int(this._inner, (int) other);
         }
         else {
             return super.is_right((Base) other);
@@ -468,7 +469,7 @@ public class IntSpan extends Span<Integer> implements Number{
      */
     public boolean is_over_or_right(Object other) throws Exception {
         if (other instanceof Integer){
-            return functions.overright_span_int(this._inner, (int) other);
+            return GeneratedFunctions.overright_span_int(this._inner, (int) other);
         }
         else {
             return super.is_over_or_right((Base) other);
@@ -496,7 +497,7 @@ public class IntSpan extends Span<Integer> implements Number{
      */
     public Float distance(Object other) throws Exception {
         if (other instanceof Integer){
-            return (float) functions.distance_span_int(this._inner, (int) other);
+            return (float) GeneratedFunctions.distance_span_int(this._inner, (int) other);
         }
         return 0f;
     }
@@ -508,16 +509,16 @@ public class IntSpan extends Span<Integer> implements Number{
     public IntSpan intersection(Object other) throws Exception {
         Pointer result = null;
         if ((other instanceof Integer) || (other instanceof Float)){
-            result= functions.intersection_span_int(this._inner, (int) other);
+            result= GeneratedFunctions.intersection_span_int(this._inner, (int) other);
         }
         else if (other instanceof IntSpan){
-            result= functions.intersection_span_span(this._inner, ((IntSpan) other)._inner);
+            result= GeneratedFunctions.intersection_span_span(this._inner, ((IntSpan) other)._inner);
         }
         else if (other instanceof IntSpanSet){
-            result= functions.intersection_spanset_span(this._inner, ((IntSpanSet) other).get_inner());
+            result= GeneratedFunctions.intersection_spanset_span(this._inner, ((IntSpanSet) other).get_inner());
         }
         else if ((other instanceof IntSet)){
-            result= functions.intersection_set_set(this._inner, ((IntSet) other).get_inner());
+            result= GeneratedFunctions.intersection_set_set(this._inner, ((IntSet) other).get_inner());
         }
         else {
             throw new Exception("Operation not supported with " + other + " type");
@@ -541,13 +542,13 @@ public class IntSpan extends Span<Integer> implements Number{
     public IntSpanSet minus(Object other){
         Pointer result = null;
         if (other instanceof Integer){
-            result = functions.minus_span_int(this._inner,(int)other);
+            result = GeneratedFunctions.minus_span_int(this._inner,(int)other);
         }
         else if (other instanceof IntSpan) {
-            result = functions.minus_span_span(this._inner,((IntSpan) other).get_inner());
+            result = GeneratedFunctions.minus_span_span(this._inner,((IntSpan) other).get_inner());
         }
         else if (other instanceof IntSpanSet) {
-            result = functions.minus_spanset_span(((IntSpanSet) other).get_inner(), this._inner);
+            result = GeneratedFunctions.minus_spanset_span(((IntSpanSet) other).get_inner(), this._inner);
         }
         return new IntSpanSet(result);
     }
@@ -569,13 +570,13 @@ public class IntSpan extends Span<Integer> implements Number{
     public IntSpanSet union(Object other) throws Exception {
         Pointer result = null;
         if (other instanceof Integer){
-            result = functions.union_span_int(this._inner,(int)other);
+            result = GeneratedFunctions.union_span_int(this._inner,(int)other);
         }
         else if (other instanceof IntSpan) {
-            result = functions.union_span_span(this._inner,((IntSpan) other).get_inner());
+            result = GeneratedFunctions.union_span_span(this._inner,((IntSpan) other).get_inner());
         }
         else if (other instanceof IntSpanSet) {
-            result = functions.union_spanset_span(((IntSpanSet) other).get_inner(), this._inner);
+            result = GeneratedFunctions.union_spanset_span(((IntSpanSet) other).get_inner(), this._inner);
         }
         else {
             throw new Exception("Operation not supported with this type");

--- a/jmeos-core/src/main/java/types/collections/number/IntSpanSet.java
+++ b/jmeos-core/src/main/java/types/collections/number/IntSpanSet.java
@@ -7,6 +7,7 @@ import types.collections.base.Base;
 import types.collections.base.SpanSet;
 import jnr.ffi.Pointer;
 import functions.functions;
+import functions.GeneratedFunctions;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -46,13 +47,13 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
 
     public IntSpanSet(String str){
         super(str);
-        this._inner = functions.intspanset_in(str);
+        this._inner = GeneratedFunctions.intspanset_in(str);
     }
 
 
     @Override
     public Pointer createStringInner(String str){
-        return functions.intspanset_in(str);
+        return GeneratedFunctions.intspanset_in(str);
     }
 
     @Override
@@ -79,7 +80,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
      * @return A new {@link String} instance
      */
     public String toString(){
-        return functions.intspanset_out(this._inner);
+        return GeneratedFunctions.intspanset_out(this._inner);
     }
 
 
@@ -97,7 +98,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
      * @return A new {@link IntSpan} instance
      */
     public IntSpan to_span(){
-        return new IntSpan(functions.spanset_span(this._inner));
+        return new IntSpan(GeneratedFunctions.spanset_span(this._inner));
     }
 
     /**
@@ -112,7 +113,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
      */
 
     public FloatSpanSet to_floatspanset(){
-        return new FloatSpanSet(functions.intspanset_to_floatspanset(this._inner));
+        return new FloatSpanSet(GeneratedFunctions.intspanset_to_floatspanset(this._inner));
     }
 
 
@@ -141,7 +142,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
      * @return A `float` representing the duration of the spanset
      */
     public int width(boolean ignore_gaps){
-        return functions.intspanset_width(this._inner, ignore_gaps);
+        return GeneratedFunctions.intspanset_width(this._inner, ignore_gaps);
     }
 
     /*
@@ -153,7 +154,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
       @return A {@link IntSpan} instance
      */
     public IntSpan start_span(){
-        return new IntSpan(functions.spanset_start_span(this._inner));
+        return new IntSpan(GeneratedFunctions.spanset_start_span(this._inner));
     }
 
     /*
@@ -165,7 +166,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
       @return A {@link IntSpan} instance
      */
     public IntSpan end_span(){
-        return new IntSpan(functions.spanset_end_span(this._inner));
+        return new IntSpan(GeneratedFunctions.spanset_end_span(this._inner));
     }
 
     /*
@@ -177,7 +178,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
       @return A {@link IntSpan} instance
      */
     public IntSpan span_n(int n){
-        return new IntSpan(functions.spanset_span_n(this._inner, n));
+        return new IntSpan(GeneratedFunctions.spanset_span_n(this._inner, n));
     }
 
 
@@ -249,7 +250,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
      */
 
     public IntSpanSet shift_scale(int delta, int width){
-        return new IntSpanSet(functions.intspanset_shift_scale(this._inner,delta,width,delta != 0,width!=0));
+        return new IntSpanSet(GeneratedFunctions.intspanset_shift_scale(this._inner,delta,width,delta != 0,width!=0));
     }
 
 
@@ -278,7 +279,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
     public boolean is_adjacent(Object other) throws Exception {
         boolean answer = false;
         if (other instanceof Integer){
-            answer = functions.adjacent_spanset_int(this._inner, (int) other);
+            answer = GeneratedFunctions.adjacent_spanset_int(this._inner, (int) other);
         }
         else{
             answer = super.is_adjacent((Base)other);
@@ -303,7 +304,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
     public boolean contains(Object other) throws Exception {
         boolean answer = false;
         if (other instanceof Integer){
-            answer = functions.contains_spanset_int(this._inner, (int) other);
+            answer = GeneratedFunctions.contains_spanset_int(this._inner, (int) other);
         }
         else{
             answer = super.contains((Base)other);
@@ -326,7 +327,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
      */
     public boolean is_same(Object other) throws Exception {
         if (other instanceof Integer){
-            return functions.spanset_eq(this._inner,functions.int_to_spanset((int) other));
+            return GeneratedFunctions.spanset_eq(this._inner,GeneratedFunctions.int_to_spanset((int) other));
         }
         else{
             return super.is_same((Base)other);
@@ -354,7 +355,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
     public boolean is_left(Object other) throws Exception {
         boolean answer = false;
         if (other instanceof Integer){
-            answer = functions.left_spanset_int(this._inner,(int) other);
+            answer = GeneratedFunctions.left_spanset_int(this._inner,(int) other);
         }
         else{
             answer = super.is_left((Base)other);
@@ -381,7 +382,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
     public boolean is_over_or_left(Object other) throws Exception {
         boolean answer = false;
         if (other instanceof Integer){
-            answer = functions.overleft_spanset_int(this._inner,(int) other);
+            answer = GeneratedFunctions.overleft_spanset_int(this._inner,(int) other);
         }
         else{
             answer = super.is_over_or_left((Base)other);
@@ -408,7 +409,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
     public boolean is_right(Object other) throws Exception {
         boolean answer = false;
         if (other instanceof Integer){
-            answer = functions.right_spanset_int(this._inner,(int) other);
+            answer = GeneratedFunctions.right_spanset_int(this._inner,(int) other);
         }
         else{
             answer = super.is_right((Base)other);
@@ -436,7 +437,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
     public boolean is_over_or_right(Object other) throws Exception {
         boolean answer = false;
         if (other instanceof Integer){
-            answer = functions.overright_spanset_int(this._inner,(int) other);
+            answer = GeneratedFunctions.overright_spanset_int(this._inner,(int) other);
         }
         else{
             answer = super.is_over_or_right((Base)other);
@@ -464,14 +465,14 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
     public float distance(Object other) throws Exception {
         float answer = 0;
         if (other instanceof Integer) {
-            answer = (float) functions.distance_spanset_int(this._inner, (int) other);
+            answer = (float) GeneratedFunctions.distance_spanset_int(this._inner, (int) other);
         } else if (other instanceof IntSet) {
             IntSpan is = ((IntSet) other).to_span(IntSpan.class);
-            answer = (float) functions.distance_intspanset_intspan(this._inner, (is).get_inner());
+            answer = (float) GeneratedFunctions.distance_intspanset_intspan(this._inner, (is).get_inner());
         } else if (other instanceof IntSpan) {
-            answer = (float) functions.distance_intspanset_intspan(this._inner, ((IntSpan) other).get_inner());
+            answer = (float) GeneratedFunctions.distance_intspanset_intspan(this._inner, ((IntSpan) other).get_inner());
         } else if (other instanceof IntSpanSet) {
-            answer = (float) functions.distance_intspanset_intspanset(this._inner, ((IntSpanSet) other).get_inner());
+            answer = (float) GeneratedFunctions.distance_intspanset_intspanset(this._inner, ((IntSpanSet) other).get_inner());
         } else {
             throw new Exception("Operation not supported with " + other + " type");
         }
@@ -492,7 +493,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
     public IntSpanSet intersection(Object other) throws Exception {
         Pointer result = null;
         if (other instanceof Integer){
-            result= functions.intersection_spanset_int(this._inner, (int) other);
+            result= GeneratedFunctions.intersection_spanset_int(this._inner, (int) other);
         }
         else{
             IntSpanSet tmp= (IntSpanSet) super.intersection((Base) other);
@@ -523,7 +524,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
     public IntSpanSet minus(Object other) throws Exception {
         Pointer result = null;
         if ((other instanceof Integer) || (other instanceof Float)){
-            result = functions.minus_spanset_int(this._inner, (int) other);
+            result = GeneratedFunctions.minus_spanset_int(this._inner, (int) other);
         }
         else{
             IntSpanSet tmp = (IntSpanSet) super.minus((Base) other);
@@ -556,7 +557,7 @@ public class IntSpanSet extends SpanSet<Integer> implements Number{
     public IntSpanSet union(Object other) throws Exception {
         Pointer result = null;
         if ((other instanceof Integer) || (other instanceof Float)){
-            result = functions.union_spanset_int(this._inner, (int) other);
+            result = GeneratedFunctions.union_spanset_int(this._inner, (int) other);
         }
         else{
             IntSpanSet tmp = (IntSpanSet) super.minus((Base) other);

--- a/jmeos-core/src/main/java/types/collections/time/dateset.java
+++ b/jmeos-core/src/main/java/types/collections/time/dateset.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import functions.functions;
+import functions.GeneratedFunctions;
 import utils.ConversionUtils;
 
 /**
@@ -51,7 +52,7 @@ public class dateset extends Set<LocalDate> implements Time, TimeCollection{
 
     public dateset(String value){
         super(value);
-        _inner = functions.dateset_in(value);
+        _inner = GeneratedFunctions.dateset_in(value);
     }
 
     public dateset(List<LocalDate> dates)  {
@@ -68,7 +69,7 @@ public class dateset extends Set<LocalDate> implements Time, TimeCollection{
         }
         sb.append("}");
 //        System.out.println(sb);
-        _inner = functions.dateset_in(sb.toString());
+        _inner = GeneratedFunctions.dateset_in(sb.toString());
     }
 
     /**
@@ -92,7 +93,7 @@ public class dateset extends Set<LocalDate> implements Time, TimeCollection{
 
     @Override
     public Pointer createStringInner(String str) {
-        return functions.dateset_in(str);
+        return GeneratedFunctions.dateset_in(str);
     }
 
     @Override
@@ -102,7 +103,7 @@ public class dateset extends Set<LocalDate> implements Time, TimeCollection{
 
 
     public String toString(){
-        return functions.dateset_out(this.get_inner());
+        return GeneratedFunctions.dateset_out(this.get_inner());
     }
 
 /**
@@ -111,7 +112,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public LocalDate date_adt_to_date(int ts){
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        String dateStr= functions.date_out(ts);
+        String dateStr= GeneratedFunctions.date_out(ts);
         return LocalDate.parse(dateStr, DateTimeFormatter.ISO_LOCAL_DATE);
     }
 
@@ -126,7 +127,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     @Override
     public LocalDate start_element() throws ParseException {
-        return date_adt_to_date(functions.dateset_start_value(this._inner));
+        return date_adt_to_date(GeneratedFunctions.dateset_start_value(this._inner));
     }
 
 /**
@@ -140,7 +141,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     @Override
     public LocalDate end_element() throws ParseException {
-        return date_adt_to_date(functions.dateset_end_value(this._inner));
+        return date_adt_to_date(GeneratedFunctions.dateset_end_value(this._inner));
     }
 
     /**
@@ -243,7 +244,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     */
 
     public dateset shift_scale(Integer shift, Integer duration){
-        return new dateset(functions.dateset_shift_scale(this._inner, shift, duration, shift!=0, duration!=0));
+        return new dateset(GeneratedFunctions.dateset_shift_scale(this._inner, shift, duration, shift!=0, duration!=0));
     }
 
     /**
@@ -267,15 +268,15 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
                 contains_set_date, contains_set_set, contains_spanset_spanset
     */
     public int dateToTimestamp(LocalDate date){
-       return functions.date_in(date.toString());
+       return GeneratedFunctions.date_in(date.toString());
     }
 
     public boolean contains(Object other) throws Exception {
         if (other instanceof LocalDateTime){
-            return functions.contains_set_date(this._inner, dateToTimestamp(((LocalDateTime) other).toLocalDate()));
+            return GeneratedFunctions.contains_set_date(this._inner, dateToTimestamp(((LocalDateTime) other).toLocalDate()));
         }
         else if (other instanceof LocalDate){
-            return functions.contains_set_date(this._inner, dateToTimestamp((LocalDate) other));
+            return GeneratedFunctions.contains_set_date(this._inner, dateToTimestamp((LocalDate) other));
         }
         else {
             return super.contains((Base) other);
@@ -306,7 +307,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean overlaps(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.contains_set_date(this._inner, dateToTimestamp(((LocalDate) other)));
+            return GeneratedFunctions.contains_set_date(this._inner, dateToTimestamp(((LocalDate) other)));
         }
         if (other instanceof datespan){
             return this.to_span(datespan.class).is_adjacent((Base) other);
@@ -343,7 +344,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean is_left(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.before_set_date(this._inner, dateToTimestamp(((LocalDate) other)));
+            return GeneratedFunctions.before_set_date(this._inner, dateToTimestamp(((LocalDate) other)));
         }
         if (other instanceof datespan){
             return this.to_span(datespan.class).is_left(other);
@@ -380,7 +381,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean is_over_or_left(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.overbefore_set_date(this._inner, dateToTimestamp(((LocalDate) other)));
+            return GeneratedFunctions.overbefore_set_date(this._inner, dateToTimestamp(((LocalDate) other)));
         }
         if (other instanceof datespan){
             return this.to_span(datespan.class).is_over_or_left(other);
@@ -417,7 +418,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean is_over_or_right(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.overafter_set_date(this._inner, dateToTimestamp(((LocalDate) other)));
+            return GeneratedFunctions.overafter_set_date(this._inner, dateToTimestamp(((LocalDate) other)));
         }
         if (other instanceof datespan){
             return this.to_span(datespan.class).is_over_or_right(other);
@@ -455,7 +456,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean is_right(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.after_set_date(this._inner, dateToTimestamp(((LocalDate) other)));
+            return GeneratedFunctions.after_set_date(this._inner, dateToTimestamp(((LocalDate) other)));
         }
         if (other instanceof datespan){
             return this.to_span(datespan.class).is_over_or_left(other);
@@ -509,9 +510,9 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     public Duration distance(Object other) throws Exception {
         Duration answer = null;
         if (other instanceof LocalDate) {
-            answer= Duration.ofSeconds(functions.distance_set_date(this._inner, dateToTimestamp((LocalDate) other)));
+            answer= Duration.ofSeconds(GeneratedFunctions.distance_set_date(this._inner, dateToTimestamp((LocalDate) other)));
         } else if (other instanceof dateset) {
-            answer= Duration.ofSeconds(functions.distance_dateset_dateset(this._inner, ((dateset) other)._inner));
+            answer= Duration.ofSeconds(GeneratedFunctions.distance_dateset_dateset(this._inner, ((dateset) other)._inner));
         } else if (other instanceof datespan) {
             answer= this.to_spanset(datespan.class).distance(other);
         } else if (other instanceof datespanset) {
@@ -544,18 +545,18 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     public Time intersection(Object other) throws Exception {
         Time result;
         if (other instanceof LocalDate){
-            result = new dateset(functions.intersection_set_date(this._inner, dateToTimestamp((LocalDate) other)));
+            result = new dateset(GeneratedFunctions.intersection_set_date(this._inner, dateToTimestamp((LocalDate) other)));
         }
         else if (other instanceof dateset){
-            result = new dateset(functions.intersection_set_set(this._inner, ((dateset) other)._inner));
+            result = new dateset(GeneratedFunctions.intersection_set_set(this._inner, ((dateset) other)._inner));
         }
         else if (other instanceof datespan){
             datespan ds = this.to_span(datespan.class);
-            result = new datespan(functions.intersection_span_span(ds.get_inner(), ((datespan) other).get_inner()));
+            result = new datespan(GeneratedFunctions.intersection_span_span(ds.get_inner(), ((datespan) other).get_inner()));
         }
         else if (other instanceof datespanset){
             datespanset dss = this.to_spanset(datespanset.class);
-            result = new datespanset(functions.intersection_spanset_spanset(dss.get_inner(), ((datespanset) other).get_inner()));
+            result = new datespanset(GeneratedFunctions.intersection_spanset_spanset(dss.get_inner(), ((datespanset) other).get_inner()));
         }
         else{
             throw new Exception("Operation not supported with this type");
@@ -580,18 +581,18 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     public Time minus(Object other) throws Exception{
         Time result;
         if (other instanceof LocalDate){
-            result = new dateset(functions.minus_set_date(this._inner, dateToTimestamp((LocalDate) other)));
+            result = new dateset(GeneratedFunctions.minus_set_date(this._inner, dateToTimestamp((LocalDate) other)));
         }
         else if (other instanceof dateset){
-            result = new dateset(functions.minus_set_set(this._inner, ((dateset) other)._inner));
+            result = new dateset(GeneratedFunctions.minus_set_set(this._inner, ((dateset) other)._inner));
         }
         else if (other instanceof datespan){
             datespan ds = this.to_span(datespan.class);
-            result = new datespanset(functions.minus_span_span(ds.get_inner(), ((datespan) other).get_inner()));
+            result = new datespanset(GeneratedFunctions.minus_span_span(ds.get_inner(), ((datespan) other).get_inner()));
         }
         else if (other instanceof datespanset){
             datespanset dss = this.to_spanset(datespanset.class);
-            result = new datespanset(functions.minus_spanset_spanset(dss.get_inner(), ((datespanset) other).get_inner()));
+            result = new datespanset(GeneratedFunctions.minus_spanset_spanset(dss.get_inner(), ((datespanset) other).get_inner()));
         }
         else{
             throw new Exception("Operation not supported with this type");
@@ -613,7 +614,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 */
 
     public dateset subtract_from(LocalDate other) throws Exception {
-        return new dateset(functions.minus_date_set(dateToTimestamp(other), this._inner));
+        return new dateset(GeneratedFunctions.minus_date_set(dateToTimestamp(other), this._inner));
     }
 
 /**
@@ -633,21 +634,21 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     public dateset union(Object other) throws Exception{
         dateset result = null;
         if (other instanceof LocalDate){
-            Pointer resultPointer= functions.union_set_date(this._inner, dateToTimestamp((LocalDate) other));
+            Pointer resultPointer= GeneratedFunctions.union_set_date(this._inner, dateToTimestamp((LocalDate) other));
             result = new dateset(resultPointer);
         }
         else if (other instanceof dateset){
-            Pointer resultPointer= functions.union_set_set(this._inner, ((dateset) other)._inner);
+            Pointer resultPointer= GeneratedFunctions.union_set_set(this._inner, ((dateset) other)._inner);
             result = new dateset(resultPointer);
         }
         else if (other instanceof datespan){
             datespan ds = this.to_span(datespan.class);
-            Pointer resultPointer= functions.union_span_span(ds.get_inner(), ((datespan) other).get_inner());
+            Pointer resultPointer= GeneratedFunctions.union_span_span(ds.get_inner(), ((datespan) other).get_inner());
             result = new dateset(resultPointer);
         }
         else if (other instanceof datespanset){
             datespanset dss = this.to_spanset(datespanset.class);
-            Pointer resultPointer= functions.union_spanset_spanset(dss.get_inner(), ((datespanset) other).get_inner());
+            Pointer resultPointer= GeneratedFunctions.union_spanset_spanset(dss.get_inner(), ((datespanset) other).get_inner());
             result = new dateset(resultPointer);
         }
         else{

--- a/jmeos-core/src/main/java/types/collections/time/datespan.java
+++ b/jmeos-core/src/main/java/types/collections/time/datespan.java
@@ -13,6 +13,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import utils.ConversionUtils;
 
 /**
@@ -46,7 +47,7 @@ public class datespan extends Span<LocalDate> implements Time, TimeCollection{
 
     public datespan(String str) {
         super(str);
-        _inner = functions.datespan_in(str);
+        _inner = GeneratedFunctions.datespan_in(str);
     }
 
 //    // Formatter for parsing date strings
@@ -67,7 +68,7 @@ public class datespan extends Span<LocalDate> implements Time, TimeCollection{
 //        }
 //        this.lowerInc = lowerInc;
 //        this.upperInc = upperInc;
-//        _inner= functions.datespan_make(time)
+//        _inner= GeneratedFunctions.datespan_make(time)
 //    }
 //
 //    // Constructor accepting LocalDate bounds with specified inclusivity
@@ -104,7 +105,7 @@ public class datespan extends Span<LocalDate> implements Time, TimeCollection{
 */
 
     public tstzspan to_tstzspan() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
-        return new tstzspan(functions.datespan_to_tstzspan(this._inner));
+        return new tstzspan(GeneratedFunctions.datespan_to_tstzspan(this._inner));
     }
 
 /**
@@ -118,7 +119,7 @@ public class datespan extends Span<LocalDate> implements Time, TimeCollection{
             datespan_duration
 */
     public Duration duration() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
-        return ConversionUtils.interval_to_timedelta(functions.datespan_duration(this._inner));
+        return ConversionUtils.interval_to_timedelta(GeneratedFunctions.datespan_duration(this._inner));
     }
 
 /**
@@ -142,7 +143,7 @@ public class datespan extends Span<LocalDate> implements Time, TimeCollection{
 
     @Override
     public Pointer createStringInner(String str) {
-        return functions.datespan_in(str);
+        return GeneratedFunctions.datespan_in(str);
     }
 
     @Override
@@ -172,12 +173,12 @@ public class datespan extends Span<LocalDate> implements Time, TimeCollection{
 
     @Override
     public LocalDate lower() {
-        return date_adt_to_date(functions.datespan_lower(this._inner));
+        return date_adt_to_date(GeneratedFunctions.datespan_lower(this._inner));
     }
 
     @Override
     public LocalDate upper() {
-        return date_adt_to_date(functions.datespan_upper(this._inner));
+        return date_adt_to_date(GeneratedFunctions.datespan_upper(this._inner));
     }
 
     @Override
@@ -187,7 +188,7 @@ public class datespan extends Span<LocalDate> implements Time, TimeCollection{
 
 
     public String toString(){
-        return functions.datespan_out(this.get_inner());
+        return GeneratedFunctions.datespan_out(this.get_inner());
     }
 
 /**
@@ -196,7 +197,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public LocalDate date_adt_to_date(int ts){
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        String dateStr= functions.date_out(ts);
+        String dateStr= GeneratedFunctions.date_out(ts);
         return LocalDate.parse(dateStr, DateTimeFormatter.ISO_LOCAL_DATE);
     }
 
@@ -211,7 +212,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public LocalDate start_element() throws ParseException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
         datespanset dss = this.to_spanset(datespanset.class);
-        return date_adt_to_date(functions.datespanset_start_date(dss.get_inner()));
+        return date_adt_to_date(GeneratedFunctions.datespanset_start_date(dss.get_inner()));
     }
 
 /**
@@ -225,7 +226,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     
     public LocalDate end_element() throws ParseException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
         datespanset dss = this.to_spanset(datespanset.class);
-        return date_adt_to_date(functions.datespanset_end_date(dss.get_inner()));
+        return date_adt_to_date(GeneratedFunctions.datespanset_end_date(dss.get_inner()));
     }
 
 /**
@@ -294,7 +295,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 */
 
     public datespan shift_scale(Integer shift, Integer duration){
-        return new datespan(functions.datespan_shift_scale(this._inner, shift, duration, shift!=0, duration!=0));
+        return new datespan(GeneratedFunctions.datespan_shift_scale(this._inner, shift, duration, shift!=0, duration!=0));
     }
 
 /**
@@ -318,15 +319,15 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
             contains_span_span, contains_span_spanset, contains_span_date
 */
     public int dateToTimestamp(LocalDate date){
-        return functions.date_in(date.toString());
+        return GeneratedFunctions.date_in(date.toString());
     }
 
     public boolean contains(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.contains_span_date(this._inner, dateToTimestamp((LocalDate) other));
+            return GeneratedFunctions.contains_span_date(this._inner, dateToTimestamp((LocalDate) other));
         }
         else if (other instanceof LocalDateTime){
-            return functions.contains_span_date(this._inner, dateToTimestamp(((LocalDateTime) other).toLocalDate()));
+            return GeneratedFunctions.contains_span_date(this._inner, dateToTimestamp(((LocalDateTime) other).toLocalDate()));
         }
         else {
             return super.contains((Base) other);
@@ -349,7 +350,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     
     public boolean is_adjacent(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.adjacent_span_date(this._inner, dateToTimestamp((LocalDate) other));
+            return GeneratedFunctions.adjacent_span_date(this._inner, dateToTimestamp((LocalDate) other));
         }
         else{
             return super.is_adjacent((Base) other);
@@ -412,7 +413,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean is_left(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.before_span_date(this._inner, dateToTimestamp(((LocalDate) other)));
+            return GeneratedFunctions.before_span_date(this._inner, dateToTimestamp(((LocalDate) other)));
         }
         else {
             return super.is_left((Base) other);
@@ -443,7 +444,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean is_over_or_left(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.overbefore_span_date(this._inner, dateToTimestamp(((LocalDate) other)));
+            return GeneratedFunctions.overbefore_span_date(this._inner, dateToTimestamp(((LocalDate) other)));
         }
         else {
             return super.is_over_or_left((Base) other);
@@ -474,7 +475,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean is_over_or_right(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.overafter_span_date(this._inner, dateToTimestamp(((LocalDate) other)));
+            return GeneratedFunctions.overafter_span_date(this._inner, dateToTimestamp(((LocalDate) other)));
         }
         else {
             return super.is_over_or_right((Base) other);
@@ -506,7 +507,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean is_right(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.after_span_date(this._inner, dateToTimestamp(((LocalDate) other)));
+            return GeneratedFunctions.after_span_date(this._inner, dateToTimestamp(((LocalDate) other)));
         }
         else {
             return super.is_right((Base) other);
@@ -553,14 +554,14 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     public Duration distance(Object other) throws Exception {
         Duration answer = null;
         if (other instanceof LocalDate) {
-            answer= Duration.ofSeconds(functions.distance_span_date(this._inner, dateToTimestamp((LocalDate) other)));
+            answer= Duration.ofSeconds(GeneratedFunctions.distance_span_date(this._inner, dateToTimestamp((LocalDate) other)));
         } else if (other instanceof dateset) {
             datespanset ds = ((dateset) other).to_spanset(datespanset.class);
-            answer= Duration.ofSeconds(functions.distance_datespanset_datespan(ds.get_inner(), this.get_inner()));
+            answer= Duration.ofSeconds(GeneratedFunctions.distance_datespanset_datespan(ds.get_inner(), this.get_inner()));
         } else if (other instanceof datespan) {
-            answer= Duration.ofSeconds(functions.distance_datespan_datespan(this._inner, ((datespan)other)._inner));
+            answer= Duration.ofSeconds(GeneratedFunctions.distance_datespan_datespan(this._inner, ((datespan)other)._inner));
         } else if (other instanceof datespanset) {
-            answer= Duration.ofSeconds(functions.distance_datespanset_datespan(((datespanset) other).get_inner(), this._inner));
+            answer= Duration.ofSeconds(GeneratedFunctions.distance_datespanset_datespan(((datespanset) other).get_inner(), this._inner));
         } else {
             throw new Exception("Operation not supported with " + other + " type");
         }
@@ -587,17 +588,17 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     public Time intersection(Object other) throws Exception {
         Time result;
         if (other instanceof LocalDate){
-            result = new datespan(functions.intersection_span_date(this._inner, dateToTimestamp((LocalDate) other)));
+            result = new datespan(GeneratedFunctions.intersection_span_date(this._inner, dateToTimestamp((LocalDate) other)));
         }
         else if (other instanceof datespan){
-            result = new datespan(functions.intersection_span_span(this._inner, ((datespan) other)._inner));
+            result = new datespan(GeneratedFunctions.intersection_span_span(this._inner, ((datespan) other)._inner));
         }
         else if (other instanceof dateset){
             datespanset ds = ((dateset) other).to_spanset(datespanset.class);
-            result = new datespanset(functions.intersection_spanset_span(ds.get_inner(), this._inner));
+            result = new datespanset(GeneratedFunctions.intersection_spanset_span(ds.get_inner(), this._inner));
         }
         else if (other instanceof datespanset){
-            result = new datespanset(functions.intersection_spanset_span(((datespanset) other).get_inner(), this._inner));
+            result = new datespanset(GeneratedFunctions.intersection_spanset_span(((datespanset) other).get_inner(), this._inner));
         }
         else{
             throw new Exception("Operation not supported with this type");
@@ -621,20 +622,20 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     public datespanset minus(Object other) throws Exception{
         datespanset result = null;
         if (other instanceof LocalDate){
-            Pointer resultPointer= functions.minus_span_date(this._inner, dateToTimestamp((LocalDate) other));
+            Pointer resultPointer= GeneratedFunctions.minus_span_date(this._inner, dateToTimestamp((LocalDate) other));
             result = new datespanset(resultPointer);
         }
         else if (other instanceof dateset){
             datespanset ds = ((dateset) other).to_spanset(datespanset.class);
-            Pointer resultPointer= functions.minus_spanset_span((ds).get_inner(), this._inner);
+            Pointer resultPointer= GeneratedFunctions.minus_spanset_span((ds).get_inner(), this._inner);
             result = new datespanset(resultPointer);
         }
         else if (other instanceof datespan){
-            Pointer resultPointer= functions.minus_span_span(this._inner, ((datespan) other)._inner);
+            Pointer resultPointer= GeneratedFunctions.minus_span_span(this._inner, ((datespan) other)._inner);
             result = new datespanset(resultPointer);
         }
         else if (other instanceof datespanset){
-            Pointer resultPointer= functions.minus_span_spanset(this._inner, ((datespanset) other).get_inner());
+            Pointer resultPointer= GeneratedFunctions.minus_span_spanset(this._inner, ((datespanset) other).get_inner());
             result = new datespanset(resultPointer);
         }
         else{
@@ -657,7 +658,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 */
 
     public datespanset subtract_from(LocalDate other) throws Exception {
-        return new datespanset(functions.minus_date_span(dateToTimestamp(other), this._inner));
+        return new datespanset(GeneratedFunctions.minus_date_span(dateToTimestamp(other), this._inner));
     }
 
 /**
@@ -676,20 +677,20 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     public datespanset union(Object other) throws Exception{
         datespanset result = null;
         if (other instanceof LocalDate){
-            Pointer resultPointer= functions.union_span_date(this._inner, dateToTimestamp((LocalDate) other));
+            Pointer resultPointer= GeneratedFunctions.union_span_date(this._inner, dateToTimestamp((LocalDate) other));
             result = new datespanset(resultPointer);
         }
         else if (other instanceof dateset){
             datespanset ds = ((dateset) other).to_spanset(datespanset.class);
-            Pointer resultPointer= functions.union_spanset_span((ds).get_inner(), this.get_inner());
+            Pointer resultPointer= GeneratedFunctions.union_spanset_span((ds).get_inner(), this.get_inner());
             result = new datespanset(resultPointer);
         }
         else if (other instanceof datespan){
-            Pointer resultPointer= functions.union_span_span(this._inner, ((datespan) other).get_inner());
+            Pointer resultPointer= GeneratedFunctions.union_span_span(this._inner, ((datespan) other).get_inner());
             result = new datespanset(resultPointer);
         }
         else if (other instanceof datespanset){
-            Pointer resultPointer= functions.union_spanset_span(((datespanset) other).get_inner(), this._inner);
+            Pointer resultPointer= GeneratedFunctions.union_spanset_span(((datespanset) other).get_inner(), this._inner);
             result = new datespanset(resultPointer);
         }
         else{

--- a/jmeos-core/src/main/java/types/collections/time/datespanset.java
+++ b/jmeos-core/src/main/java/types/collections/time/datespanset.java
@@ -16,6 +16,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import functions.functions;
+import functions.GeneratedFunctions;
 import utils.ConversionUtils;
 
 /**
@@ -46,7 +47,7 @@ public class datespanset extends SpanSet<LocalDate> implements Time, TimeCollect
 
     public datespanset(String str) {
         super(str);
-        _inner = functions.datespanset_in(str);
+        _inner = GeneratedFunctions.datespanset_in(str);
     }
 
     public datespanset(List<?> dspan) {
@@ -85,7 +86,7 @@ public class datespanset extends SpanSet<LocalDate> implements Time, TimeCollect
 
         sb.append("}");
 //        System.out.println(sb);
-        _inner = functions.datespanset_in(sb.toString());
+        _inner = GeneratedFunctions.datespanset_in(sb.toString());
     }
 
 /**
@@ -113,7 +114,7 @@ public class datespanset extends SpanSet<LocalDate> implements Time, TimeCollect
 */
 
     public tstzspanset to_tstzspanset() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
-        return new tstzspanset(functions.datespanset_to_tstzspanset(this._inner));
+        return new tstzspanset(GeneratedFunctions.datespanset_to_tstzspanset(this._inner));
     }
 
     /**
@@ -127,11 +128,11 @@ public class datespanset extends SpanSet<LocalDate> implements Time, TimeCollect
                 datespan_duration
     */
     public Duration duration(boolean ignore_gaps) throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
-        return ConversionUtils.interval_to_timedelta(functions.datespanset_duration(this._inner, ignore_gaps));
+        return ConversionUtils.interval_to_timedelta(GeneratedFunctions.datespanset_duration(this._inner, ignore_gaps));
     }
 
     public int num_dates(){
-        return functions.datespanset_num_dates(this._inner);
+        return GeneratedFunctions.datespanset_num_dates(this._inner);
     }
 
     @Override
@@ -141,7 +142,7 @@ public class datespanset extends SpanSet<LocalDate> implements Time, TimeCollect
 
     @Override
     public Pointer createStringInner(String str) {
-        return functions.datespanset_in(str);
+        return GeneratedFunctions.datespanset_in(str);
     }
 
     @Override
@@ -150,11 +151,11 @@ public class datespanset extends SpanSet<LocalDate> implements Time, TimeCollect
     }
 
     public LocalDate start_date(){
-        return date_adt_to_date(functions.datespanset_start_date(this._inner));
+        return date_adt_to_date(GeneratedFunctions.datespanset_start_date(this._inner));
     }
 
     public LocalDate end_date(){
-        return date_adt_to_date(functions.datespanset_end_date(this._inner));
+        return date_adt_to_date(GeneratedFunctions.datespanset_end_date(this._inner));
     }
 
 /**
@@ -170,7 +171,7 @@ public class datespanset extends SpanSet<LocalDate> implements Time, TimeCollect
             throw new Exception("Index out of bounds");
         }
         else{
-            Pointer resultPointer= functions.datespanset_date_n(this._inner, n+1);
+            Pointer resultPointer= GeneratedFunctions.datespanset_date_n(this._inner, n+1);
             assert resultPointer != null;
             int ts = resultPointer.getInt(0);
             return date_adt_to_date(ts);
@@ -178,7 +179,7 @@ public class datespanset extends SpanSet<LocalDate> implements Time, TimeCollect
     }
 
     public String toString(){
-        return functions.datespanset_out(this.get_inner());
+        return GeneratedFunctions.datespanset_out(this.get_inner());
     }
 
 /**
@@ -187,7 +188,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public LocalDate date_adt_to_date(int ts){
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        String dateStr= functions.date_out(ts);
+        String dateStr= GeneratedFunctions.date_out(ts);
         return LocalDate.parse(dateStr, DateTimeFormatter.ISO_LOCAL_DATE);
     }
 
@@ -201,7 +202,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     */
 
     public datespan start_span() throws ParseException {
-        return new datespan(functions.spanset_start_span(this._inner));
+        return new datespan(GeneratedFunctions.spanset_start_span(this._inner));
     }
 
 /**
@@ -214,16 +215,16 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 */
 
     public datespan end_element() throws ParseException {
-        return new datespan(functions.spanset_end_span(this._inner));
+        return new datespan(GeneratedFunctions.spanset_end_span(this._inner));
     }
 
     public datespan span_n(int n) throws ParseException {
-        return new datespan(functions.spanset_span_n(this._inner, n));
+        return new datespan(GeneratedFunctions.spanset_span_n(this._inner, n));
     }
 
     public List<datespan> elements() throws Exception {
         return super.spans(datespan.class);
-//        Pointer ps = functions.spanset_spans(this._inner);
+//        Pointer ps = GeneratedFunctions.spanset_spans(this._inner);
 //        int numSpans = this.num_spans();
 //        System.out.println(numSpans);
 //        List<datespan> spanList = new ArrayList<datespan>();
@@ -305,7 +306,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 */
 
     public datespanset shift_scale(Integer shift, Integer duration){
-        return new datespanset(functions.datespanset_shift_scale(this._inner, shift, duration, shift!=0, duration!=0));
+        return new datespanset(GeneratedFunctions.datespanset_shift_scale(this._inner, shift, duration, shift!=0, duration!=0));
     }
 
     /**
@@ -329,12 +330,12 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
                 contains_span_span, contains_span_spanset, contains_span_date
     */
     public int dateToTimestamp(LocalDate date){
-        return functions.date_in(date.toString());
+        return GeneratedFunctions.date_in(date.toString());
     }
 
     public boolean contains(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.contains_spanset_date(this._inner, dateToTimestamp((LocalDate) other));
+            return GeneratedFunctions.contains_spanset_date(this._inner, dateToTimestamp((LocalDate) other));
         }
         else {
             return super.contains((Base) other);
@@ -357,7 +358,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean is_adjacent(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.adjacent_spanset_date(this._inner, dateToTimestamp((LocalDate) other));
+            return GeneratedFunctions.adjacent_spanset_date(this._inner, dateToTimestamp((LocalDate) other));
         }
         else{
             return super.is_adjacent((Base) other);
@@ -420,7 +421,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean is_left(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.before_spanset_date(this._inner, dateToTimestamp(((LocalDate) other)));
+            return GeneratedFunctions.before_spanset_date(this._inner, dateToTimestamp(((LocalDate) other)));
         }
         else {
             return super.is_left((Base) other);
@@ -451,7 +452,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean is_over_or_left(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.overbefore_spanset_date(this._inner, dateToTimestamp(((LocalDate) other)));
+            return GeneratedFunctions.overbefore_spanset_date(this._inner, dateToTimestamp(((LocalDate) other)));
         }
         else {
             return super.is_over_or_left((Base) other);
@@ -482,7 +483,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean is_over_or_right(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.overafter_spanset_date(this._inner, dateToTimestamp(((LocalDate) other)));
+            return GeneratedFunctions.overafter_spanset_date(this._inner, dateToTimestamp(((LocalDate) other)));
         }
         else {
             return super.is_over_or_right((Base) other);
@@ -514,7 +515,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 
     public boolean is_right(Object other) throws Exception {
         if (other instanceof LocalDate){
-            return functions.after_spanset_date(this._inner, dateToTimestamp(((LocalDate) other)));
+            return GeneratedFunctions.after_spanset_date(this._inner, dateToTimestamp(((LocalDate) other)));
         }
         else {
             return super.is_right((Base) other);
@@ -561,14 +562,14 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     public Duration distance(Object other) throws Exception {
         Duration answer = null;
         if (other instanceof LocalDate) {
-            answer= Duration.ofSeconds(functions.distance_spanset_date(this._inner, dateToTimestamp((LocalDate) other)));
+            answer= Duration.ofSeconds(GeneratedFunctions.distance_spanset_date(this._inner, dateToTimestamp((LocalDate) other)));
         } else if (other instanceof dateset) {
             datespanset ds = ((dateset) other).to_spanset(datespanset.class);
-            answer= Duration.ofSeconds(functions.distance_datespanset_datespanset(this._inner, (ds).get_inner()));
+            answer= Duration.ofSeconds(GeneratedFunctions.distance_datespanset_datespanset(this._inner, (ds).get_inner()));
         } else if (other instanceof datespan) {
-            answer= Duration.ofSeconds(functions.distance_datespanset_datespan(this._inner, ((datespan) other).get_inner()));
+            answer= Duration.ofSeconds(GeneratedFunctions.distance_datespanset_datespan(this._inner, ((datespan) other).get_inner()));
         } else if (other instanceof datespanset) {
-            answer= Duration.ofSeconds(functions.distance_datespanset_datespanset(this._inner, ((datespanset) other).get_inner()));
+            answer= Duration.ofSeconds(GeneratedFunctions.distance_datespanset_datespanset(this._inner, ((datespanset) other).get_inner()));
         } else {
             throw new Exception("Operation not supported with"+other+"type");
         }
@@ -595,20 +596,20 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     public datespanset intersection(Object other) throws Exception {
         datespanset result = null;
         if (other instanceof LocalDate){
-            Pointer resultPointer= functions.intersection_spanset_date(this._inner, dateToTimestamp((LocalDate) other));
+            Pointer resultPointer= GeneratedFunctions.intersection_spanset_date(this._inner, dateToTimestamp((LocalDate) other));
             result = new datespanset(resultPointer);
         }
         else if (other instanceof datespan){
-            Pointer resultPointer= functions.intersection_spanset_span(this._inner, ((datespan) other).get_inner());
+            Pointer resultPointer= GeneratedFunctions.intersection_spanset_span(this._inner, ((datespan) other).get_inner());
             result = new datespanset(resultPointer);
         }
         else if (other instanceof dateset){
             datespanset ds = ((dateset) other).to_spanset(datespanset.class);
-            Pointer resultPointer= functions.intersection_spanset_spanset(this._inner, (ds).get_inner());
+            Pointer resultPointer= GeneratedFunctions.intersection_spanset_spanset(this._inner, (ds).get_inner());
             result = new datespanset(resultPointer);
         }
         else if (other instanceof datespanset){
-            Pointer resultPointer= functions.intersection_spanset_spanset(this._inner, ((datespanset) other).get_inner());
+            Pointer resultPointer= GeneratedFunctions.intersection_spanset_spanset(this._inner, ((datespanset) other).get_inner());
             result = new datespanset(resultPointer);
         }
         else{
@@ -633,20 +634,20 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     public datespanset minus(Object other) throws Exception{
         datespanset result = null;
         if (other instanceof LocalDate){
-            Pointer resultPointer= functions.minus_spanset_date(this._inner, dateToTimestamp((LocalDate) other));
+            Pointer resultPointer= GeneratedFunctions.minus_spanset_date(this._inner, dateToTimestamp((LocalDate) other));
             result= new datespanset(resultPointer);
         }
         else if (other instanceof datespan){
-            Pointer resultPointer= functions.minus_spanset_span(this._inner, ((datespan) other).get_inner());
+            Pointer resultPointer= GeneratedFunctions.minus_spanset_span(this._inner, ((datespan) other).get_inner());
             result = new datespanset(resultPointer);
         }
         else if (other instanceof dateset){
             datespanset ds = ((dateset) other).to_spanset(datespanset.class);
-            Pointer resultPointer= functions.minus_spanset_spanset(this._inner, (ds).get_inner());
+            Pointer resultPointer= GeneratedFunctions.minus_spanset_spanset(this._inner, (ds).get_inner());
             result = new datespanset(resultPointer);
         }
         else if (other instanceof datespanset){
-            Pointer resultPointer= functions.minus_spanset_spanset(this._inner, ((datespanset) other).get_inner());
+            Pointer resultPointer= GeneratedFunctions.minus_spanset_spanset(this._inner, ((datespanset) other).get_inner());
             result = new datespanset(resultPointer);
         }
         else{
@@ -669,7 +670,7 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
 */
 
     public datespanset subtract_from(LocalDate other) throws Exception {
-        return new datespanset(functions.minus_date_spanset(dateToTimestamp(other), this._inner));
+        return new datespanset(GeneratedFunctions.minus_date_spanset(dateToTimestamp(other), this._inner));
     }
 
 /**
@@ -688,20 +689,20 @@ Function to convert the integer timestamp to LocalDate format so that it can be 
     public datespanset union(Object other) throws Exception{
         datespanset result = null;
         if (other instanceof LocalDate){
-            Pointer resultPointer= functions.union_spanset_date(this._inner, dateToTimestamp((LocalDate) other));
+            Pointer resultPointer= GeneratedFunctions.union_spanset_date(this._inner, dateToTimestamp((LocalDate) other));
             result = new datespanset(resultPointer);
         }
         else if (other instanceof datespan){
-            Pointer resultPointer= functions.union_spanset_span(this._inner, ((datespan) other).get_inner());
+            Pointer resultPointer= GeneratedFunctions.union_spanset_span(this._inner, ((datespan) other).get_inner());
             result = new datespanset(resultPointer);
         }
         else if (other instanceof dateset){
             datespanset ds = ((dateset) other).to_spanset(datespanset.class);
-            Pointer resultPointer= functions.union_spanset_spanset(this._inner, (ds).get_inner());
+            Pointer resultPointer= GeneratedFunctions.union_spanset_spanset(this._inner, (ds).get_inner());
             result = new datespanset(resultPointer);
         }
         else if (other instanceof datespanset){
-            Pointer resultPointer= functions.union_spanset_spanset(this._inner, ((datespanset) other).get_inner());
+            Pointer resultPointer= GeneratedFunctions.union_spanset_spanset(this._inner, ((datespanset) other).get_inner());
             result = new datespanset(resultPointer);
         }
         else{

--- a/jmeos-core/src/main/java/types/collections/time/tstzset.java
+++ b/jmeos-core/src/main/java/types/collections/time/tstzset.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import functions.functions;
+import functions.GeneratedFunctions;
 import java.util.List;
 import java.util.Objects;
 
@@ -64,7 +65,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	public tstzset(Pointer _inner)  {
 		super(_inner);
 		this._inner = _inner;
-		//String str = functions.timestampset_out(this._inner);
+		//String str = GeneratedFunctions.timestampset_out(this._inner);
 	}
 	
 	
@@ -75,13 +76,13 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	 */
 	public tstzset(String value) {
 		super(value);
-		this._inner = functions.tstzset_in(value);
+		this._inner = GeneratedFunctions.tstzset_in(value);
 	}
 
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.tstzset_in(str);
+		return GeneratedFunctions.tstzset_in(str);
 	}
 
 	@Override
@@ -98,7 +99,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	 * @return a new tstzset instance
 	 */
 //	public tstzset copy() {
-//		return new tstzset(functions.tstz(this._inner));
+//		return new tstzset(GeneratedFunctions.tstz(this._inner));
 //	}
 
 
@@ -111,12 +112,12 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	 * @return a new tstzset instance
 	 */
 //	public static tstzset from_hexwkb(String hexwkb) {
-//		Pointer result = functions.tstzset_(hexwkb);
+//		Pointer result = GeneratedFunctions.tstzset_(hexwkb);
 //		return new tstzset(result);
 //	}
 
 	public static tstzset from_hexwkb(String hexwkb) {
-		Pointer result = functions.set_from_hexwkb(hexwkb);
+		Pointer result = GeneratedFunctions.set_from_hexwkb(hexwkb);
 		return new tstzset(result);
 	}
 
@@ -131,7 +132,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	 * @return a new String instance
 	 */
 	public String toString(){
-		return functions.tstzset_out(this._inner);
+		return GeneratedFunctions.tstzset_out(this._inner);
 	}
 
 
@@ -146,7 +147,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	 * @return a new tstzspanset instance
 	 */
 	public tstzspanset to_periodset() {
-		return new tstzspanset(functions.set_to_spanset(this.get_inner()));
+		return new tstzspanset(GeneratedFunctions.set_to_spanset(this.get_inner()));
 	}
 
 	/**
@@ -157,11 +158,11 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	 * @return a new tstzspan instance
 	 */
 	public tstzspan to_span() {
-		return new tstzspan(functions.set_to_span(this._inner));
+		return new tstzspan(GeneratedFunctions.set_to_span(this._inner));
 	}
 
 	public tstzspanset to_spanset() {
-		return new tstzspanset(functions.set_to_spanset(this._inner));
+		return new tstzspanset(GeneratedFunctions.set_to_spanset(this._inner));
 	}
 
 	/**
@@ -176,7 +177,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	}
 
 	public Duration duration(){
-		return ConversionUtils.interval_to_timedelta(functions.tstzspan_duration(functions.set_to_span(this._inner)));
+		return ConversionUtils.interval_to_timedelta(GeneratedFunctions.tstzspan_duration(GeneratedFunctions.set_to_span(this._inner)));
 	}
 
 
@@ -199,7 +200,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	 * @return a new Integer instance
 	 */
 	public int num_timestamps(){
-		return functions.set_num_values(this._inner);
+		return GeneratedFunctions.set_num_values(this._inner);
 	}
 
 	/**
@@ -212,7 +213,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	 * @return a {@link LocalDateTime instance}
 	 */
 	public LocalDateTime start_element(){
-		return ConversionUtils.timestamptz_to_datetime(functions.tstzset_start_value(this._inner));
+		return ConversionUtils.timestamptz_to_datetime(GeneratedFunctions.tstzset_start_value(this._inner));
 	}
 
 	/**
@@ -225,12 +226,12 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	 * @return a {@link LocalDateTime instance}
 	 */
 	public LocalDateTime end_element(){
-		return ConversionUtils.timestamptz_to_datetime(functions.tstzset_end_value(this._inner));
+		return ConversionUtils.timestamptz_to_datetime(GeneratedFunctions.tstzset_end_value(this._inner));
 	}
 
 	public LocalDateTime element_n(int n) throws Exception {
 		super.element_n(n);
-		return ConversionUtils.timestamptz_to_datetime(OffsetDateTime.parse(Objects.requireNonNull(functions.tstzset_value_n(this._inner, n + 1)).toString()));
+		return ConversionUtils.timestamptz_to_datetime(OffsetDateTime.parse(Objects.requireNonNull(GeneratedFunctions.tstzset_value_n(this._inner, n + 1)).toString()));
 	}
 
 	public List<LocalDateTime> elements() throws Exception {
@@ -256,7 +257,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	}
 
 	public tstzset shift_scale(Integer shift, Integer duration){
-		return new tstzset(functions.tstzset_shift_scale(this._inner, ConversionUtils.timedelta_to_interval(Duration.ofDays(shift)), ConversionUtils.timedelta_to_interval(Duration.ofDays(duration))));
+		return new tstzset(GeneratedFunctions.tstzset_shift_scale(this._inner, ConversionUtils.timedelta_to_interval(Duration.ofDays(shift)), ConversionUtils.timedelta_to_interval(Duration.ofDays(duration))));
 	}
 
 	/**
@@ -267,7 +268,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	 * @return a new Integer instance
 	 */
 	public long hash(){
-		return functions.set_hash(this._inner);
+		return GeneratedFunctions.set_hash(this._inner);
 	}
 
 
@@ -305,7 +306,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 			return this.is_adjacent(((Temporal<?>) other).time());
 		}
 		else if (other instanceof Box){
-			return functions.adjacent_span_span(functions.set_to_span(this._inner), ((Box) other).to_period().get_inner());
+			return GeneratedFunctions.adjacent_span_span(GeneratedFunctions.set_to_span(this._inner), ((Box) other).to_period().get_inner());
 		}
 		else{
 			return super.is_adjacent((Base) other);
@@ -339,10 +340,10 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	public boolean is_contained_in(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.contained_span_span(functions.set_to_span(this._inner), p.get_inner());
-			case tstzspanset ps -> returnValue = functions.contained_spanset_spanset(functions.set_to_span(this._inner), ps.get_inner());
+			case tstzspan p -> returnValue = GeneratedFunctions.contained_span_span(GeneratedFunctions.set_to_span(this._inner), p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.contained_spanset_spanset(GeneratedFunctions.set_to_span(this._inner), ps.get_inner());
 			case Temporal t -> returnValue = this.is_contained_in(t.time());
-			case Box b -> returnValue = functions.contained_span_span(functions.set_to_span(this._inner), b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.contained_span_span(GeneratedFunctions.set_to_span(this._inner), b.to_period().get_inner());
 			default -> returnValue = super.is_contained_in((Base) other);
 		}
 		return returnValue;
@@ -375,7 +376,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	public boolean contains(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzset ts -> returnValue = functions.contains_set_set(this._inner, ts.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.contains_set_set(this._inner, ts.get_inner());
 			case Temporal t -> returnValue = this.contains(t.time());
 			default -> returnValue = super.contains((Base) other);
 		}
@@ -409,10 +410,10 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	public boolean overlaps(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.overlaps_span_span(functions.set_to_span(this._inner), p.get_inner());
-			case tstzspanset ps -> returnValue = functions.overlaps_spanset_spanset(functions.set_to_spanset(this._inner), ps.get_inner());
-			case tstzset ts -> returnValue = functions.overlaps_set_set(this._inner, ts.get_inner());
-			case Box b -> returnValue = functions.overlaps_span_span(functions.set_to_span(this._inner), b.to_period().get_inner());
+			case tstzspan p -> returnValue = GeneratedFunctions.overlaps_span_span(GeneratedFunctions.set_to_span(this._inner), p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.overlaps_spanset_spanset(GeneratedFunctions.set_to_spanset(this._inner), ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.overlaps_set_set(this._inner, ts.get_inner());
+			case Box b -> returnValue = GeneratedFunctions.overlaps_span_span(GeneratedFunctions.set_to_span(this._inner), b.to_period().get_inner());
 			default -> returnValue = super.overlaps((Base) other);
 		}
 		return returnValue;
@@ -467,11 +468,11 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	public boolean is_after(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.right_span_span(functions.set_to_span(this._inner), p.get_inner());
-			case tstzspanset ps -> returnValue = functions.right_span_spanset(functions.set_to_span(this._inner), ps.get_inner());
-			case tstzset ts -> returnValue = functions.right_set_set(this._inner, ts.get_inner());
+			case tstzspan p -> returnValue = GeneratedFunctions.right_span_span(GeneratedFunctions.set_to_span(this._inner), p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.right_span_spanset(GeneratedFunctions.set_to_span(this._inner), ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.right_set_set(this._inner, ts.get_inner());
 			case Temporal t -> returnValue = this.to_period().is_after(other);
-			case Box b -> returnValue = functions.right_span_span(functions.set_to_span(this._inner), b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.right_span_span(GeneratedFunctions.set_to_span(this._inner), b.to_period().get_inner());
 			default -> returnValue = super.is_left((Base) other);
 		}
 		return returnValue;
@@ -504,11 +505,11 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	public boolean is_before(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.left_span_span(functions.set_to_span(this._inner), p.get_inner());
-			case tstzspanset ps -> returnValue = functions.left_span_spanset(functions.set_to_span(this._inner), ps.get_inner());
-			case tstzset ts -> returnValue = functions.left_set_set(this._inner, ts.get_inner());
+			case tstzspan p -> returnValue = GeneratedFunctions.left_span_span(GeneratedFunctions.set_to_span(this._inner), p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.left_span_spanset(GeneratedFunctions.set_to_span(this._inner), ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.left_set_set(this._inner, ts.get_inner());
 			case Temporal t -> returnValue = this.to_period().is_before(other);
-			case Box b -> returnValue = functions.left_span_span(functions.set_to_span(this._inner), b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.left_span_span(GeneratedFunctions.set_to_span(this._inner), b.to_period().get_inner());
 			default -> returnValue = super.is_left((Base) other);
 		}
 		return returnValue;
@@ -540,11 +541,11 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	public boolean is_over_or_after(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.overright_span_span(functions.set_to_span(this._inner), p.get_inner());
-			case tstzspanset ps -> returnValue = functions.overright_span_spanset(functions.set_to_span(this._inner), ps.get_inner());
-			case tstzset ts -> returnValue = functions.overright_set_set(this._inner, ts.get_inner());
+			case tstzspan p -> returnValue = GeneratedFunctions.overright_span_span(GeneratedFunctions.set_to_span(this._inner), p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.overright_span_spanset(GeneratedFunctions.set_to_span(this._inner), ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.overright_set_set(this._inner, ts.get_inner());
 			case Temporal t -> returnValue = this.to_period().is_over_or_after(other);
-			case Box b -> returnValue = functions.overright_span_span(functions.set_to_span(this._inner), b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.overright_span_span(GeneratedFunctions.set_to_span(this._inner), b.to_period().get_inner());
 			default -> returnValue = super.is_over_or_right((Base) other);
 		}
 		return returnValue;
@@ -577,11 +578,11 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	public boolean is_over_or_before(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.overleft_span_span(functions.set_to_span(this._inner), p.get_inner());
-			case tstzspanset ps -> returnValue = functions.overleft_span_spanset(functions.set_to_span(this._inner), ps.get_inner());
-			case tstzset ts -> returnValue = functions.overleft_set_set(this._inner, ts.get_inner());
+			case tstzspan p -> returnValue = GeneratedFunctions.overleft_span_span(GeneratedFunctions.set_to_span(this._inner), p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.overleft_span_spanset(GeneratedFunctions.set_to_span(this._inner), ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.overleft_set_set(this._inner, ts.get_inner());
 			case Temporal t -> returnValue = this.to_period().is_over_or_before(other);
-			case Box b -> returnValue = functions.overleft_span_span(functions.set_to_span(this._inner), b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.overleft_span_span(GeneratedFunctions.set_to_span(this._inner), b.to_period().get_inner());
 			default -> returnValue = super.is_over_or_left((Base) other);
 		}
 		return returnValue;
@@ -591,15 +592,15 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	public Duration distance(Object other) throws Exception {
 		Duration answer = null;
 		if (other instanceof LocalDateTime) {
-			answer= Duration.ofSeconds((long)functions.distance_set_timestamptz(this._inner, ConversionUtils.datetimeToTimestampTz((LocalDateTime) other)));
+			answer= Duration.ofSeconds((long)GeneratedFunctions.distance_set_timestamptz(this._inner, ConversionUtils.datetimeToTimestampTz((LocalDateTime) other)));
 		} else if (other instanceof tstzset) {
-			answer= Duration.ofSeconds((long)functions.distance_tstzset_tstzset(this._inner, ((tstzset) other)._inner));
+			answer= Duration.ofSeconds((long)GeneratedFunctions.distance_tstzset_tstzset(this._inner, ((tstzset) other)._inner));
 		} else if (other instanceof tstzspan) {
 			answer= Duration.ofSeconds((long)this.to_span().distance((TemporalObject) other));
-//					Duration.ofSeconds((long)functions.distance_tstzspanset_tstzspan(this.to_spanset(tstzspan.class).get_inner(), ((tstzspan) other).get_inner()));
+//					Duration.ofSeconds((long)GeneratedFunctions.distance_tstzspanset_tstzspan(this.to_spanset(tstzspan.class).get_inner(), ((tstzspan) other).get_inner()));
 		} else if (other instanceof tstzspanset) {
 			answer= Duration.ofSeconds((long)this.to_span().distance((TemporalObject) other));
-//					Duration.ofSeconds((long)functions.distance_tstzspanset_tstzspanset(this.to_spanset(tstzspan.class).get_inner(), ((tstzspanset) other).get_inner()));
+//					Duration.ofSeconds((long)GeneratedFunctions.distance_tstzspanset_tstzspanset(this.to_spanset(tstzspan.class).get_inner(), ((tstzspanset) other).get_inner()));
 		} else if (other instanceof Temporal) {
 			answer= Duration.ofSeconds((long)this.to_span().distance((TemporalObject) other));
 		} else if (other instanceof Box) {
@@ -612,8 +613,8 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 
 //	public Duration distance(Object other) throws Exception {
 //		Duration answer = switch (other) {
-//            case LocalDateTime localDateTime -> Duration.ofSeconds((long) functions.distance_set_timestamptz(this._inner, ConversionUtils.datetimeToTimestampTz(localDateTime)));
-//            case tstzset tstzset -> Duration.ofSeconds((long) functions.distance_tstzset_tstzset(this._inner, tstzset._inner));
+//            case LocalDateTime localDateTime -> Duration.ofSeconds((long) GeneratedFunctions.distance_set_timestamptz(this._inner, ConversionUtils.datetimeToTimestampTz(localDateTime)));
+//            case tstzset tstzset -> Duration.ofSeconds((long) GeneratedFunctions.distance_tstzset_tstzset(this._inner, tstzset._inner));
 //            case tstzspan tstzspan -> Duration.ofSeconds((long) tstzspan.distance((TemporalObject) other));
 //            case tstzspanset tstzspanset -> Duration.ofSeconds((long) tstzspanset.to_span().distance((TemporalObject) other));
 //            case Temporal ts -> Duration.ofSeconds((long) this.to_span().distance((TemporalObject) other));
@@ -628,8 +629,8 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 //		double returnValue;
 //		switch (other){
 //			case tstzspan p -> returnValue = this.to_span().distance(other);
-//			case tstzset ts -> returnValue = functions.distance_tstzspanset_tstzspan(ts.get_inner(),this._inner);
-//			case Box b -> returnValue = functions.distance_tstzspan_tstzspan(this._inner, b.to_period().get_inner());
+//			case tstzset ts -> returnValue = GeneratedFunctions.distance_tstzspanset_tstzspan(ts.get_inner(),this._inner);
+//			case Box b -> returnValue = GeneratedFunctions.distance_tstzspan_tstzspan(this._inner, b.to_period().get_inner());
 //			default -> throw new TypeNotPresentException(other.getClass().toString(), new Throwable("Operation not supported with this type"));
 //		}
 //		return returnValue;
@@ -656,9 +657,9 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	public Time intersection(TemporalObject other) throws Exception {
 		Time returnValue = null;
 		switch (other) {
-			case tstzspan p -> returnValue = new tstzspanset(functions.intersection_spanset_span(functions.set_to_spanset(this._inner), p.get_inner()));
-			case tstzspanset ps -> returnValue = new tstzspanset(functions.intersection_spanset_spanset(functions.set_to_spanset(this._inner),ps.get_inner()));
-			case tstzset ts -> returnValue = new tstzset(functions.intersection_set_set(this._inner,ts.get_inner()));
+			case tstzspan p -> returnValue = new tstzspanset(GeneratedFunctions.intersection_spanset_span(GeneratedFunctions.set_to_spanset(this._inner), p.get_inner()));
+			case tstzspanset ps -> returnValue = new tstzspanset(GeneratedFunctions.intersection_spanset_spanset(GeneratedFunctions.set_to_spanset(this._inner),ps.get_inner()));
+			case tstzset ts -> returnValue = new tstzset(GeneratedFunctions.intersection_set_set(this._inner,ts.get_inner()));
 			case Temporal t -> returnValue = (Time) this.intersection(t.time());
 			case Box b -> returnValue = (Time) this.intersection(b.to_period());
 			default -> throw new TypeNotPresentException(other.getClass().toString(), new Throwable("Operation not supported with this type"));
@@ -702,9 +703,9 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	public Time minus(TemporalObject other) throws Exception {
 		Time returnValue = null;
 		switch (other) {
-			case tstzspan p -> returnValue = new tstzspanset(functions.minus_spanset_span(functions.set_to_spanset(this._inner), p.get_inner()));
-			case tstzspanset ps -> returnValue = new tstzspanset(functions.minus_spanset_spanset(functions.set_to_spanset(this._inner),ps.get_inner()));
-			case tstzset ts -> returnValue = new tstzset(functions.minus_set_set(this._inner,ts.get_inner()));
+			case tstzspan p -> returnValue = new tstzspanset(GeneratedFunctions.minus_spanset_span(GeneratedFunctions.set_to_spanset(this._inner), p.get_inner()));
+			case tstzspanset ps -> returnValue = new tstzspanset(GeneratedFunctions.minus_spanset_spanset(GeneratedFunctions.set_to_spanset(this._inner),ps.get_inner()));
+			case tstzset ts -> returnValue = new tstzset(GeneratedFunctions.minus_set_set(this._inner,ts.get_inner()));
 			case Temporal t -> returnValue = (Time) this.minus(t.time());
 			case Box b -> returnValue = (Time) this.minus(b.to_period());
 			default -> throw new TypeNotPresentException(other.getClass().toString(), new Throwable("Operation not supported with this type"));
@@ -749,9 +750,9 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	public Time union(TemporalObject other) throws Exception {
 		Time returnValue = null;
 		switch (other) {
-			case tstzspan p -> returnValue = new tstzspan(functions.union_spanset_span(functions.set_to_spanset(this._inner),p.get_inner()));
-			case tstzspanset ps -> returnValue = new tstzspanset(functions.union_spanset_spanset(functions.set_to_spanset(this._inner),ps.get_inner()));
-			case tstzset ts -> returnValue =  new tstzset(functions.union_set_set(this._inner,ts.get_inner()));
+			case tstzspan p -> returnValue = new tstzspan(GeneratedFunctions.union_spanset_span(GeneratedFunctions.set_to_spanset(this._inner),p.get_inner()));
+			case tstzspanset ps -> returnValue = new tstzspanset(GeneratedFunctions.union_spanset_spanset(GeneratedFunctions.set_to_spanset(this._inner),ps.get_inner()));
+			case tstzset ts -> returnValue =  new tstzset(GeneratedFunctions.union_set_set(this._inner,ts.get_inner()));
 			case Temporal t -> returnValue = (Time) this.union(t.time());
 			case Box b -> returnValue = (Time) this.union(b.to_period());
 			default -> throw new TypeNotPresentException(other.getClass().toString(), new Throwable("Operation not supported with this type"));
@@ -795,7 +796,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	/*
 	public boolean eq(Time other) throws SQLException{
 		boolean result;
-		result = other instanceof tstzset ? functions.set_eq(this._inner,((tstzset) other).get_inner()) : false;
+		result = other instanceof tstzset ? GeneratedFunctions.set_eq(this._inner,((tstzset) other).get_inner()) : false;
 		return result;
 	}
 
@@ -818,7 +819,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	/*
 	public boolean notEquals(Time other) throws SQLException{
 		boolean result;
-		result = other instanceof tstzset ? functions.set_ne(this._inner,((tstzset) other).get_inner()) : true;
+		result = other instanceof tstzset ? GeneratedFunctions.set_ne(this._inner,((tstzset) other).get_inner()) : true;
 		return result;
 	}
 
@@ -842,7 +843,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	/*
 	public boolean lessThan(Time other) throws SQLException{
 		if (other instanceof tstzset){
-			return functions.set_lt(this._inner,((tstzset) other).get_inner());
+			return GeneratedFunctions.set_lt(this._inner,((tstzset) other).get_inner());
 		}
 		else{
 			throw new SQLException("Operation not supported with this type.");
@@ -870,7 +871,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	/*
 	public boolean lessThanOrEqual(Time other) throws SQLException{
 		if (other instanceof tstzset){
-			return functions.set_le(this._inner,((tstzset) other).get_inner());
+			return GeneratedFunctions.set_le(this._inner,((tstzset) other).get_inner());
 		}
 		else{
 			throw new SQLException("Operation not supported with this type.");
@@ -897,7 +898,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	/*
 	public boolean greaterThan(Time other) throws SQLException{
 		if (other instanceof tstzset){
-			return functions.set_gt(this._inner,((tstzset) other).get_inner());
+			return GeneratedFunctions.set_gt(this._inner,((tstzset) other).get_inner());
 		}
 		else{
 			throw new SQLException("Operation not supported with this type.");
@@ -922,7 +923,7 @@ public class tstzset extends Set<LocalDateTime> implements Time, TimeCollection 
 	/*
 	public boolean greaterThanOrEqual(Time other) throws SQLException{
 		if (other instanceof tstzset){
-			return functions.set_ge(this._inner,((tstzset) other).get_inner());
+			return GeneratedFunctions.set_ge(this._inner,((tstzset) other).get_inner());
 		}
 		else{
 			throw new SQLException("Operation not supported with this type.");

--- a/jmeos-core/src/main/java/types/collections/time/tstzspan.java
+++ b/jmeos-core/src/main/java/types/collections/time/tstzspan.java
@@ -13,6 +13,7 @@ import types.collections.base.Span;
 import types.temporal.Temporal;
 import utils.ConversionUtils;
 import functions.functions;
+import functions.GeneratedFunctions;
 
 import javax.naming.OperationNotSupportedException;
 
@@ -83,7 +84,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 */
 	public tstzspan(final String value){
 		super(value);
-		this._inner = functions.tstzspan_in(value);
+		this._inner = GeneratedFunctions.tstzspan_in(value);
 	}
 
 
@@ -98,9 +99,9 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 		super(lower,upper,true,false);
 		this.lowerInclusive = true;
 		this.upperInclusive = false;
-		OffsetDateTime lower_ts = functions.timestamptz_in(lower, -1);
-		OffsetDateTime upper_ts = functions.timestamptz_in(upper, -1);
-		this._inner = functions.tstzspan_make(lower_ts, upper_ts, this.lowerInclusive, this.upperInclusive);
+		OffsetDateTime lower_ts = GeneratedFunctions.timestamptz_in(lower, -1);
+		OffsetDateTime upper_ts = GeneratedFunctions.timestamptz_in(upper, -1);
+		this._inner = GeneratedFunctions.tstzspan_make(lower_ts, upper_ts, this.lowerInclusive, this.upperInclusive);
 	}
 	
 	/**
@@ -113,9 +114,9 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 */
 	public tstzspan(String lower, String upper, boolean lowerInclusive, boolean upperInclusive) {
 		super(lower,upper,lowerInclusive,upperInclusive);
-		OffsetDateTime lower_ts = functions.timestamptz_in(lower, -1);
-		OffsetDateTime upper_ts = functions.timestamptz_in(upper, -1);
-		this._inner = functions.tstzspan_make(lower_ts, upper_ts, lowerInclusive, upperInclusive);
+		OffsetDateTime lower_ts = GeneratedFunctions.timestamptz_in(lower, -1);
+		OffsetDateTime upper_ts = GeneratedFunctions.timestamptz_in(upper, -1);
+		this._inner = GeneratedFunctions.tstzspan_make(lower_ts, upper_ts, lowerInclusive, upperInclusive);
 	}
 
 
@@ -131,7 +132,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 		this.upperInclusive = false;
 		OffsetDateTime lower_ts = ConversionUtils.datetimeToTimestampTz(lower);
 		OffsetDateTime upper_ts = ConversionUtils.datetimeToTimestampTz(upper);
-		this._inner = functions.tstzspan_make(lower_ts, upper_ts, this.lowerInclusive, this.upperInclusive);
+		this._inner = GeneratedFunctions.tstzspan_make(lower_ts, upper_ts, this.lowerInclusive, this.upperInclusive);
 	}
 
 
@@ -147,7 +148,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 		super(lower.toString(),upper.toString(),lowerInclusive,upperInclusive);
 		OffsetDateTime lower_ts = ConversionUtils.datetimeToTimestampTz(lower);
 		OffsetDateTime upper_ts = ConversionUtils.datetimeToTimestampTz(upper);
-		this._inner = functions.tstzspan_make(lower_ts, upper_ts, this.lowerInclusive, this.upperInclusive);
+		this._inner = GeneratedFunctions.tstzspan_make(lower_ts, upper_ts, this.lowerInclusive, this.upperInclusive);
 	}
 
 
@@ -161,9 +162,9 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 		super(lower,upper.toString(),true,false);
 		this.lowerInclusive = true;
 		this.upperInclusive = false;
-		OffsetDateTime lower_ts = functions.timestamptz_in(lower,-1);
+		OffsetDateTime lower_ts = GeneratedFunctions.timestamptz_in(lower,-1);
 		OffsetDateTime upper_ts = ConversionUtils.datetimeToTimestampTz(upper);
-		this._inner = functions.tstzspan_make(lower_ts, upper_ts, this.lowerInclusive, this.upperInclusive);
+		this._inner = GeneratedFunctions.tstzspan_make(lower_ts, upper_ts, this.lowerInclusive, this.upperInclusive);
 	}
 
 	/**
@@ -177,14 +178,14 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 		this.lowerInclusive = true;
 		this.upperInclusive = false;
 		OffsetDateTime lower_ts = ConversionUtils.datetimeToTimestampTz(lower);
-		OffsetDateTime upper_ts = functions.timestamptz_in(upper,-1);
-		this._inner = functions.tstzspan_make(lower_ts, upper_ts, this.lowerInclusive, this.upperInclusive);
+		OffsetDateTime upper_ts = GeneratedFunctions.timestamptz_in(upper,-1);
+		this._inner = GeneratedFunctions.tstzspan_make(lower_ts, upper_ts, this.lowerInclusive, this.upperInclusive);
 	}
 
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.tstzspan_in(str);
+		return GeneratedFunctions.tstzspan_in(str);
 	}
 
 	@Override
@@ -194,25 +195,25 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 
 	@Override
 	public Pointer createIntInt(java.lang.Number lower, java.lang.Number upper, boolean lower_inc, boolean upper_inc){
-		return functions.intspan_make(lower.intValue(),upper.intValue(),lower_inc,upper_inc);
+		return GeneratedFunctions.intspan_make(lower.intValue(),upper.intValue(),lower_inc,upper_inc);
 	}
 	@Override
 	public Pointer createIntStr(java.lang.Number lower, String upper, boolean lower_inc, boolean upper_inc){
 		int new_upper = Integer.parseInt(upper);
-		return functions.intspan_make(lower.intValue(),new_upper,lower_inc,upper_inc);
+		return GeneratedFunctions.intspan_make(lower.intValue(),new_upper,lower_inc,upper_inc);
 	}
 	@Override
 	public Pointer createStrStr(String lower, String upper, boolean lower_inc, boolean upper_inc){
-		return functions.tstzspan_make(functions.timestamptz_in(lower,-1),functions.timestamptz_in(upper,-1),lower_inc,upper_inc);
+		return GeneratedFunctions.tstzspan_make(GeneratedFunctions.timestamptz_in(lower,-1),GeneratedFunctions.timestamptz_in(upper,-1),lower_inc,upper_inc);
 	}
 	@Override
 	public Pointer createStrInt(String lower, java.lang.Number upper, boolean lower_inc, boolean upper_inc){
 		int new_lower = Integer.parseInt(lower);
-		return functions.intspan_make(new_lower,upper.intValue(),lower_inc,upper_inc);
+		return GeneratedFunctions.intspan_make(new_lower,upper.intValue(),lower_inc,upper_inc);
 	}
 	@Override
 	public Pointer createIntIntNb(java.lang.Number lower, java.lang.Number upper){
-		return functions.intspan_make(lower.intValue(),upper.intValue(),true,false);
+		return GeneratedFunctions.intspan_make(lower.intValue(),upper.intValue(),true,false);
 	}
 
 
@@ -227,7 +228,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 * @return Instance of tstzspan class
 	 */
     public tstzspan copy(){
-        return new tstzspan(functions.span_copy(this._inner));
+        return new tstzspan(GeneratedFunctions.span_copy(this._inner));
     }
 
 
@@ -244,7 +245,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 * @return Instance of tstzspan class
 	 */
 	public static tstzspan from_hexwkb(String hexwkb) {
-		return new tstzspan(functions.span_from_hexwkb(hexwkb));
+		return new tstzspan(GeneratedFunctions.span_from_hexwkb(hexwkb));
 	}
 
 
@@ -263,7 +264,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 * @return string instance
 	 */
 	public String toString(){
-		return functions.tstzspan_out(this._inner);
+		return GeneratedFunctions.tstzspan_out(this._inner);
 	}
 
 
@@ -281,7 +282,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 * @return tstzspanset instance
 	 */
 	public tstzspanset to_spanset(){
-		return new tstzspanset(functions.span_to_spanset(this._inner));
+		return new tstzspanset(GeneratedFunctions.span_to_spanset(this._inner));
 	}
 
 
@@ -296,7 +297,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 * @return tstzspanset instance
 	 */
 	public tstzspanset to_periodset() {
-		return new tstzspanset(functions.span_to_spanset(this._inner));
+		return new tstzspanset(GeneratedFunctions.span_to_spanset(this._inner));
 	}
 
 
@@ -321,7 +322,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 * @return true if the lower bound of the period is inclusive and false otherwise
 	 */
 	public boolean lower_inc(){
-		return functions.span_lower_inc(this._inner);
+		return GeneratedFunctions.span_lower_inc(this._inner);
 	}
 
 	/**
@@ -333,7 +334,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 * @return True if the upper bound of the period is inclusive and False otherwise
 	 */
 	public boolean upper_inc(){
-		return functions.span_upper_inc(this._inner);
+		return GeneratedFunctions.span_upper_inc(this._inner);
 	}
 
 
@@ -346,7 +347,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 * @return The lower bound of the period as a {@link LocalDateTime}
 	 */
 	public LocalDateTime lower() {
-		return ConversionUtils.timestamptz_to_datetime(functions.tstzspan_lower(this._inner));
+		return ConversionUtils.timestamptz_to_datetime(GeneratedFunctions.tstzspan_lower(this._inner));
 	}
 
 
@@ -359,7 +360,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 * @return The upper bound of the period as a {@link LocalDateTime}
 	 */
 	public LocalDateTime upper() {
-		return ConversionUtils.timestamptz_to_datetime(functions.tstzspan_upper(this._inner));
+		return ConversionUtils.timestamptz_to_datetime(GeneratedFunctions.tstzspan_upper(this._inner));
 	}
 
 
@@ -372,7 +373,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 * @return timedelta instance representing the duration of the period
 	 */
 	public Duration duration(){
-		return ConversionUtils.interval_to_timedelta(functions.tstzspan_duration(this._inner));
+		return ConversionUtils.interval_to_timedelta(GeneratedFunctions.tstzspan_duration(this._inner));
 	}
 
 
@@ -398,7 +399,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 * @return integer instance
 	 */
 	public long hash(){
-		return functions.span_hash(this._inner);
+		return GeneratedFunctions.span_hash(this._inner);
 	}
 
 
@@ -422,8 +423,8 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 * @return tstzspan instance
 	 */
 //	public tstzspan expand(tstzspan other) {
-//		Pointer copy = functions.span_copy(this._inner);
-//		functions.span_expand(other._inner, copy);
+//		Pointer copy = GeneratedFunctions.span_copy(this._inner);
+//		GeneratedFunctions.span_expand(other._inner, copy);
 //		return new tstzspan(copy);
 //	}
 
@@ -459,12 +460,12 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	public boolean is_adjacent(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.adjacent_span_span(this._inner, p.get_inner());
-			case tstzspanset ps -> returnValue = functions.adjacent_spanset_span(ps.get_inner(), this._inner);
-			//case Time dt -> returnValue = functions.adjacent_period_timestamp(this._inner, ConversionUtils.datetimeToTimestampTz(dt));
-			case tstzset ts -> returnValue = functions.adjacent_spanset_spanset(this._inner, functions.set_to_span(ts.get_inner()));
-			case Temporal t -> returnValue = functions.adjacent_span_span(this._inner,functions.temporal_to_tstzspan(t.getInner()));
-			case Box b -> returnValue = functions.adjacent_span_span(this._inner, b.to_period().get_inner());
+			case tstzspan p -> returnValue = GeneratedFunctions.adjacent_span_span(this._inner, p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.adjacent_spanset_span(ps.get_inner(), this._inner);
+			//case Time dt -> returnValue = GeneratedFunctions.adjacent_period_timestamp(this._inner, ConversionUtils.datetimeToTimestampTz(dt));
+			case tstzset ts -> returnValue = GeneratedFunctions.adjacent_spanset_spanset(this._inner, GeneratedFunctions.set_to_span(ts.get_inner()));
+			case Temporal t -> returnValue = GeneratedFunctions.adjacent_span_span(this._inner,GeneratedFunctions.temporal_to_tstzspan(t.getInner()));
+			case Box b -> returnValue = GeneratedFunctions.adjacent_span_span(this._inner, b.to_period().get_inner());
 			default -> returnValue = super.is_adjacent((Base) other);
 		}
 		return returnValue;
@@ -496,10 +497,10 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	public boolean is_contained_in(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other){
-			case tstzspan p -> returnValue = functions.contained_span_span(this._inner,p.get_inner());
-			case tstzspanset ps -> returnValue = functions.contained_span_spanset(this._inner,ps.get_inner());
+			case tstzspan p -> returnValue = GeneratedFunctions.contained_span_span(this._inner,p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.contained_span_spanset(this._inner,ps.get_inner());
 			case Temporal t -> returnValue = this.is_contained_in((TemporalObject)t.period());
-			case Box b -> returnValue = functions.contained_span_span(this._inner,b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.contained_span_span(this._inner,b.to_period().get_inner());
 			default -> returnValue = super.is_contained_in((Base) other);
 		}
 		return returnValue;
@@ -533,11 +534,11 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	public boolean contains(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other){
-			case tstzspan p -> returnValue = functions.contains_span_span(this._inner,p.get_inner());
-			case tstzspanset ps -> returnValue = functions.contains_span_spanset(this._inner,ps.get_inner());
-			case tstzset ts -> returnValue = functions.contains_span_span(this._inner,functions.set_to_span(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.contains_span_span(this._inner,p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.contains_span_spanset(this._inner,ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.contains_span_span(this._inner,GeneratedFunctions.set_to_span(ts.get_inner()));
 			case Temporal t -> returnValue = contains((TemporalObject) t.period());
-			case Box b -> returnValue = functions.contains_span_span(this._inner,b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.contains_span_span(this._inner,b.to_period().get_inner());
 			default -> returnValue = super.contains((Base) other);
 		}
 		return returnValue;
@@ -569,11 +570,11 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	public boolean overlaps(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other){
-			case tstzspan p -> returnValue = functions.overlaps_span_span(this._inner,p.get_inner());
-			case tstzspanset ps -> returnValue = functions.overlaps_spanset_span(ps.get_inner(),this._inner);
-			case tstzset ts -> returnValue = functions.overlaps_span_span(this._inner,functions.set_to_span(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.overlaps_span_span(this._inner,p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.overlaps_spanset_span(ps.get_inner(),this._inner);
+			case tstzset ts -> returnValue = GeneratedFunctions.overlaps_span_span(this._inner,GeneratedFunctions.set_to_span(ts.get_inner()));
 			case Temporal t -> returnValue = this.overlaps((TemporalObject)t.period());
-			case Box b -> returnValue = functions.overlaps_span_span(this._inner,b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.overlaps_span_span(this._inner,b.to_period().get_inner());
 			default -> returnValue = super.overlaps((Base) other);
 		}
 
@@ -598,11 +599,11 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	public boolean is_same(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other){
-			case tstzspan p -> returnValue = functions.span_eq(this._inner,p.get_inner());
-			case tstzspanset ps -> returnValue = functions.span_eq(this._inner,functions.spanset_span(ps.get_inner()));
-			case tstzset ts -> returnValue = functions.span_eq(this._inner,functions.set_to_span(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.span_eq(this._inner,p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.span_eq(this._inner,GeneratedFunctions.spanset_span(ps.get_inner()));
+			case tstzset ts -> returnValue = GeneratedFunctions.span_eq(this._inner,GeneratedFunctions.set_to_span(ts.get_inner()));
 			case Temporal t -> returnValue = this.is_same((TemporalObject)t.period());
-			case Box b -> returnValue = functions.span_eq(this._inner,b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.span_eq(this._inner,b.to_period().get_inner());
 			default -> returnValue = super.is_same((Base) other);
 		}
 		return returnValue;
@@ -639,11 +640,11 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	public boolean is_before(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other){
-			case tstzspan p -> returnValue = functions.left_span_span(this._inner,p.get_inner());
-			case tstzspanset ps -> returnValue = functions.left_span_spanset(this._inner,ps.get_inner());
-			case tstzset ts -> returnValue = functions.left_span_span(this._inner,functions.set_to_span(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.left_span_span(this._inner,p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.left_span_spanset(this._inner,ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.left_span_span(this._inner,GeneratedFunctions.set_to_span(ts.get_inner()));
 			case Temporal t -> returnValue = is_before(t.period());
-			case Box b -> returnValue = functions.left_span_span(this._inner,b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.left_span_span(this._inner,b.to_period().get_inner());
 			default -> returnValue = super.is_left((Base) other);
 		}
 		return returnValue;
@@ -677,11 +678,11 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	public boolean is_over_or_before(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other){
-			case tstzspan p -> returnValue = functions.overleft_span_span(this._inner,p.get_inner());
-			case tstzspanset ps -> returnValue = functions.overleft_span_spanset(this._inner,ps.get_inner());
-			case tstzset ts -> returnValue = functions.overleft_span_span(this._inner,functions.set_to_span(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.overleft_span_span(this._inner,p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.overleft_span_spanset(this._inner,ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.overleft_span_span(this._inner,GeneratedFunctions.set_to_span(ts.get_inner()));
 			case Temporal t -> returnValue = is_over_or_before(t.period());
-			case Box b -> returnValue = functions.overleft_span_span(this._inner,b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.overleft_span_span(this._inner,b.to_period().get_inner());
 			default -> returnValue = super.is_over_or_left((Base) other);
 		}
 		return returnValue;
@@ -714,11 +715,11 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	public boolean is_after(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other){
-			case tstzspan p -> returnValue = functions.right_span_span(this._inner,p.get_inner());
-			case tstzspanset ps -> returnValue = functions.right_span_spanset(this._inner,ps.get_inner());
-			case tstzset ts -> returnValue = functions.right_span_span(this._inner,functions.set_to_span(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.right_span_span(this._inner,p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.right_span_spanset(this._inner,ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.right_span_span(this._inner,GeneratedFunctions.set_to_span(ts.get_inner()));
 			case Temporal t -> returnValue = is_after(t.period());
-			case Box b -> returnValue = functions.right_span_span(this._inner,b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.right_span_span(this._inner,b.to_period().get_inner());
 			default -> returnValue = super.is_right((Base) other);
 		}
 		return returnValue;
@@ -754,11 +755,11 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	public boolean is_over_or_after(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other){
-			case tstzspan p -> returnValue = functions.overright_span_span(this._inner,p.get_inner());
-			case tstzspanset ps -> returnValue = functions.overright_span_spanset(this._inner,ps.get_inner());
-			case tstzset ts -> returnValue = functions.overright_span_span(this._inner,functions.set_to_span(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.overright_span_span(this._inner,p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.overright_span_spanset(this._inner,ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.overright_span_span(this._inner,GeneratedFunctions.set_to_span(ts.get_inner()));
 			case Temporal t -> returnValue = is_over_or_after(t.period());
-			case Box b -> returnValue = functions.overright_span_span(this._inner,b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.overright_span_span(this._inner,b.to_period().get_inner());
 			default -> returnValue = super.is_over_or_right((Base) other);
 		}
 		return returnValue;
@@ -787,10 +788,10 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	public double distance(TemporalObject other) throws Exception {
 		double returnValue;
 		switch (other){
-			case tstzspan p -> returnValue = functions.distance_tstzspan_tstzspan(this._inner,p.get_inner());
-			case tstzspanset ps -> returnValue = functions.distance_tstzspanset_tstzspan(ps.get_inner(),this._inner);
+			case tstzspan p -> returnValue = GeneratedFunctions.distance_tstzspan_tstzspan(this._inner,p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.distance_tstzspanset_tstzspan(ps.get_inner(),this._inner);
 			case tstzset ts -> returnValue = ts.to_span().distance(other);
-			case Box b -> returnValue = functions.distance_tstzspan_tstzspan(this._inner, b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.distance_tstzspan_tstzspan(this._inner, b.to_period().get_inner());
 			default -> throw new TypeNotPresentException(other.getClass().toString(), new Throwable("Operation not supported with this type"));
 		}
 		return returnValue;
@@ -817,9 +818,9 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
     public Time intersection(TemporalObject other) throws Exception {
         Time returnValue = null;
         switch (other){
-            case tstzspan p -> returnValue = new tstzspan(functions.intersection_span_span(this._inner,p.get_inner()));
-            case tstzspanset ps -> returnValue = new tstzspanset(functions.intersection_spanset_span(ps.get_inner(), this._inner));
-            case tstzset ts -> returnValue = new tstzset(functions.intersection_spanset_span(functions.set_to_spanset(ts.get_inner()),this._inner));
+            case tstzspan p -> returnValue = new tstzspan(GeneratedFunctions.intersection_span_span(this._inner,p.get_inner()));
+            case tstzspanset ps -> returnValue = new tstzspanset(GeneratedFunctions.intersection_spanset_span(ps.get_inner(), this._inner));
+            case tstzset ts -> returnValue = new tstzset(GeneratedFunctions.intersection_spanset_span(GeneratedFunctions.set_to_spanset(ts.get_inner()),this._inner));
             default -> returnValue = (Time) new Exception("Operation not supported with this type");
         }
         return returnValue;
@@ -863,9 +864,9 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	public tstzspanset minus(Time other)  {
 		tstzspanset returnValue;
 		switch (other){
-			case tstzspan p -> returnValue = new tstzspanset(functions.minus_span_span(this._inner,p.get_inner()));
-			case tstzspanset ps -> returnValue = new tstzspanset(functions.minus_span_spanset(this._inner,ps.get_inner()));
-			case tstzset ts -> returnValue = new tstzspanset(functions.minus_span_spanset(this._inner,functions.set_to_spanset(ts.get_inner())));
+			case tstzspan p -> returnValue = new tstzspanset(GeneratedFunctions.minus_span_span(this._inner,p.get_inner()));
+			case tstzspanset ps -> returnValue = new tstzspanset(GeneratedFunctions.minus_span_spanset(this._inner,ps.get_inner()));
+			case tstzset ts -> returnValue = new tstzspanset(GeneratedFunctions.minus_span_spanset(this._inner,GeneratedFunctions.set_to_spanset(ts.get_inner())));
 			default -> throw new TypeNotPresentException(other.getClass().toString(), new Throwable("Operation not supported with this type"));
 		}
 		return returnValue;
@@ -909,9 +910,9 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	public tstzspanset union(Time other)  {
 		tstzspanset returnValue;
 		switch (other){
-			case tstzspan p -> returnValue = new tstzspanset(functions.union_span_span(this._inner,p.get_inner()));
-			case tstzspanset ps -> returnValue = new tstzspanset(functions.union_spanset_span(ps.get_inner(),this._inner));
-			case tstzset ts -> returnValue = new tstzspanset(functions.union_spanset_span(functions.set_to_spanset(ts.get_inner()),this._inner));
+			case tstzspan p -> returnValue = new tstzspanset(GeneratedFunctions.union_span_span(this._inner,p.get_inner()));
+			case tstzspanset ps -> returnValue = new tstzspanset(GeneratedFunctions.union_spanset_span(ps.get_inner(),this._inner));
+			case tstzset ts -> returnValue = new tstzspanset(GeneratedFunctions.union_spanset_span(GeneratedFunctions.set_to_spanset(ts.get_inner()),this._inner));
 			default -> throw new TypeNotPresentException(other.getClass().toString(), new Throwable("Operation not supported with this type"));
 		}
 		return returnValue;
@@ -953,7 +954,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 */
 	public boolean eq(Time other) {
 		boolean result;
-		result = other instanceof tstzspan && functions.span_eq(this._inner, ((tstzspan) other).get_inner());
+		result = other instanceof tstzspan && GeneratedFunctions.span_eq(this._inner, ((tstzspan) other).get_inner());
 		return result;
 	}
 
@@ -969,7 +970,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 */
 	public boolean notEquals(Time other) {
 		boolean result;
-		result = !(other instanceof tstzspan) || functions.span_ne(this._inner, ((tstzspan) other).get_inner());
+		result = !(other instanceof tstzspan) || GeneratedFunctions.span_ne(this._inner, ((tstzspan) other).get_inner());
 		return result;
 	}
 
@@ -989,7 +990,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 */
 	public boolean lessThan(Time other) throws OperationNotSupportedException {
 		if (other instanceof tstzspan){
-			return functions.span_lt(this._inner,((tstzspan) other).get_inner());
+			return GeneratedFunctions.span_lt(this._inner,((tstzspan) other).get_inner());
 		}
 		else{
 			throw new OperationNotSupportedException("Operation not supported with this type.");
@@ -1010,7 +1011,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 */
 	public boolean lessThanOrEqual(Time other) throws OperationNotSupportedException {
 		if (other instanceof tstzspan){
-			return functions.span_le(this._inner,((tstzspan) other).get_inner());
+			return GeneratedFunctions.span_le(this._inner,((tstzspan) other).get_inner());
 		}
 		else{
 			throw new OperationNotSupportedException("Operation not supported with this type.");
@@ -1030,7 +1031,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 */
 	public boolean greaterThan(Time other) throws OperationNotSupportedException {
 		if (other instanceof tstzspan){
-			return functions.span_gt(this._inner,((tstzspan) other).get_inner());
+			return GeneratedFunctions.span_gt(this._inner,((tstzspan) other).get_inner());
 		}
 		else{
 			throw new OperationNotSupportedException("Operation not supported with this type.");
@@ -1050,7 +1051,7 @@ public class tstzspan extends Span<LocalDateTime> implements Time, TimeCollectio
 	 */
 	public boolean greaterThanOrEqual(Time other) throws OperationNotSupportedException {
 		if (other instanceof tstzspan){
-			return functions.span_ge(this._inner,((tstzspan) other).get_inner());
+			return GeneratedFunctions.span_ge(this._inner,((tstzspan) other).get_inner());
 		}
 		else{
 			throw new OperationNotSupportedException("Operation not supported with this type.");

--- a/jmeos-core/src/main/java/types/collections/time/tstzspanset.java
+++ b/jmeos-core/src/main/java/types/collections/time/tstzspanset.java
@@ -13,6 +13,7 @@ import javax.naming.OperationNotSupportedException;
 import java.time.LocalDateTime;
 import java.util.List;
 import functions.functions;
+import functions.GeneratedFunctions;
 
 
 /**
@@ -60,7 +61,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 */
 	public tstzspanset(String value) {
 		super(value);
-		this._inner = functions.tstzspanset_in(value);
+		this._inner = GeneratedFunctions.tstzspanset_in(value);
 	}
 	
 	/**
@@ -83,12 +84,12 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 		}
 		sb.append("}");
 		System.out.println(sb);
-		this._inner = functions.tstzspanset_in(sb.toString());
+		this._inner = GeneratedFunctions.tstzspanset_in(sb.toString());
 	}
 
 	@Override
 	public Pointer createStringInner(String str){
-		return functions.tstzspanset_in(str);
+		return GeneratedFunctions.tstzspanset_in(str);
 	}
 
 	@Override
@@ -108,7 +109,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 			}
 		}
 		sb.append("}");
-		return functions.tstzspanset_in(sb.toString());
+		return GeneratedFunctions.tstzspanset_in(sb.toString());
 	}
 
 	/**
@@ -121,7 +122,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 * @return a new tstzspanset instance
 	 */
 	public Pointer copy()  {
-		return functions.spanset_copy(this._inner);
+		return GeneratedFunctions.spanset_copy(this._inner);
 	}
 
 
@@ -135,7 +136,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 * @return a new tstzspanset instance
 	 */
 	public Pointer from_hexwkb(String str)  {
-        return functions.spanset_from_hexwkb(str);
+        return GeneratedFunctions.spanset_from_hexwkb(str);
 	}
 
 
@@ -150,7 +151,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 * @return a new String instance
 	 */
 	public String toString(){
-		return functions.tstzspanset_out(this._inner);
+		return GeneratedFunctions.tstzspanset_out(this._inner);
 	}
     /* ------------------------- Conversions ----------------------------------- */
 
@@ -162,7 +163,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 * @return a new tstzspan instance
 	 */
 	public tstzspan to_period() {
-		return new tstzspan(functions.spanset_span(this._inner));
+		return new tstzspan(GeneratedFunctions.spanset_span(this._inner));
 	}
 
 
@@ -196,7 +197,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 * @return an Integer instance
 	 */
 	public int num_timestamps(){
-		return functions.tstzspanset_num_timestamps(this._inner);
+		return GeneratedFunctions.tstzspanset_num_timestamps(this._inner);
 	}
 
 	/**
@@ -208,7 +209,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 * @return A {@link LocalDateTime} instance
 	 */
 	public LocalDateTime start_timestamp(){
-		return ConversionUtils.timestamptz_to_datetime(functions.tstzspanset_start_timestamptz(this._inner));
+		return ConversionUtils.timestamptz_to_datetime(GeneratedFunctions.tstzspanset_start_timestamptz(this._inner));
 	}
 
 	/**
@@ -220,7 +221,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 * @return A {@link LocalDateTime} instance
 	 */
 	public LocalDateTime end_timestamp(){
-		return ConversionUtils.timestamptz_to_datetime(functions.tstzspanset_end_timestamptz(this._inner));
+		return ConversionUtils.timestamptz_to_datetime(GeneratedFunctions.tstzspanset_end_timestamptz(this._inner));
 	}
 
 
@@ -244,7 +245,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 * @return an Integer instance
 	 */
 	public int num_periods(){
-		return functions.spanset_num_spans(this._inner);
+		return GeneratedFunctions.spanset_num_spans(this._inner);
 	}
 
 
@@ -256,7 +257,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 * @return a new tstzspan instance
 	 */
 	public tstzspan start_period()  {
-		return new tstzspan(functions.spanset_start_span(this._inner));
+		return new tstzspan(GeneratedFunctions.spanset_start_span(this._inner));
 	}
 
 
@@ -279,7 +280,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 * @return a new tstzspan instance
 	 */
 	public tstzspan end_period() {
-		return new tstzspan(functions.spanset_end_span(this._inner));
+		return new tstzspan(GeneratedFunctions.spanset_end_span(this._inner));
 	}
 
 
@@ -303,7 +304,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 * @return a new Integer instance
 	 */
 	public long hash(){
-		return functions.spanset_hash(this._inner);
+		return GeneratedFunctions.spanset_hash(this._inner);
 	}
 
 
@@ -335,11 +336,11 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	public boolean is_adjacent(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.adjacent_spanset_span(this._inner, p.get_inner());
-			case tstzspanset ps -> returnValue = functions.adjacent_spanset_spanset(this._inner, ps.get_inner());
-			case tstzset ts -> returnValue = functions.adjacent_spanset_spanset(this._inner, functions.set_to_spanset(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.adjacent_spanset_span(this._inner, p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.adjacent_spanset_spanset(this._inner, ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.adjacent_spanset_spanset(this._inner, GeneratedFunctions.set_to_spanset(ts.get_inner()));
 			case Temporal t -> returnValue = is_adjacent((TemporalObject)t.period());
-			case Box b -> returnValue = functions.adjacent_spanset_span(this._inner, b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.adjacent_spanset_span(this._inner, b.to_period().get_inner());
 			default -> returnValue = super.is_adjacent((Base) other);
 		}
 		return returnValue;
@@ -369,10 +370,10 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	public boolean is_contained_in(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.contained_spanset_span(this._inner, p.get_inner());
-			case tstzspanset ps -> returnValue = functions.contained_spanset_spanset(this._inner, ps.get_inner());
+			case tstzspan p -> returnValue = GeneratedFunctions.contained_spanset_span(this._inner, p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.contained_spanset_spanset(this._inner, ps.get_inner());
 			case Temporal t -> returnValue = is_contained_in((TemporalObject)t.period());
-			case Box b -> returnValue = functions.contained_spanset_span(this._inner, b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.contained_spanset_span(this._inner, b.to_period().get_inner());
 			default -> returnValue = super.is_contained_in((Base) other);
 		}
 		return returnValue;
@@ -403,11 +404,11 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	public boolean contains(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.contains_spanset_span(this._inner, p.get_inner());
-			case tstzspanset ps -> returnValue = functions.contains_spanset_spanset(this._inner, ps.get_inner());
-			case tstzset ts -> returnValue = functions.contains_spanset_spanset(this._inner, functions.set_to_spanset(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.contains_spanset_span(this._inner, p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.contains_spanset_spanset(this._inner, ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.contains_spanset_spanset(this._inner, GeneratedFunctions.set_to_spanset(ts.get_inner()));
 			case Temporal t -> returnValue = contains((TemporalObject)t.period());
-			case Box b -> returnValue = functions.contains_spanset_span(this._inner, b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.contains_spanset_span(this._inner, b.to_period().get_inner());
 			default -> returnValue = super.contains((Base) other);
 		}
 		return returnValue;
@@ -436,11 +437,11 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	public boolean overlaps(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.overlaps_spanset_span(this._inner, p.get_inner());
-			case tstzspanset ps -> returnValue = functions.overlaps_spanset_spanset(this._inner, ps.get_inner());
-			case tstzset ts -> returnValue = functions.overlaps_spanset_spanset(this._inner, functions.set_to_span(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.overlaps_spanset_span(this._inner, p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.overlaps_spanset_spanset(this._inner, ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.overlaps_spanset_spanset(this._inner, GeneratedFunctions.set_to_span(ts.get_inner()));
 			case Temporal t -> returnValue = overlaps((TemporalObject)t.period());
-			case Box b -> returnValue = functions.overlaps_spanset_span(this._inner, b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.overlaps_spanset_span(this._inner, b.to_period().get_inner());
 			default -> returnValue = super.overlaps((Base) other);
 		}
 		return returnValue;
@@ -488,11 +489,11 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	public boolean is_before(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.left_spanset_span(this._inner, p.get_inner());
-			case tstzspanset ps -> returnValue = functions.left_spanset_spanset(this._inner, ps.get_inner());
-			case tstzset ts -> returnValue = functions.left_spanset_spanset(this._inner, functions.set_to_spanset(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.left_spanset_span(this._inner, p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.left_spanset_spanset(this._inner, ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.left_spanset_spanset(this._inner, GeneratedFunctions.set_to_spanset(ts.get_inner()));
 			case Temporal t -> returnValue = is_before((TemporalObject)t.period());
-			case Box b -> returnValue = functions.left_spanset_span(this._inner, b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.left_spanset_span(this._inner, b.to_period().get_inner());
 			default -> returnValue = super.is_left((Base) other);
 		}
 		return returnValue;
@@ -526,11 +527,11 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	public boolean is_over_or_before(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.overleft_spanset_span(this._inner, p.get_inner());
-			case tstzspanset ps -> returnValue = functions.overleft_spanset_spanset(this._inner, ps.get_inner());
-			case tstzset ts -> returnValue = functions.overleft_spanset_span(this._inner, functions.set_to_span(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.overleft_spanset_span(this._inner, p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.overleft_spanset_spanset(this._inner, ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.overleft_spanset_span(this._inner, GeneratedFunctions.set_to_span(ts.get_inner()));
 			case Temporal t -> returnValue = is_over_or_before((TemporalObject)t.period());
-			case Box b -> returnValue = functions.overleft_spanset_span(this._inner, b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.overleft_spanset_span(this._inner, b.to_period().get_inner());
 			default -> returnValue = super.is_over_or_left((Base) other);
 		}
 		return returnValue;
@@ -560,11 +561,11 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	public boolean is_after(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.right_spanset_span(this._inner, p.get_inner());
-			case tstzspanset ps -> returnValue = functions.right_spanset_spanset(this._inner, ps.get_inner());
-			case tstzset ts -> returnValue = functions.right_spanset_span(this._inner, functions.set_to_span(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.right_spanset_span(this._inner, p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.right_spanset_spanset(this._inner, ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.right_spanset_span(this._inner, GeneratedFunctions.set_to_span(ts.get_inner()));
 			case Temporal t -> returnValue = is_after((TemporalObject)t.period());
-			case Box b -> returnValue = functions.right_spanset_span(this._inner, b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.right_spanset_span(this._inner, b.to_period().get_inner());
 			default -> returnValue = super.is_right((Base) other);
 		}
 		return returnValue;
@@ -596,11 +597,11 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	public boolean is_over_or_after(TemporalObject other) throws Exception {
 		boolean returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = functions.overright_spanset_span(this._inner, p.get_inner());
-			case tstzspanset ps -> returnValue = functions.overright_spanset_spanset(this._inner, ps.get_inner());
-			case tstzset ts -> returnValue = functions.overright_spanset_span(this._inner, functions.set_to_span(ts.get_inner()));
+			case tstzspan p -> returnValue = GeneratedFunctions.overright_spanset_span(this._inner, p.get_inner());
+			case tstzspanset ps -> returnValue = GeneratedFunctions.overright_spanset_spanset(this._inner, ps.get_inner());
+			case tstzset ts -> returnValue = GeneratedFunctions.overright_spanset_span(this._inner, GeneratedFunctions.set_to_span(ts.get_inner()));
 			case Temporal t -> returnValue = is_over_or_after((TemporalObject)t.period());
-			case Box b -> returnValue = functions.overright_spanset_span(this._inner, b.to_period().get_inner());
+			case Box b -> returnValue = GeneratedFunctions.overright_spanset_span(this._inner, b.to_period().get_inner());
 			default -> returnValue = super.is_over_or_right((Base) other);
 		}
 		return returnValue;
@@ -627,9 +628,9 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	public Time intersection(Time other) {
 		Time returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = new tstzspan(functions.intersection_spanset_span(this._inner,p.get_inner()));
-			case tstzspanset ps -> returnValue = new tstzspan(functions.intersection_spanset_spanset(this._inner,ps.get_inner()));
-			case tstzset ts -> returnValue = new tstzspan(functions.intersection_spanset_spanset(this._inner,functions.set_to_spanset(ts.get_inner())));
+			case tstzspan p -> returnValue = new tstzspan(GeneratedFunctions.intersection_spanset_span(this._inner,p.get_inner()));
+			case tstzspanset ps -> returnValue = new tstzspan(GeneratedFunctions.intersection_spanset_spanset(this._inner,ps.get_inner()));
+			case tstzset ts -> returnValue = new tstzspan(GeneratedFunctions.intersection_spanset_spanset(this._inner,GeneratedFunctions.set_to_spanset(ts.get_inner())));
 			default -> throw new TypeNotPresentException(other.getClass().toString(), new Throwable("Operation not supported with this type"));
 		}
 		return returnValue;
@@ -668,9 +669,9 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	public tstzspanset minus(Time other) {
 		tstzspanset returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = new tstzspanset(functions.minus_spanset_span(this._inner,p.get_inner()));
-			case tstzspanset ps -> returnValue = new tstzspanset(functions.minus_spanset_spanset(this._inner,ps.get_inner()));
-			case tstzset ts -> returnValue = new tstzspanset(functions.minus_spanset_spanset(this._inner,functions.set_to_spanset(ts.get_inner())));
+			case tstzspan p -> returnValue = new tstzspanset(GeneratedFunctions.minus_spanset_span(this._inner,p.get_inner()));
+			case tstzspanset ps -> returnValue = new tstzspanset(GeneratedFunctions.minus_spanset_spanset(this._inner,ps.get_inner()));
+			case tstzset ts -> returnValue = new tstzspanset(GeneratedFunctions.minus_spanset_spanset(this._inner,GeneratedFunctions.set_to_spanset(ts.get_inner())));
 			default -> throw new TypeNotPresentException(other.getClass().toString(), new Throwable("Operation not supported with this type"));
 		}
 		return returnValue;
@@ -711,9 +712,9 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	public tstzspanset union(Time other) {
 		tstzspanset returnValue;
 		switch (other) {
-			case tstzspan p -> returnValue = new tstzspanset(functions.union_spanset_span(this._inner,p.get_inner()));
-			case tstzspanset ps -> returnValue = new tstzspanset(functions.union_spanset_spanset(this._inner,ps.get_inner()));
-			case tstzset ts -> returnValue = new tstzspanset(functions.union_spanset_spanset(this._inner,functions.set_to_spanset(ts.get_inner())));
+			case tstzspan p -> returnValue = new tstzspanset(GeneratedFunctions.union_spanset_span(this._inner,p.get_inner()));
+			case tstzspanset ps -> returnValue = new tstzspanset(GeneratedFunctions.union_spanset_spanset(this._inner,ps.get_inner()));
+			case tstzset ts -> returnValue = new tstzspanset(GeneratedFunctions.union_spanset_spanset(this._inner,GeneratedFunctions.set_to_spanset(ts.get_inner())));
 			default -> throw new TypeNotPresentException(other.getClass().toString(), new Throwable("Operation not supported with this type"));
 		}
 		return returnValue;
@@ -755,7 +756,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 */
 	public boolean eq(Time other) {
 		boolean result;
-		result = other instanceof tstzspanset && functions.spanset_eq(this._inner, ((tstzspanset) other).get_inner());
+		result = other instanceof tstzspanset && GeneratedFunctions.spanset_eq(this._inner, ((tstzspanset) other).get_inner());
 		return result;
 	}
 
@@ -771,7 +772,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 */
 	public boolean notEquals(Time other) {
 		boolean result;
-		result = !(other instanceof tstzspanset) || functions.spanset_ne(this._inner, ((tstzspanset) other).get_inner());
+		result = !(other instanceof tstzspanset) || GeneratedFunctions.spanset_ne(this._inner, ((tstzspanset) other).get_inner());
 		return result;
 	}
 
@@ -788,7 +789,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 */
 	public boolean lessThan(Time other) throws OperationNotSupportedException {
 		if (other instanceof tstzspanset){
-			return functions.spanset_lt(this._inner,((tstzspanset) other).get_inner());
+			return GeneratedFunctions.spanset_lt(this._inner,((tstzspanset) other).get_inner());
 		}
 		else{
 			throw new OperationNotSupportedException("Operation not supported with this type.");
@@ -806,7 +807,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 */
 	public boolean lessThanOrEqual(Time other) throws OperationNotSupportedException {
 		if (other instanceof tstzspanset){
-			return functions.spanset_le(this._inner,((tstzspanset) other).get_inner());
+			return GeneratedFunctions.spanset_le(this._inner,((tstzspanset) other).get_inner());
 		}
 		else{
 			throw new OperationNotSupportedException("Operation not supported with this type.");
@@ -825,7 +826,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 */
 	public boolean greaterThan(Time other) throws OperationNotSupportedException {
 		if (other instanceof tstzspanset){
-			return functions.spanset_gt(this._inner,((tstzspanset) other).get_inner());
+			return GeneratedFunctions.spanset_gt(this._inner,((tstzspanset) other).get_inner());
 		}
 		else{
 			throw new OperationNotSupportedException("Operation not supported with this type.");
@@ -843,7 +844,7 @@ public class tstzspanset extends SpanSet<LocalDateTime> implements Time, TimeCol
 	 */
 	public boolean greaterThanOrEqual(Time other) throws OperationNotSupportedException {
 		if (other instanceof tstzspanset){
-			return functions.spanset_ge(this._inner,((tstzspanset) other).get_inner());
+			return GeneratedFunctions.spanset_ge(this._inner,((tstzspanset) other).get_inner());
 		}
 		else{
 			throw new OperationNotSupportedException("Operation not supported with this type.");

--- a/jmeos-core/src/main/java/types/temporal/Temporal.java
+++ b/jmeos-core/src/main/java/types/temporal/Temporal.java
@@ -1,6 +1,7 @@
 package types.temporal;
 
 import functions.functions;
+import functions.GeneratedFunctions;
 import jnr.ffi.Memory;
 import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
@@ -63,7 +64,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return a copy of the object
      */
     public Temporal copy(){
-        return Factory.create_temporal(functions.temporal_copy(this.inner),this.getCustomType(),this.getTemporalType());
+        return Factory.create_temporal(GeneratedFunctions.temporal_copy(this.inner),this.getCustomType(),this.getTemporalType());
     }
 
     /**
@@ -76,7 +77,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return  A temporal object from a hex-encoded WKB string.
      */
     public Temporal from_hexwkb(String str){
-        Pointer result = functions.temporal_from_hexwkb(str);
+        Pointer result = GeneratedFunctions.temporal_from_hexwkb(str);
         return Factory.create_temporal(result, this.getCustomType(), this.getTemporalType());
     }
 
@@ -94,7 +95,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
 */
 
     public Temporal from_wkb(Pointer wkb, long size){
-        Pointer result= functions.temporal_from_wkb(wkb, size);
+        Pointer result= GeneratedFunctions.temporal_from_wkb(wkb, size);
         return Factory.create_temporal(result, this.getCustomType(), this.getTemporalType());
     }
 
@@ -108,7 +109,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
             temporal_as_hexwkb
 */
     public String as_hexwkb(Pointer wkb, long size){
-        String[] result= new String[]{functions.temporal_as_hexwkb(this.inner, (byte) -1)};
+        String[] result= new String[]{GeneratedFunctions.temporal_as_hexwkb(this.inner, (byte) -1)};
 //        System.out.println(result[0]);
         return result[0];
     }
@@ -123,7 +124,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
             temporal_as_wkb
 */
     public Pointer as_wkb(){
-        Pointer result= functions.temporal_as_wkb(this.inner, (byte) 4);
+        Pointer result= GeneratedFunctions.temporal_as_wkb(this.inner, (byte) 4);
         return result;
     }
 
@@ -137,7 +138,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return A temporal object from a MF-JSON string.
      */
 //    public Temporal from_mfjson(String str){
-//        Pointer result = functions.temporal_as_(str);
+//        Pointer result = GeneratedFunctions.temporal_as_(str);
 //        return Factory.create_temporal(result, this.getCustomType(), this.getTemporalType());
 //    }
 
@@ -161,7 +162,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return The temporal object as a MF-JSON string.
      */
     public String as_mfjson(boolean with_bbox, int flags, int precision, String srs){
-        return functions.temporal_as_mfjson(this.inner,with_bbox,flags,precision,srs);
+        return GeneratedFunctions.temporal_as_mfjson(this.inner,with_bbox,flags,precision,srs);
     }
 
 
@@ -211,7 +212,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         for (int i = 0; i < length_list; i++) {
             temporalP.putPointer((long) i * Long.BYTES, temporal_list.get(i).getInner());
         }
-        Pointer result= functions.temporal_merge_array(temporalP, length_list);
+        Pointer result= GeneratedFunctions.temporal_merge_array(temporalP, length_list);
         return Factory.create_temporal(result, this.getCustomType(), this.getTemporalType());
     }
 
@@ -246,7 +247,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         for (int i = 0; i < length; i++) {
             temporalPointer.putPointer((long) i * Long.BYTES, temporal_list.get(i).getInner());
         }
-        Pointer result = functions.temporal_merge_array(temporalPointer, length);
+        Pointer result = GeneratedFunctions.temporal_merge_array(temporalPointer, length);
         return Factory.create_temporal(result, this.getCustomType(), this.getTemporalType());
     }
 
@@ -268,7 +269,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return The bounding box of `self`.
      */
     public tstzspan bounding_box(){
-        return new tstzspan(functions.temporal_to_tstzspan(this.inner));
+        return new tstzspan(GeneratedFunctions.temporal_to_tstzspan(this.inner));
     }
 
     /**
@@ -279,13 +280,13 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return the {@link tstzspanset}  on which `self` is defined.
      */
     public tstzspanset time(){
-        return new tstzspanset(functions.temporal_time(this.inner));
+        return new tstzspanset(GeneratedFunctions.temporal_time(this.inner));
     }
 
 
 
     public TInterpolation interpolation(){
-        return TInterpolation.fromString(functions.temporal_interp(this.inner),true);
+        return TInterpolation.fromString(GeneratedFunctions.temporal_interp(this.inner),true);
     }
 
 
@@ -310,7 +311,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return
      */
     public tstzspan timespan(){
-        return new tstzspan(functions.temporal_to_tstzspan(this.inner));
+        return new tstzspan(GeneratedFunctions.temporal_to_tstzspan(this.inner));
     }
 
 
@@ -322,7 +323,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return Returns the number of instants in "this".
      */
     public int num_instants(){
-        return functions.temporal_num_instants(this.inner);
+        return GeneratedFunctions.temporal_num_instants(this.inner);
     }
 
 
@@ -334,7 +335,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return Returns the first instant in "this".
      */
     public Temporal start_instant(){
-        return Factory.create_temporal(functions.temporal_start_instant(this.inner), this.getCustomType(), TEMPORAL_INSTANT);
+        return Factory.create_temporal(GeneratedFunctions.temporal_start_instant(this.inner), this.getCustomType(), TEMPORAL_INSTANT);
     }
 
     /**
@@ -345,7 +346,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return Returns the last instant in "this".
      */
     public Temporal end_instant(){
-        return Factory.create_temporal(functions.temporal_end_instant(this.inner), this.getCustomType(), TEMPORAL_INSTANT);
+        return Factory.create_temporal(GeneratedFunctions.temporal_end_instant(this.inner), this.getCustomType(), TEMPORAL_INSTANT);
     }
 
 
@@ -358,7 +359,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return Returns the instant in "this" with the minimum value.
      */
     public Temporal min_instant(){
-        return Factory.create_temporal(functions.temporal_min_instant(this.inner), this.getCustomType(), TEMPORAL_INSTANT);
+        return Factory.create_temporal(GeneratedFunctions.temporal_min_instant(this.inner), this.getCustomType(), TEMPORAL_INSTANT);
     }
 
     /**
@@ -370,7 +371,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return Returns the instant in "this" with the maximum value.
      */
     public Temporal max_instant(){
-        return Factory.create_temporal(functions.temporal_max_instant(this.inner), this.getCustomType(), TEMPORAL_INSTANT);
+        return Factory.create_temporal(GeneratedFunctions.temporal_max_instant(this.inner), this.getCustomType(), TEMPORAL_INSTANT);
     }
 
     /**
@@ -382,18 +383,18 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return a new Temporal
      */
     public Temporal instant_n(int n){
-        return Factory.create_temporal(functions.temporal_instant_n(this.inner, n+1), this.getCustomType(), TEMPORAL_INSTANT);
+        return Factory.create_temporal(GeneratedFunctions.temporal_instant_n(this.inner, n+1), this.getCustomType(), TEMPORAL_INSTANT);
     }
 
 //    public List<Temporal> instants(){
-//        functions.temporal_instants(this.inner);
+//        GeneratedFunctions.temporal_instants(this.inner);
 //    }
 
 //    public abstract Temporal value_at_timestamp();
 
     public Duration duration(boolean ignore_gaps){
         ignore_gaps = false;
-        return ConversionUtils.interval_to_timedelta(functions.temporal_duration(this.inner, ignore_gaps));
+        return ConversionUtils.interval_to_timedelta(GeneratedFunctions.temporal_duration(this.inner, ignore_gaps));
     }
 
     public tstzspan tstzspan(){
@@ -408,7 +409,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return Returns the number of timestamps in "this".
      */
     public int num_timestamps(){
-        return functions.temporal_num_timestamps(this.inner);
+        return GeneratedFunctions.temporal_num_timestamps(this.inner);
     }
 
     /**
@@ -419,7 +420,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return Returns the first timestamp in "this".
      */
     public LocalDateTime start_timestamp(){
-        return ConversionUtils.timestamptz_to_datetime(functions.temporal_start_timestamptz(this.inner));
+        return ConversionUtils.timestamptz_to_datetime(GeneratedFunctions.temporal_start_timestamptz(this.inner));
     }
 
 
@@ -431,11 +432,11 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return Returns the last timestamp in "this".
      */
     public LocalDateTime end_timestamp(){
-        return ConversionUtils.timestamptz_to_datetime(functions.temporal_end_timestamptz(this.inner));
+        return ConversionUtils.timestamptz_to_datetime(GeneratedFunctions.temporal_end_timestamptz(this.inner));
     }
 
     public LocalDateTime timestamp_n(int n){
-        Pointer result = Objects.requireNonNull(functions.temporal_timestamptz_n(this.inner, n + 1));
+        Pointer result = Objects.requireNonNull(GeneratedFunctions.temporal_timestamptz_n(this.inner, n + 1));
         return utils.TimestampTzConverter.toLocalDateTime(result.getLong(0));
     }
 
@@ -451,7 +452,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         Runtime runtime = Runtime.getSystemRuntime();
         // Allocate memory for an integer (4 bytes) but do not set a value
         Pointer intPointer = Memory.allocate(runtime, 4);
-        Pointer array= functions.temporal_timestamps(this.inner, intPointer);
+        Pointer array= GeneratedFunctions.temporal_timestamps(this.inner, intPointer);
         List<LocalDateTime> datetimeList= new ArrayList<LocalDateTime>();
         for(int i=0;i<this.num_timestamps(); i++){
             long ts= array.getLong((long) i * Long.BYTES);
@@ -473,7 +474,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         Runtime runtime = Runtime.getSystemRuntime();
         // Allocate memory for an integer (4 bytes) but do not set a value
         Pointer intPointer = Memory.allocate(runtime, 4);
-        Pointer array= functions.temporal_instants(this.inner, intPointer);
+        Pointer array= GeneratedFunctions.temporal_instants(this.inner, intPointer);
         List<Temporal> instantList= new ArrayList<Temporal>();
         for(int i=0; i<this.num_instants(); i++){
             Pointer p= array.getPointer((long) i *Long.BYTES);
@@ -503,9 +504,9 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         Runtime runtime = Runtime.getSystemRuntime();
         // Allocate memory for an integer (4 bytes) but do not set a value
         Pointer intPointer = Memory.allocate(runtime, 4);
-        Pointer array= functions.temporal_segments(this.inner, intPointer);
+        Pointer array= GeneratedFunctions.temporal_segments(this.inner, intPointer);
         List<Temporal> segmentList= new ArrayList<Temporal>();
-        int num_segments= functions.temporal_num_sequences(this.inner);
+        int num_segments= GeneratedFunctions.temporal_num_sequences(this.inner);
         for(int i=0;i<num_segments; i++){
             Pointer p= array.getPointer((long) i *Long.BYTES);
             Temporal t= Factory.create_temporal(p, this.getCustomType(),this.getTemporalType());
@@ -525,7 +526,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return The hash of the temporal object.
      */
     public long hash(){
-        return functions.temporal_hash(this.inner);
+        return GeneratedFunctions.temporal_hash(this.inner);
     }
 
     /* ------------------------- Transformations ---------------------------------------- */
@@ -541,7 +542,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      *      *         interpolation.
      */
     public Temporal set_interpolation(TInterpolation interpolation){
-        return Factory.create_temporal(functions.temporal_set_interp(this.inner, interpolation.getValue()),this.getCustomType(),this.getTemporalType());
+        return Factory.create_temporal(GeneratedFunctions.temporal_set_interp(this.inner, interpolation.getValue()),this.getCustomType(),this.getTemporalType());
 
     }
 
@@ -557,7 +558,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
 */
 
     public Temporal shift_time(Duration duration){
-        Pointer shifted= functions.temporal_shift_time(this.inner, ConversionUtils.timedelta_to_interval(duration));
+        Pointer shifted= GeneratedFunctions.temporal_shift_time(this.inner, ConversionUtils.timedelta_to_interval(duration));
         return Factory.create_temporal(shifted,this.getCustomType(),this.getTemporalType());
     }
 
@@ -573,7 +574,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
                 temporal_scale_time
     */
     public Temporal scale_time(Duration duration){
-        Pointer scaled= functions.temporal_scale_time(this.inner, ConversionUtils.timedelta_to_interval(duration));
+        Pointer scaled= GeneratedFunctions.temporal_scale_time(this.inner, ConversionUtils.timedelta_to_interval(duration));
         return Factory.create_temporal(scaled,this.getCustomType(),this.getTemporalType());
     }
 
@@ -591,7 +592,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
                 temporal_shift_scale_time
     */
     public Temporal shift_scale_time(Duration shift, Duration scale){
-        Pointer scaled= functions.temporal_shift_scale_time(this.inner, ConversionUtils.timedelta_to_interval(shift), ConversionUtils.timedelta_to_interval(scale));
+        Pointer scaled= GeneratedFunctions.temporal_shift_scale_time(this.inner, ConversionUtils.timedelta_to_interval(shift), ConversionUtils.timedelta_to_interval(scale));
         return Factory.create_temporal(scaled,this.getCustomType(),this.getTemporalType());
     }
 
@@ -614,20 +615,20 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         Pointer dt= null;
         TInterpolation intrp= null;
         if (start == null){
-            st= functions.timestamptz_in("2000-01-03", -1);
+            st= GeneratedFunctions.timestamptz_in("2000-01-03", -1);
         }
         else if (start instanceof LocalDateTime){
             st= ConversionUtils.datetimeToTimestampTz((LocalDateTime)start);
         }
         else{
-            st= functions.timestamptz_in(start.toString(), -1);
+            st= GeneratedFunctions.timestamptz_in(start.toString(), -1);
         }
 
         if(duration instanceof Duration){
             dt= ConversionUtils.timedelta_to_interval((Duration) duration);
         }
         else{
-            dt= functions.interval_in(duration.toString(), -1);
+            dt= GeneratedFunctions.interval_in(duration.toString(), -1);
         }
 
         if(interpolation == null){
@@ -637,7 +638,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
             intrp= interpolation;
         }
         int intrp_val= intrp.getValue();
-        Pointer result= functions.temporal_tsample(this.inner, dt, st, intrp_val);
+        Pointer result= GeneratedFunctions.temporal_tsample(this.inner, dt, st, intrp_val);
         return Factory.create_temporal(result, this.getCustomType(), this.getTemporalType());
     }
 
@@ -658,22 +659,22 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         OffsetDateTime st= null;
         Pointer dt= null;
         if (start == null){
-            st= functions.timestamptz_in("2000-01-03", -1);
+            st= GeneratedFunctions.timestamptz_in("2000-01-03", -1);
         }
         else if (start instanceof LocalDateTime){
             st= ConversionUtils.datetimeToTimestampTz((LocalDateTime)start);
         }
         else{
-            st= functions.timestamptz_in(start.toString(), -1);
+            st= GeneratedFunctions.timestamptz_in(start.toString(), -1);
         }
 
         if(duration instanceof Duration){
             dt= ConversionUtils.timedelta_to_interval((Duration) duration);
         }
         else{
-            dt= functions.interval_in(duration.toString(), -1);
+            dt= GeneratedFunctions.interval_in(duration.toString(), -1);
         }
-        Pointer result= functions.temporal_tprecision(this.inner, dt, st);
+        Pointer result= GeneratedFunctions.temporal_tprecision(this.inner, dt, st);
         return Factory.create_temporal(result, this.getCustomType(), this.getTemporalType());
     }
 
@@ -687,7 +688,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return Returns "this" as a {@link TInstant}.
      */
     public Temporal to_instant(){
-        return Factory.create_temporal(functions.temporal_as_tinstant(this.inner),this.getCustomType(),TEMPORAL_INSTANT);
+        return Factory.create_temporal(GeneratedFunctions.temporal_as_tinstant(this.inner),this.getCustomType(),TEMPORAL_INSTANT);
     }
 
 
@@ -701,7 +702,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      */
     public Temporal to_sequence(TInterpolation interpolation){
         System.out.println(interpolation.toString());
-        return Factory.create_temporal(functions.temporal_tsequence(this.inner, interpolation.getValue()),this.getCustomType(),TEMPORAL_SEQUENCE);
+        return Factory.create_temporal(GeneratedFunctions.temporal_tsequence(this.inner, interpolation.getValue()),this.getCustomType(),TEMPORAL_SEQUENCE);
     }
 
     /**
@@ -713,7 +714,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return a new {@link TSequenceSet}
      */
     public Temporal to_sequenceset(TInterpolation interpolation){
-        return Factory.create_temporal(functions.temporal_tsequenceset(this.inner, interpolation.getValue()),this.getCustomType(),TEMPORAL_SEQUENCE_SET);
+        return Factory.create_temporal(GeneratedFunctions.temporal_tsequenceset(this.inner, interpolation.getValue()),this.getCustomType(),TEMPORAL_SEQUENCE_SET);
 
     }
 
@@ -758,7 +759,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         else{
             interv= ConversionUtils.timedelta_to_interval(max_time);
         }
-        Pointer resultPointer= functions.temporal_append_tinstant(this.inner, instant.getInner(), interp, (double) max_dist, interv, false);
+        Pointer resultPointer= GeneratedFunctions.temporal_append_tinstant(this.inner, instant.getInner(), interp, (double) max_dist, interv, false);
         return Factory.create_temporal(resultPointer, this.getCustomType(), this.getTemporalType());
     }
 
@@ -774,7 +775,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return a new {@link Temporal} object
      */
     public Temporal append_sequence(TSequence sequence){
-        return Factory.create_temporal(functions.temporal_append_tsequence(this.inner, sequence.getInner(), false), this.getCustomType(), this.getTemporalType());
+        return Factory.create_temporal(GeneratedFunctions.temporal_append_tsequence(this.inner, sequence.getInner(), false), this.getCustomType(), this.getTemporalType());
     }
 
 
@@ -832,13 +833,13 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         }
         else if (other instanceof Temporal) {
             Temporal<?> temporalOther = (Temporal<?>) other;
-            newTemp = functions.temporal_merge(this.inner, temporalOther.inner);
+            newTemp = GeneratedFunctions.temporal_merge(this.inner, temporalOther.inner);
         }
         else if (other instanceof List<?>) {
             List<?> otherList = (List<?>) other;
             Pointer pointers = createPointerArray(otherList);
 
-            newTemp = functions.temporal_merge_array(pointers, otherList.size() + 1);
+            newTemp = GeneratedFunctions.temporal_merge_array(pointers, otherList.size() + 1);
         } else {
             throw new Exception("Operation not supported with type " + other.getClass().getName());
         }
@@ -860,7 +861,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      *      *         inserted.
      */
     public Temporal insert(Temporal other, boolean connect){
-        return Factory.create_temporal(functions.temporal_insert(this.inner,other.inner,connect),this.getCustomType(),this.getTemporalType());
+        return Factory.create_temporal(GeneratedFunctions.temporal_insert(this.inner,other.inner,connect),this.getCustomType(),this.getTemporalType());
     }
 
 
@@ -895,7 +896,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      *      *         "other".
      */
     public Temporal update(Temporal other, boolean connect){
-        return Factory.create_temporal(functions.temporal_update(this.inner,other.inner,connect),this.getCustomType(),this.getTemporalType());
+        return Factory.create_temporal(GeneratedFunctions.temporal_update(this.inner,other.inner,connect),this.getCustomType(),this.getTemporalType());
     }
 
     /**
@@ -913,16 +914,16 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
     public Temporal delete(Object other, Boolean connect) throws Exception {
         Pointer new_inner=null;
         if(other instanceof LocalDateTime){
-            new_inner= functions.temporal_delete_timestamptz(this.inner, ConversionUtils.datetimeToTimestampTz((LocalDateTime) other), connect);
+            new_inner= GeneratedFunctions.temporal_delete_timestamptz(this.inner, ConversionUtils.datetimeToTimestampTz((LocalDateTime) other), connect);
         }
         else if(other instanceof tstzset){
-            new_inner= functions.temporal_delete_tstzset(this.inner, ((tstzset) other).get_inner(), connect);
+            new_inner= GeneratedFunctions.temporal_delete_tstzset(this.inner, ((tstzset) other).get_inner(), connect);
         }
         else if(other instanceof tstzspan){
-            new_inner= functions.temporal_delete_tstzspan(this.inner, ((tstzspan) other).get_inner(), connect);
+            new_inner= GeneratedFunctions.temporal_delete_tstzspan(this.inner, ((tstzspan) other).get_inner(), connect);
         }
         else if (other instanceof tstzspanset){
-            new_inner= functions.temporal_delete_tstzspanset(this.inner, ((tstzspanset) other).get_inner(), connect);
+            new_inner= GeneratedFunctions.temporal_delete_tstzspanset(this.inner, ((tstzspanset) other).get_inner(), connect);
         }
         else{
             throw new Exception("Operation not supported with type " + other.getClass().getName());
@@ -957,13 +958,13 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
     public Temporal at(Time other){
         Pointer result = null;
         if (other instanceof tstzset){
-            result = functions.temporal_at_tstzset(this.inner,((tstzset) other).get_inner());
+            result = GeneratedFunctions.temporal_at_tstzset(this.inner,((tstzset) other).get_inner());
 
         } else if (other instanceof tstzspan) {
-            result = functions.temporal_at_tstzspan(this.inner,((tstzspan) other).get_inner());
+            result = GeneratedFunctions.temporal_at_tstzspan(this.inner,((tstzspan) other).get_inner());
 
         } else if (other instanceof tstzspanset) {
-            result = functions.temporal_at_tstzspanset(this.inner,((tstzspanset) other).get_inner());
+            result = GeneratedFunctions.temporal_at_tstzspanset(this.inner,((tstzspanset) other).get_inner());
         }
         return Factory.create_temporal(result, this.getCustomType(),this.getTemporalType());
     }
@@ -981,7 +982,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return A new temporal object of the same subtype as `self`.
      */
     public Temporal at_min(){
-        return Factory.create_temporal(functions.temporal_at_min(this.inner),this.getCustomType(),this.getTemporalType());
+        return Factory.create_temporal(GeneratedFunctions.temporal_at_min(this.inner),this.getCustomType(),this.getTemporalType());
     }
 
 
@@ -997,7 +998,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return A new temporal object of the same subtype as `self`.
      */
     public Temporal at_max(){
-        return Factory.create_temporal(functions.temporal_at_max(this.inner),this.getCustomType(),this.getTemporalType());
+        return Factory.create_temporal(GeneratedFunctions.temporal_at_max(this.inner),this.getCustomType(),this.getTemporalType());
     }
 
 
@@ -1021,13 +1022,13 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
     public Temporal minus(Time other){
         Pointer result = null;
         if (other instanceof tstzset){
-            result = functions.temporal_minus_tstzset(this.inner,((tstzset) other).get_inner());
+            result = GeneratedFunctions.temporal_minus_tstzset(this.inner,((tstzset) other).get_inner());
 
         } else if (other instanceof tstzspan) {
-            result = functions.temporal_minus_tstzspan(this.inner,((tstzspan) other).get_inner());
+            result = GeneratedFunctions.temporal_minus_tstzspan(this.inner,((tstzspan) other).get_inner());
 
         } else if (other instanceof tstzspanset) {
-            result = functions.temporal_minus_tstzspanset(this.inner,((tstzspanset) other).get_inner());
+            result = GeneratedFunctions.temporal_minus_tstzspanset(this.inner,((tstzspanset) other).get_inner());
         }
         return Factory.create_temporal(result, this.getCustomType(),this.getTemporalType());
     }
@@ -1043,7 +1044,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return A new temporal object of the same subtype as "this".
      */
     public Temporal minus_min(){
-        return Factory.create_temporal(functions.temporal_minus_min(this.inner),this.getCustomType(),this.getTemporalType());
+        return Factory.create_temporal(GeneratedFunctions.temporal_minus_min(this.inner),this.getCustomType(),this.getTemporalType());
     }
 
     /**
@@ -1057,7 +1058,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return A new temporal object of the same subtype as "this".
      */
     public Temporal minus_max(){
-        return Factory.create_temporal(functions.temporal_minus_max(this.inner),this.getCustomType(),this.getTemporalType());
+        return Factory.create_temporal(GeneratedFunctions.temporal_minus_max(this.inner),this.getCustomType(),this.getTemporalType());
     }
 
     /* ------------------------- Topological Operations ------------------------ */
@@ -1288,7 +1289,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return A {@link Float} with the Frechet distance.
      */
     public float frechet_distance(Temporal other){
-        return (float) functions.temporal_frechet_distance(this.inner,other.getInner());
+        return (float) GeneratedFunctions.temporal_frechet_distance(this.inner,other.getInner());
     }
 
     /**
@@ -1303,7 +1304,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return A {@link Float} with the Dynamic Time Warp distance.
      */
     public float dyntimewarp_distance(Temporal other){
-        return (float) functions.temporal_dyntimewarp_distance(this.inner,other.getInner());
+        return (float) GeneratedFunctions.temporal_dyntimewarp_distance(this.inner,other.getInner());
     }
 
     /**
@@ -1318,7 +1319,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return A {@link Float} with the Hausdorff distance.
      */
     public float hausdorff_distance(Temporal other){
-        return (float) functions.temporal_hausdorff_distance(this.inner,other.getInner());
+        return (float) GeneratedFunctions.temporal_hausdorff_distance(this.inner,other.getInner());
     }
 
 
@@ -1330,7 +1331,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return a new Pointer object
      */
     public Pointer temporal_simplify_dp(Pointer temp, double dist, boolean sync){
-        return functions.temporal_simplify_dp(temp,dist,sync);
+        return GeneratedFunctions.temporal_simplify_dp(temp,dist,sync);
     }
 
     /* ------------------------- Split Operations ----------------------------------- */
@@ -1364,21 +1365,21 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         OffsetDateTime st= null;
         Pointer dt= null;
         if(start == null){
-            st= functions.timestamptz_in("2000-01-03", -1);
+            st= GeneratedFunctions.timestamptz_in("2000-01-03", -1);
         }
         else{
             if(start instanceof LocalDateTime){
                 st= ConversionUtils.datetimeToTimestampTz((LocalDateTime) start);
             }
             else{
-                st= functions.timestamptz_in(start.toString(), -1);
+                st= GeneratedFunctions.timestamptz_in(start.toString(), -1);
             }
 
             if(duration instanceof Duration){
                 dt= ConversionUtils.timedelta_to_interval((Duration) duration);
             }
             else{
-                dt= functions.interval_in(duration.toString(), -1);
+                dt= GeneratedFunctions.interval_in(duration.toString(), -1);
             }
         }
         // Create a JNR-FFI runtime instance
@@ -1386,7 +1387,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         // Allocate memory for an integer (4 bytes) but do not set a value
         Pointer intPointer = Memory.allocate(runtime, 4);
         Pointer listPointer = createEmptyPointerArray(runtime);
-        Pointer p= functions.temporal_time_split(this.inner, dt, st, listPointer, intPointer);
+        Pointer p= GeneratedFunctions.temporal_time_split(this.inner, dt, st, listPointer, intPointer);
         List<Temporal> tempList= new ArrayList<>();
         int count= intPointer.getInt(Integer.BYTES);
         for(int i=0;i<count;i++){
@@ -1441,7 +1442,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         if(this.start_timestamp() == this.end_timestamp()){
             return Collections.singletonList(this);
         }
-        st= functions.temporal_start_timestamptz(this.inner);
+        st= GeneratedFunctions.temporal_start_timestamptz(this.inner);
         LocalDateTime start= this.start_timestamp();
         LocalDateTime end= this.end_timestamp();
         Duration dur= calculateIntermediateDuration(start, end, n);
@@ -1451,7 +1452,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
         // Allocate memory for an integer (4 bytes) but do not set a value
         Pointer intPointer = Memory.allocate(runtime, 4);
         Pointer listPointer = createEmptyPointerArray(runtime);
-        Pointer p= functions.temporal_time_split(this.inner, dt, st, listPointer, intPointer);
+        Pointer p= GeneratedFunctions.temporal_time_split(this.inner, dt, st, listPointer, intPointer);
         List<Temporal> tempList= new ArrayList<>();
         int count= intPointer.getInt(Integer.BYTES);
         for(int i=0;i<count;i++){
@@ -1481,7 +1482,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
 
     public Temporal stops(double max_distance, Duration max_duration){
         Pointer new_inner= null;
-        new_inner= functions.temporal_stops(this.inner, max_distance, ConversionUtils.timedelta_to_interval(max_duration));
+        new_inner= GeneratedFunctions.temporal_stops(this.inner, max_distance, ConversionUtils.timedelta_to_interval(max_duration));
         return Factory.create_temporal(new_inner, this.getCustomType(), this.getTemporalType());
     }
 
@@ -1499,7 +1500,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return A {@link Boolean} with the result of the equality relation.
      */
     public boolean eq(Temporal other){
-        return functions.temporal_eq(this.inner,other.getInner());
+        return GeneratedFunctions.temporal_eq(this.inner,other.getInner());
     }
 
     /**
@@ -1513,7 +1514,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return A {@link Boolean} with the result of the not equal relation.
      */
     public boolean notEquals(Temporal other){
-        return functions.temporal_ne(this.inner,other.getInner());
+        return GeneratedFunctions.temporal_ne(this.inner,other.getInner());
     }
 
     /**
@@ -1527,7 +1528,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return A {@link Boolean} with the result of the less than relation.
      */
     public boolean lessThan(Temporal other){
-        return functions.temporal_lt(this.inner,other.getInner());
+        return GeneratedFunctions.temporal_lt(this.inner,other.getInner());
     }
 
 
@@ -1542,7 +1543,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return A {@link Boolean} with the result of the less or equal than relation.
      */
     public boolean lessThanOrEqual(Temporal other){
-        return functions.temporal_le(this.inner,other.getInner());
+        return GeneratedFunctions.temporal_le(this.inner,other.getInner());
     }
 
 
@@ -1557,7 +1558,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      * @return A {@link Boolean} with the result of the greater than relation.
      */
     public boolean greaterThan(Temporal other){
-        return functions.temporal_gt(this.inner,other.getInner());
+        return GeneratedFunctions.temporal_gt(this.inner,other.getInner());
     }
 
 
@@ -1573,7 +1574,7 @@ public abstract class Temporal<V extends Serializable> implements Serializable, 
      *      *             relation.
      */
     public boolean greaterThanOrEqual(Temporal other){
-        return functions.temporal_ge(this.inner,other.getInner());
+        return GeneratedFunctions.temporal_ge(this.inner,other.getInner());
     }
 
 

--- a/jmeos-core/src/main/java/utils/ConversionUtils.java
+++ b/jmeos-core/src/main/java/utils/ConversionUtils.java
@@ -2,6 +2,7 @@ package utils;
 
 import com.google.common.collect.BoundType;
 import functions.error_handler;
+import functions.GeneratedFunctions;
 import jnr.ffi.Pointer;
 import com.google.common.collect.Range;
 import org.locationtech.jts.geom.Geometry;
@@ -40,10 +41,10 @@ public class ConversionUtils {
 	 */
 	public static OffsetDateTime datetimeToTimestampTz(LocalDateTime dt) {
 		error_handler handler= new error_handler();
-		functions.meos_initialize_timezone("UTC");
-		functions.meos_initialize_error_handler(handler);
+		GeneratedFunctions.meos_initialize_timezone("UTC");
+		GeneratedFunctions.meos_initialize_error_handler(handler);
 		String formattedDt = dt.atZone(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-		return functions.timestamptz_in(formattedDt, -1);
+		return GeneratedFunctions.timestamptz_in(formattedDt, -1);
 	}
 
 	
@@ -56,7 +57,7 @@ public class ConversionUtils {
 	public static LocalDateTime timestamptz_to_datetime(OffsetDateTime ts) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssX");
 		// Parse the string to LocalDateTime
-		return LocalDateTime.parse(functions.timestamptz_out(ts), formatter);
+		return LocalDateTime.parse(GeneratedFunctions.timestamptz_out(ts), formatter);
 	}
 
 
@@ -68,11 +69,11 @@ public class ConversionUtils {
 		int hours = (int)td.toHours();
 		int minutes = (int)td.toMinutes();
 		double seconds = (double)td.toSeconds();
-		return functions.interval_make(years,month,weeks,days,hours,minutes,seconds);
+		return GeneratedFunctions.interval_make(years,month,weeks,days,hours,minutes,seconds);
 	}
 
 	public static Duration interval_to_timedelta(Pointer p){
-		String res= functions.interval_out(p);
+		String res= GeneratedFunctions.interval_out(p);
 		System.out.println(res);
 		Pattern pattern = Pattern.compile("(\\d+)\\s+days(?:\\s+(\\d{2}):(\\d{2}):(\\d{2}))?");
 		Matcher matcher = pattern.matcher(res);
@@ -107,25 +108,25 @@ public class ConversionUtils {
 	public static Pointer intrange_to_intspan(Range<Integer> intrange) throws SQLException {
 		boolean lower_inc = intrange.lowerBoundType() == BoundType.CLOSED;
 		boolean upper_inc = intrange.upperBoundType() == BoundType.CLOSED;
-		return functions.intspan_make(intrange.lowerEndpoint(),intrange.upperEndpoint(),lower_inc, upper_inc);
+		return GeneratedFunctions.intspan_make(intrange.lowerEndpoint(),intrange.upperEndpoint(),lower_inc, upper_inc);
 	}
 
 	public static Range intspan_to_intrange(Pointer span){
-		BoundType lower_inc = functions.span_lower_inc(span) ? BoundType.CLOSED : BoundType.OPEN;
-		BoundType upper_inc = functions.span_upper_inc(span) ? BoundType.CLOSED : BoundType.OPEN;
-		return Range.range(functions.intspan_lower(span), lower_inc, functions.intspan_upper(span), upper_inc);
+		BoundType lower_inc = GeneratedFunctions.span_lower_inc(span) ? BoundType.CLOSED : BoundType.OPEN;
+		BoundType upper_inc = GeneratedFunctions.span_upper_inc(span) ? BoundType.CLOSED : BoundType.OPEN;
+		return Range.range(GeneratedFunctions.intspan_lower(span), lower_inc, GeneratedFunctions.intspan_upper(span), upper_inc);
 	}
 
 	public static Pointer floatrange_to_floatspan(Range<Float> floatrange){
 		boolean lower_inc = floatrange.lowerBoundType() == BoundType.CLOSED;
 		boolean upper_inc = floatrange.upperBoundType() == BoundType.CLOSED;
-		return functions.floatspan_make(floatrange.lowerEndpoint(),floatrange.upperEndpoint(),lower_inc, upper_inc);
+		return GeneratedFunctions.floatspan_make(floatrange.lowerEndpoint(),floatrange.upperEndpoint(),lower_inc, upper_inc);
 	}
 
 	public static Range floatspan_to_floatrange(Pointer span){
-		BoundType lower_inc = functions.span_lower_inc(span) ? BoundType.CLOSED : BoundType.OPEN;
-		BoundType upper_inc = functions.span_upper_inc(span) ? BoundType.CLOSED : BoundType.OPEN;
-		return Range.range(functions.floatspan_lower(span), lower_inc, functions.floatspan_upper(span), upper_inc);
+		BoundType lower_inc = GeneratedFunctions.span_lower_inc(span) ? BoundType.CLOSED : BoundType.OPEN;
+		BoundType upper_inc = GeneratedFunctions.span_upper_inc(span) ? BoundType.CLOSED : BoundType.OPEN;
+		return Range.range(GeneratedFunctions.floatspan_lower(span), lower_inc, GeneratedFunctions.floatspan_upper(span), upper_inc);
 	}
 
 
@@ -159,7 +160,7 @@ public class ConversionUtils {
 		if (geom.getSRID() > 0){
 			text = "SRID="+geom.getSRID()+";"+text;
 		}
-		Pointer ptr = functions.geom_in(text,-1);
+		Pointer ptr = GeneratedFunctions.geom_in(text,-1);
 		return ptr;
 	}
 
@@ -170,7 +171,7 @@ public class ConversionUtils {
 		if (geom.getSRID() > 0){
 			text = "SRID="+geom.getSRID()+";"+text;
 		}
-		Pointer ptr = functions.geog_in(text,-1);
+		Pointer ptr = GeneratedFunctions.geog_in(text,-1);
 		return ptr;
 	}
 
@@ -180,10 +181,10 @@ public class ConversionUtils {
 	}
 
 	public static Geometry gserialized_to_shapely_geometry(Pointer geom, int precision) throws ParseException, ParseException {
-		String text = functions.geo_as_text(geom,precision);
+		String text = GeneratedFunctions.geo_as_text(geom,precision);
 		WKTReader wktReader = new WKTReader();
 		Geometry geometry = wktReader.read(text);
-		int srid = functions.geo_srid(geom);
+		int srid = GeneratedFunctions.geo_srid(geom);
 		if (srid > 0){
 			geometry.setSRID(srid);
 		}


### PR DESCRIPTION
The object layer reaches MEOS through `functions/functions.java`, a hand-written facade that
duplicates the generated surface and states its parameter lists by hand, so it drifts from the
library whenever MEOS changes a signature. `GeneratedFunctions` derives its declarations from the
MEOS-API catalog, so it follows MEOS by construction.

This points the object layer at `GeneratedFunctions`: 1231 call sites across 47 classes. The
change is a repoint, not a reshape — the arities already agree, which the signature parity check
covers.

Two call sites stay on the hand facade, `TPoint.space_split` and `TPoint.space_time_split`. The
functions they reach return a struct by value, which jnr-ffi cannot bind:

- it has no `ByValue` annotation — that one belongs to JNA;
- a `Struct`-typed return compiles and runs but reads back zeroed, so the count MEOS computed
  arrives as 0;
- supplying the result address as the hidden first argument the System V ABI calls for crashes the
  runtime.

The generator reports these three functions and leaves them out rather than declaring a return the
library does not produce. `functions/functions.java` therefore stays for as long as they lack a
bindable shape; nothing else in it has a caller.

`mvn clean test` against a libmeos built from MobilityDB master: 102 code generation tests and
1760 FFI tests, no failures.