### PR TITLE
Make the binding safe under concurrent use

### DIFF
--- a/codegen/src/main/java/FunctionsGenerator.java
+++ b/codegen/src/main/java/FunctionsGenerator.java
@@ -46,6 +46,9 @@ public class FunctionsGenerator {
     /** Name of the leading parameter carrying the address of a struct returned through memory. */
     private static final String RESULT_PARAM = "_result_address";
 
+    /** The per-thread MEOS initialisation every wrapper performs before reaching the library. */
+    private static final String GUARD_CALL = "ensureReady();";
+
     // -------------------------------------------------------------------------
     // Optional MEOS type families, gated by build flags mirroring the
     // MobilityDB/MEOS flag names and ON|OFF (also 1|0) values: -DCBUFFER=OFF,
@@ -204,6 +207,17 @@ public class FunctionsGenerator {
         // 3. Generate file content
         String content = generateFile(functions);
 
+        // 3b. Every wrapper reaching the library must initialise MEOS for its thread first, so a
+        //     future emit path cannot drop the guard unnoticed.
+        List<String> unguarded = unguardedWrappers(content);
+        if (!unguarded.isEmpty()) {
+            System.err.println("FATAL: " + unguarded.size() + " generated wrapper(s) reach MEOS "
+                    + "without the per-thread init guard (" + GUARD_CALL + "):");
+            unguarded.stream().limit(20).forEach(w -> System.err.println("   " + w));
+            System.exit(1);
+        }
+        System.out.println("Per-thread MEOS-init guard: every wrapper verified");
+
         // 4. Write to disk
         Path out = Paths.get(outputPath);
         Files.createDirectories(out.getParent());
@@ -302,6 +316,89 @@ public class FunctionsGenerator {
     /** The Java name of the jnr Struct class generated for a C struct. */
     private static String structClassName(String cName) {
         return cName;
+    }
+
+    /**
+     * The generated wrappers that reach the library without initialising MEOS for their thread.
+     *
+     * <p>Reads the emitted source rather than the model, so it reports what actually ships.
+     * {@code ensureReady} itself is excluded: it is the guard.
+     */
+    private static List<String> unguardedWrappers(String content) {
+        List<String> unguarded = new ArrayList<>();
+        java.util.regex.Matcher m = java.util.regex.Pattern
+                .compile("\tpublic static [^\n]*? (\\w+)\\([^\n]*\\) \\{\n(.*?)\n\t\\}",
+                        java.util.regex.Pattern.DOTALL)
+                .matcher(content);
+        while (m.find()) {
+            String name = m.group(1);
+            String body = m.group(2);
+            if (name.equals("ensureReady") || !body.contains("_meos_")) {
+                continue; // the guard itself, or a wrapper that never reaches the library
+            }
+            if (body.indexOf(GUARD_CALL) < 0
+                    || body.indexOf(GUARD_CALL) > body.indexOf("_meos_")) {
+                unguarded.add(name);
+            }
+        }
+        return unguarded;
+    }
+
+    /**
+     * Generates the per-thread MEOS initialisation every wrapper runs before reaching the library.
+     *
+     * <p>MEOS holds its session timezone, collation cache, PROJ and GEOS contexts, RNGs and errno in
+     * thread-local storage, so a thread that has not initialised MEOS reads uninitialised state: a
+     * text comparison reaches {@code varstr_cmp} with no collation and the process dies. A library
+     * that is thread-safe still has to be thread-initialised, and the binding is what knows which
+     * threads reach the library, so it initialises each one on first use.
+     */
+    private String generateThreadGuard() {
+        return """
+                \t/**
+                \t * The error handler MEOS calls on this binding's threads. MEOS's own default ends
+                \t * the process with exit(EXIT_FAILURE), which would take the whole JVM down;
+                \t * MeosErrorHandler records the level, code and message instead, which
+                \t * MeosErrorHandler.checkError() reads after each call and rethrows as a Java
+                \t * exception. Registering it is what makes a MEOS error reach the caller, so every
+                \t * thread installs it. Held in a static field so jnr-ffi keeps the native callback
+                \t * alive for the life of the process.
+                \t */
+                \tpublic static final error_handler_fn ERROR_HANDLER = new MeosErrorHandler();
+
+                \tprivate static final ThreadLocal<Boolean> MEOS_READY = new ThreadLocal<>();
+                \tprivate static boolean MEOS_PROCESS_READY = false;
+
+                \t/**
+                \t * Initialises MEOS for the calling thread.
+                \t *
+                \t * <p>What MEOS holds per thread and what it holds per process differ, so the two
+                \t * are set up separately. The session timezone and the collation cache are
+                \t * thread-local, and the PROJ, GEOS and RNG contexts are created lazily per thread,
+                \t * so each thread prepares its own. The error handler is a single process-wide
+                \t * pointer, and meos_initialize() resets it to MEOS's default, which ends the
+                \t * process on an error; running that per thread would disarm the handler the other
+                \t * threads depend on. It therefore runs once, under a lock, before any thread goes on.
+                \t */
+                \tpublic static void ensureReady() {
+                \t\tif (MEOS_READY.get() != null) {
+                \t\t\treturn;
+                \t\t}
+                \t\t// Marked ready before the calls below, which are wrappers that ask for the
+                \t\t// same guard: the flag makes that re-entry a no-op rather than a recursion.
+                \t\tMEOS_READY.set(Boolean.TRUE);
+                \t\tsynchronized (GeneratedFunctions.class) {
+                \t\t\tif (!MEOS_PROCESS_READY) {
+                \t\t\t\tmeos_initialize();
+                \t\t\t\tmeos_initialize_error_handler(ERROR_HANDLER);
+                \t\t\t\tMEOS_PROCESS_READY = true;
+                \t\t\t}
+                \t\t}
+                \t\tmeos_initialize_timezone("UTC");
+                \t\tmeos_initialize_collation();
+                \t}
+
+                """;
     }
 
     /** Generates a jnr Struct class per struct a generated function returns by value. */
@@ -713,6 +810,7 @@ public class FunctionsGenerator {
                 \t}
 
                 """);
+        sb.append(generateThreadGuard());
         sb.append(generateStructClasses());
         sb.append(generateAllInterfaces(functions, partSize));
         sb.append("\n\n");
@@ -900,6 +998,10 @@ public class FunctionsGenerator {
                 .append(fn.name).append("(")
                 .append(buildWrapperParamList(wparams))
                 .append(") {\n");
+
+        // MEOS keeps its session timezone, collation cache, PROJ and GEOS contexts and RNGs in
+        // thread-local storage, so every thread that reaches the library initialises it for itself.
+        sb.append("\t\t").append(GUARD_CALL).append("\n");
 
         // --- Internal allocations ---
         // Determine if we need a Runtime (needed for any Memory.allocateDirect call).

--- a/jmeos-core/src/main/java/functions/MeosErrorHandler.java
+++ b/jmeos-core/src/main/java/functions/MeosErrorHandler.java
@@ -62,15 +62,23 @@ public class MeosErrorHandler implements error_handler_fn {
         EXCEPTION_MAP.put(MEOS_ERR_GEOJSON_OUTPUT,      MeosGeoJsonOutputError::new);
     }
 
-    private static int    lastCode    = 0;
-    private static int    lastLevel   = 0;
-    private static String lastMessage = null;
+    /**
+     * The last error MEOS reported to the calling thread, as {@code {code, level}}.
+     *
+     * <p>MEOS raises an error on the thread that made the call and keeps its own error number in
+     * thread-local storage, so this mirror is per-thread too. One slot shared across threads lets a
+     * thread consume or clear an error raised on another, which loses the exception its caller was
+     * owed and hands it to whichever thread asks next.
+     */
+    private static final ThreadLocal<int[]> LAST_ERROR = ThreadLocal.withInitial(() -> new int[2]);
+    private static final ThreadLocal<String> LAST_MESSAGE = new ThreadLocal<>();
 
     @Override
     public void apply(int errorLevel, int errorCode, String errorMessage) {
-        lastCode    = errorCode;
-        lastLevel   = errorLevel;
-        lastMessage = errorMessage;
+        int[] last = LAST_ERROR.get();
+        last[0] = errorCode;
+        last[1] = errorLevel;
+        LAST_MESSAGE.set(errorMessage);
     }
 
     private static void reportMeosException(int level, int code, String message) {
@@ -92,13 +100,14 @@ public class MeosErrorHandler implements error_handler_fn {
     }
 
     public static void checkError() {
-        if (lastCode != 0) {
-            int    code    = lastCode;
-            int    level   = lastLevel;
-            String message = lastMessage;
-            lastCode = 0;
-            lastLevel = 0;
-            lastMessage = null;
+        int[] last = LAST_ERROR.get();
+        if (last[0] != 0) {
+            int    code    = last[0];
+            int    level   = last[1];
+            String message = LAST_MESSAGE.get();
+            last[0] = 0;
+            last[1] = 0;
+            LAST_MESSAGE.remove();
             reportMeosException(level, code, message);
         }
     }

--- a/jmeos-core/src/main/java/types/basic/tpoint/tgeom/TGeomPoint.java
+++ b/jmeos-core/src/main/java/types/basic/tpoint/tgeom/TGeomPoint.java
@@ -82,7 +82,7 @@ public interface TGeomPoint extends TPoint {
 		} else if (base instanceof tstzspan) {
 			return new TGeomPointSeqSet(GeneratedFunctions.tpointseq_from_base_tstzspan(ConversionUtils.geometry_to_gserialized(value), ((tstzspan) base).get_inner(), interp.getValue()));
 		} else if (base instanceof tstzspanset) {
-			return new TGeomPointSeq(GeneratedFunctions.tpointseq_from_base_tstzset(ConversionUtils.geometry_to_gserialized(value), ((tstzspanset) base).get_inner()));
+			return new TGeomPointSeqSet(GeneratedFunctions.tpointseqset_from_base_tstzspanset(ConversionUtils.geometry_to_gserialized(value), ((tstzspanset) base).get_inner(), interp.getValue()));
 		}
 		else{
 			throw new UnsupportedOperationException("Operation not supported with type " + base.getClass());

--- a/jmeos-core/src/main/java/types/boxes/STBox.java
+++ b/jmeos-core/src/main/java/types/boxes/STBox.java
@@ -1213,9 +1213,6 @@ public class STBox implements Box {
 
 	@Override
 	public tstzspan to_period(){
-		error_handler_fn errorHandler = new error_handler();
-		GeneratedFunctions.meos_initialize_timezone("UTC");
-		GeneratedFunctions.meos_initialize_error_handler(errorHandler);
 		return new tstzspan(GeneratedFunctions.stbox_to_tstzspan(this._inner));
 	}
 

--- a/jmeos-core/src/main/java/types/boxes/TBox.java
+++ b/jmeos-core/src/main/java/types/boxes/TBox.java
@@ -354,9 +354,6 @@ public class TBox implements Box {
 	 * @return a {@link tstzset} instance
 	 */
 	public tstzspan to_period(){
-		error_handler_fn errorHandler = new error_handler();
-		GeneratedFunctions.meos_initialize_timezone("UTC");
-		GeneratedFunctions.meos_initialize_error_handler(errorHandler);
 		return new tstzspan(GeneratedFunctions.tbox_to_tstzspan(this._inner));
 	}
 

--- a/jmeos-core/src/main/java/utils/ConversionUtils.java
+++ b/jmeos-core/src/main/java/utils/ConversionUtils.java
@@ -40,9 +40,6 @@ public class ConversionUtils {
 	 * @return offsetDateTime
 	 */
 	public static OffsetDateTime datetimeToTimestampTz(LocalDateTime dt) {
-		error_handler handler= new error_handler();
-		GeneratedFunctions.meos_initialize_timezone("UTC");
-		GeneratedFunctions.meos_initialize_error_handler(handler);
 		String formattedDt = dt.atZone(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
 		return GeneratedFunctions.timestamptz_in(formattedDt, -1);
 	}

--- a/jmeos-core/src/test/java/basic/InstantsAccessorTest.java
+++ b/jmeos-core/src/test/java/basic/InstantsAccessorTest.java
@@ -22,7 +22,6 @@ class InstantsAccessorTest {
     @BeforeAll
     static void init() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
     }
 
     private static LocalDateTime day(int d) {

--- a/jmeos-core/src/test/java/basic/TBoolTest.java
+++ b/jmeos-core/src/test/java/basic/TBoolTest.java
@@ -37,7 +37,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_copy_constructor() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst"),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq"),
@@ -49,7 +48,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_string_constructor() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("True@2019-09-01", "TBoolInst", TInterpolation.NONE, "t@2019-09-01 00:00:00+00"),
                 Arguments.of("{True@2019-09-01, False@2019-09-02}", "TBoolSeq", TInterpolation.DISCRETE, "{t@2019-09-01 00:00:00+00, f@2019-09-02 00:00:00+00}"),
@@ -61,7 +59,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_base_time_constructor() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"), "TBoolSeq", TInterpolation.DISCRETE),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"), "TBoolSeqSet", TInterpolation.STEPWISE),
@@ -72,7 +69,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_string() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", "t@2019-09-01 00:00:00+00"),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", "{t@2019-09-01 00:00:00+00, f@2019-09-02 00:00:00+00}"),
@@ -83,7 +79,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_bounding() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new tstzspan("[2019-09-01, 2019-09-01]")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", new tstzspan("[2019-09-01, 2019-09-02]")),
@@ -95,7 +90,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_interp() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", TInterpolation.NONE),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", TInterpolation.DISCRETE),
@@ -106,7 +100,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_start() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", true),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", true),
@@ -118,7 +111,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_end() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", true),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", false),
@@ -130,7 +122,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_time() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new tstzspanset("{[2019-09-01, 2019-09-01]}")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", new tstzspanset("{[2019-09-01, 2019-09-01], [2019-09-02, 2019-09-02]}")),
@@ -142,7 +133,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_numinst() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", 1),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",2),
@@ -154,7 +144,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_startinst() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new TBoolInst("True@2019-09-01")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", new TBoolInst("True@2019-09-01")),
@@ -166,7 +155,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_endinst() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new TBoolInst("True@2019-09-01")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", new TBoolInst("False@2019-09-02")),
@@ -178,7 +166,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_mininst() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new TBoolInst("True@2019-09-01")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", new TBoolInst("False@2019-09-02")),
@@ -190,7 +177,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_maxinst() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new TBoolInst("True@2019-09-01")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq", new TBoolInst("True@2019-09-01")),
@@ -203,7 +189,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_instn() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", 0, new TBoolInst("True@2019-09-01")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",1, new TBoolInst("False@2019-09-02")),
@@ -215,7 +200,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_startmstp() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",LocalDateTime.of(2019, 9, 1, 0, 0,0)),
@@ -227,7 +211,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_endtmstp() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -239,7 +222,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_hash() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", 440045287),
 //                Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",2385901957l),
@@ -251,7 +233,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_instant() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), new TBoolInst("True@2019-09-01")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01}"), new TBoolInst("True@2019-09-01")),
@@ -263,7 +244,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_tosequence() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), TInterpolation.NONE, new TBoolSeq("[True@2019-09-01]")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), TInterpolation.DISCRETE , new TBoolSeq("{True@2019-09-01, False@2019-09-02}")),
@@ -275,7 +255,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_tosequenceset() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), TInterpolation.NONE, new TBoolSeqSet("{[True@2019-09-01]}")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), TInterpolation.NONE , new TBoolSeqSet("{[True@2019-09-01], [False@2019-09-02]}"))
@@ -286,7 +265,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_insert() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), new TBoolSeq("{True@2019-09-03}"), new TBoolSeq("{True@2019-09-01, True@2019-09-03}"), "TBoolInst"),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), new TBoolSeq("{True@2019-09-03}") , new TBoolSeq("{True@2019-09-01, False@2019-09-02, True@2019-09-03}"), "TBoolSeq"),
@@ -297,7 +275,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_update() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), new TBoolInst("False@2019-09-01"), new TBoolInst("False@2019-09-01"), "TBoolInst"),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), new TBoolInst("False@2019-09-01") , new TBoolSeq("{False@2019-09-01, False@2019-09-02}"), "TBoolSeq"),
@@ -307,7 +284,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_appendseq() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), new TBoolSeq("{True@2019-09-03}") , new TBoolSeq("{True@2019-09-01, False@2019-09-02, True@2019-09-03}"), "TBoolSeq"),
                 Arguments.of(new TBoolSeqSet("{[True@2019-09-01, False@2019-09-02],[True@2019-09-03, True@2019-09-05]}"), new TBoolSeq("[True@2019-09-06]"), new TBoolSeqSet("{[True@2019-09-01, False@2019-09-02],[True@2019-09-03, True@2019-09-05],[True@2019-09-06]}"), "TBoolSeqSet")
@@ -318,7 +294,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_whentrue() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", new tstzspanset("{[2019-09-01, 2019-09-01]}")),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq" , new tstzspanset("{[2019-09-01, 2019-09-01]}")),
@@ -329,7 +304,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_whenfalse() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq" , new tstzspanset("{[2019-09-02, 2019-09-02]}")),
                 Arguments.of(new TBoolSeq("[True@2019-09-01, False@2019-09-02]"), "TBoolSeq", new tstzspanset("{[2019-09-02, 2019-09-02]}")),
@@ -340,7 +314,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_alwaystrue() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", true),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",false),
@@ -352,7 +325,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_alwaysfalse() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", false),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",false),
@@ -364,7 +336,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_evertrue() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", true),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",true),
@@ -376,7 +347,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_everfalse() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", false),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",true),
@@ -388,7 +358,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_nevertrue() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", false),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",false),
@@ -400,7 +369,6 @@ public class TBoolTest {
 
     static Stream<Arguments> TBool_neverfalse() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", true),
                 Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",false),
@@ -423,7 +391,6 @@ public class TBoolTest {
     @MethodSource("TBool_string_constructor")
     public void testFromStringConstructor(String value, String type, TInterpolation interp, String repr) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             TBoolInst tb = new TBoolInst(value);
             System.out.println(tb.to_string());
@@ -450,7 +417,6 @@ public class TBoolTest {
     @MethodSource("TBool_base_time_constructor")
     public void testFromBaseTimeConstructor(Time base, String type, TInterpolation interp) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             TBoolInst tb = (TBoolInst) TBool.from_base_time(true, base);
             System.out.println(tb.to_string());
@@ -473,7 +439,6 @@ public class TBoolTest {
     @MethodSource("TBool_copy_constructor")
     public void testCopyConstructor(Temporal base, String type) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             TBoolInst tb = (TBoolInst) base.copy();
             assertEquals(tb.to_string(),(((TBoolInst) base).to_string()));
@@ -492,7 +457,6 @@ public class TBoolTest {
     @MethodSource("TBool_string")
     public void testString(Temporal base, String type, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals(expected,(((TBoolInst) base).to_string()));
         } else if (type == "TBoolSeq") {
@@ -507,7 +471,6 @@ public class TBoolTest {
     @MethodSource("TBool_bounding")
     public void testBoundingBox(Temporal base, String type, tstzspan expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.bounding_box().toString(),expected.toString());
     }
 
@@ -517,7 +480,6 @@ public class TBoolTest {
     @MethodSource("TBool_interp")
     public void testInterpolation(Temporal base, String type, TInterpolation expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.interpolation(),expected);
     }
 
@@ -526,7 +488,6 @@ public class TBoolTest {
     @MethodSource("TBool_start")
     public void testStartValues(Temporal base, String type, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBool) base).start_value() ,expected);
     }
 
@@ -535,7 +496,6 @@ public class TBoolTest {
     @MethodSource("TBool_end")
     public void testEndValues(Temporal base, String type, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBool) base).end_value() ,expected);
     }
 
@@ -544,7 +504,6 @@ public class TBoolTest {
     @MethodSource("TBool_time")
     public void testTime(Temporal base, String type, tstzspanset expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.time().toString() ,expected.toString());
     }
 
@@ -553,7 +512,6 @@ public class TBoolTest {
     @MethodSource("TBool_bounding")
     public void testtstzspan(Temporal base, String type, tstzspan expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.period().toString() ,expected.toString());
     }
 
@@ -562,7 +520,6 @@ public class TBoolTest {
     @MethodSource("TBool_bounding")
     public void testSpan(Temporal base, String type, tstzspan expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.timespan().toString(),expected.toString());
     }
 
@@ -571,7 +528,6 @@ public class TBoolTest {
     @MethodSource("TBool_numinst")
     public void testNumInst(Temporal base, String type, int expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.num_instants(),expected);
     }
 
@@ -580,7 +536,6 @@ public class TBoolTest {
     @MethodSource("TBool_startinst")
     public void testStartInst(Temporal base, String type, TBoolInst expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBoolInst)base.start_instant()).to_string(),expected.to_string());
     }
 
@@ -589,7 +544,6 @@ public class TBoolTest {
     @MethodSource("TBool_endinst")
     public void testEndInst(Temporal base, String type, TBoolInst expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBoolInst)base.end_instant()).to_string(),expected.to_string());
     }
 
@@ -598,7 +552,6 @@ public class TBoolTest {
     @MethodSource("TBool_mininst")
     public void testMinInst(Temporal base, String type, TBoolInst expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBoolInst)base.min_instant()).to_string(),expected.to_string());
     }
 
@@ -607,7 +560,6 @@ public class TBoolTest {
     @MethodSource("TBool_maxinst")
     public void testMaxInst(Temporal base, String type, TBoolInst expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBoolInst)base.max_instant()).to_string(),expected.to_string());
     }
 
@@ -615,7 +567,6 @@ public class TBoolTest {
     @MethodSource("TBool_instn")
     public void testInstN(Temporal base, String type, int n, TBoolInst expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TBoolInst)base.instant_n(n)).to_string(),expected.to_string());
     }
 
@@ -624,7 +575,6 @@ public class TBoolTest {
     @MethodSource("TBool_numinst")
     public void testNumtmstmp(Temporal base, String type, int expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.num_timestamps(),expected);
     }
 
@@ -633,7 +583,6 @@ public class TBoolTest {
     @MethodSource("TBool_startmstp")
     public void testStarttmstmp(Temporal base, String type, LocalDateTime expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.start_timestamp(),expected);
     }
 
@@ -642,7 +591,6 @@ public class TBoolTest {
     @MethodSource("TBool_endtmstp")
     public void testEndtmstmp(Temporal base, String type, LocalDateTime expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.end_timestamp(),expected);
     }
 
@@ -651,7 +599,6 @@ public class TBoolTest {
     @MethodSource("TBool_hash")
     public void testHash(Temporal base, String type, long expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.hash(),expected);
     }
 
@@ -660,7 +607,6 @@ public class TBoolTest {
     @MethodSource("TBool_instant")
     public void testInstant(Temporal base, TBoolInst type) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         Temporal tmp = base.to_instant();
         assertTrue(tmp instanceof TBoolInst);
         assertEquals(((TBoolInst) tmp).to_string(), type.to_string());
@@ -671,7 +617,6 @@ public class TBoolTest {
     @MethodSource("TBool_tosequence")
     public void testSequence(Temporal base, TInterpolation type, TBoolSeq tseq) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         Temporal tmp = base.to_sequence(type);
         assertTrue(tmp instanceof TBoolSeq);
         assertEquals(((TBoolSeq) tmp).to_string(), tseq.to_string());
@@ -682,7 +627,6 @@ public class TBoolTest {
     @MethodSource("TBool_tosequenceset")
     public void testSequenceSet(Temporal base, TInterpolation type, TBoolSeqSet tseqset) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         Temporal tmp = base.to_sequenceset(type);
         assertTrue(tmp instanceof TBoolSeqSet);
         assertEquals(((TBoolSeqSet) tmp).to_string(), tseqset.to_string());
@@ -693,7 +637,6 @@ public class TBoolTest {
     @MethodSource("TBool_insert")
     public void testInsert(Temporal base, Temporal base2, Temporal tseq, String type) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals(((TBoolInst)base.insert(base2)).to_string(), ((TBoolSeq) tseq).to_string());
         } else if (type == "TBoolSeq") {
@@ -708,7 +651,6 @@ public class TBoolTest {
     @MethodSource("TBool_update")
     public void testUpdate(Temporal base, Temporal base2, Temporal tseq, String type) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals(((TBoolInst)base.update(base2)).to_string(), ((TBoolInst) tseq).to_string());
         } else if (type == "TBoolSeq") {
@@ -723,7 +665,6 @@ public class TBoolTest {
     @MethodSource("TBool_appendseq")
     public void testAppendSeq(Temporal base, TSequence base2, Temporal tseq, String type) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolSeq") {
             assertEquals(((TBoolSeq)base.append_sequence(base2)).to_string(), ((TBoolSeq) tseq).to_string());
         } else if (type == "TBoolSeqSet") {
@@ -737,7 +678,6 @@ public class TBoolTest {
     @MethodSource("TBool_whentrue")
     public void testWhentrue(Temporal base, String type, tstzspanset pset) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).when_true().toString(), pset.toString());
         } else if (type == "TBoolSeq") {
@@ -752,7 +692,6 @@ public class TBoolTest {
     @MethodSource("TBool_whenfalse")
     public void testWhenfalse(Temporal base, String type, tstzspanset pset) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolSeq") {
             System.out.println(((TBoolSeq) base).when_false().toString());
             System.out.println(pset.toString());
@@ -769,7 +708,6 @@ public class TBoolTest {
     @MethodSource("TBool_alwaystrue")
     public void testAlwaystrue(Temporal base, String type, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).always_eq(true), expected);
         } else if (type == "TBoolSeq") {
@@ -784,7 +722,6 @@ public class TBoolTest {
     @MethodSource("TBool_alwaysfalse")
     public void testAlwaysfalse(Temporal base, String type, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).always_eq(false), expected);
         } else if (type == "TBoolSeq") {
@@ -800,7 +737,6 @@ public class TBoolTest {
     @MethodSource("TBool_evertrue")
     public void testEvertrue(Temporal base, String type, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).ever_eq(true), expected);
         } else if (type == "TBoolSeq") {
@@ -816,7 +752,6 @@ public class TBoolTest {
     @MethodSource("TBool_everfalse")
     public void testEverfalse(Temporal base, String type, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).ever_eq(false), expected);
         } else if (type == "TBoolSeq") {
@@ -831,7 +766,6 @@ public class TBoolTest {
     @MethodSource("TBool_nevertrue")
     public void testNevertrue(Temporal base, String type, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).never_eq(true), expected);
         } else if (type == "TBoolSeq") {
@@ -847,7 +781,6 @@ public class TBoolTest {
     @MethodSource("TBool_neverfalse")
     public void testNeverfalse(Temporal base, String type, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TBoolInst") {
             assertEquals( ((TBoolInst) base).never_eq(false), expected);
         } else if (type == "TBoolSeq") {

--- a/jmeos-core/src/test/java/basic/TFloatTest.java
+++ b/jmeos-core/src/test/java/basic/TFloatTest.java
@@ -41,7 +41,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> frombasetemporal() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TFloatInst", TInterpolation.NONE),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TFloatSeq", TInterpolation.LINEAR),
@@ -52,7 +51,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> frombasetime() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"), "TFloatSeq", TInterpolation.DISCRETE),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"), "TFloatSeqSet", TInterpolation.LINEAR),
@@ -73,7 +71,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> fromcopy() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst"),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq"),
@@ -84,7 +81,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> totint() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", "1@2019-09-01 00:00:00+00")
                 //Arguments.of(new TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}"), "TFloatSeq", "[1@2019-09-01 00:00:00+00, 2@2019-09-02 00:00:00+00]"),
@@ -96,7 +92,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> bounding() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TBox("TBOXFLOAT XT([1.5,1.5],[2019-09-01, 2019-09-01])")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new TBox("TBOXFLOAT XT([1.5,2.5],[2019-09-01, 2019-09-02])")),
@@ -108,7 +103,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> interp() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", TInterpolation.NONE),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", TInterpolation.LINEAR),
@@ -119,7 +113,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> value_span() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new FloatSpan(1.5f, 1.5f, true, true)),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new FloatSpan(1.5f, 2.5f, true, true)),
@@ -130,7 +123,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> value_spans() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new IntSpanSet("{[1,1]}")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new IntSpanSet("{[1,2]}")),
@@ -141,7 +133,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> start_value() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1.5f),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", 1.5f),
@@ -152,7 +143,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> end_value() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1.5f),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", 2.5f),
@@ -163,7 +153,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> min_value() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1.5f),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", 1.5f),
@@ -174,7 +163,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> max_value() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TIntInst", 1.5f),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TIntSeq", 2.5f),
@@ -185,7 +173,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> time() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new tstzspanset("{[2019-09-01, 2019-09-01]}")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new tstzspanset("{[2019-09-01, 2019-09-02]}")),
@@ -196,7 +183,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> period() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new tstzspan("[2019-09-01, 2019-09-01]")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new tstzspan("[2019-09-01, 2019-09-02]")),
@@ -206,7 +192,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> num_instant() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq",2),
@@ -218,7 +203,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> start_instant() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TIntInst", new TFloatInst("1.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TIntSeq",new TFloatInst("1.5@2019-09-01")),
@@ -230,7 +214,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> end_instant() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TFloatInst("1.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq",new TFloatInst("2.5@2019-09-02")),
@@ -241,7 +224,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> max_instant() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TFloatInst("1.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq",new TFloatInst("2.5@2019-09-02")),
@@ -252,7 +234,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> instant_n() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), 0, new TFloatInst("1.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), 1,new TFloatInst("2.5@2019-09-02")),
@@ -264,7 +245,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> num_timestamps() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), 1, new TIntInst("1@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), 2,new TIntInst("2@2019-09-02")),
@@ -276,7 +256,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> start_timestamps() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), 1, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), 2, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
@@ -287,7 +266,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> end_timestamps() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), 1, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), 2, LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -298,7 +276,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> hash() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), 1307112078, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), 1935376725, LocalDateTime.of(2019, 9, 2, 0, 0,0))
@@ -309,7 +286,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> toinstant() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TFloatInst("1.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01]"), "TFloatSeq", new TFloatInst("1.5@2019-09-01")),
@@ -320,7 +296,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> tosequence() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", TInterpolation.LINEAR, new TFloatSeq("[1.5@2019-09-01]")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", TInterpolation.LINEAR, new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")),
@@ -331,7 +306,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> tosequenceset() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", TInterpolation.LINEAR, new TFloatSeqSet("{[1.5@2019-09-01]}")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", TInterpolation.LINEAR, new TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02]}")),
@@ -342,7 +316,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> insert() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 //Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TFloatSeq("{1.5@2019-09-03}"), new TFloatSeq("{1.5@2019-09-01, 1.5@2019-09-03}"))
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new TFloatSeq("[1.5@2019-09-03]"), new TFloatSeqSet("[1.5@2019-09-01, 2.5@2019-09-02, 1.5@2019-09-03]")),
@@ -353,7 +326,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> update() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TFloatInst("2.5@2019-09-01"), new TFloatInst("2.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new TFloatInst("2.5@2019-09-01"), new TFloatSeqSet("{[2.5@2019-09-01], (1.5@2019-09-01, 2.5@2019-09-02]}")),
@@ -364,7 +336,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> append_sequence() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new TFloatSeq("[1.5@2019-09-03]"), new TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02], [1.5@2019-09-03]}")),
                 Arguments.of(new TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"), "TFloatSeqSet", new TFloatSeq("[1.5@2019-09-06]"), new TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05],[1.5@2019-09-06]}"))
@@ -374,7 +345,6 @@ public class TFloatTest {
 
     private static Stream<Arguments> abs() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", new TFloatInst("2.5@2019-09-01"), new TFloatInst("2.5@2019-09-01")),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new TFloatInst("2.5@2019-09-01"), new TFloatSeqSet("{[2.5@2019-09-01], (1.5@2019-09-01, 2.5@2019-09-02]}")),
@@ -385,7 +355,6 @@ public class TFloatTest {
     /*
     private static Stream<Arguments> delta_value() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), "TFloatSeq", new TFloatSeq("Interp=Step;[1@2019-09-01, 1@2019-09-02)")),
                 Arguments.of(new TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"), "TFloatSeqSet", new TFloatSeqSet("Interp=Step;{[1@2019-09-01, 1@2019-09-02),[0@2019-09-03, 0@2019-09-05)}"))
@@ -398,7 +367,6 @@ functions.meos_initialize_error_handler(errorHandler);
 
     private static Stream<Arguments> always_equal() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1.5f, true ),
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 2.5f, false ),
@@ -413,7 +381,6 @@ functions.meos_initialize_error_handler(errorHandler);
 
     private static Stream<Arguments> ever_equal() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1.5f, true ),
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 2.5f, false ),
@@ -428,7 +395,6 @@ functions.meos_initialize_error_handler(errorHandler);
 
     private static Stream<Arguments> ever_greater() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 1.5f, false ),
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TFloatInst", 2.5f, true ),
@@ -462,7 +428,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("frombasetime")
     void testFromBaseTimeConstructor(Time source, String type, TInterpolation interpolation) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TFloatSeq") {
             TFloatSeq ti = (TFloatSeq) TFloat.from_base_time(1.5f, source, interpolation);
             assertTrue(ti instanceof TFloatSeq);
@@ -482,7 +447,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("frombasetemporal")
     void testFromBaseTemporalConstructor(Temporal source, String type, TInterpolation interpolation) {
         //functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TFloatInst ti = new TFloatInst();
             TFloatInst new_ti = (TFloatInst) ti.from_base_temporal(1.5f,source,interpolation);
@@ -510,7 +474,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("fromstring")
     void testStringConstructor(String source, String type, TInterpolation interpolation, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TFloatInst tinst = new TFloatInst(source);
             assertTrue(tinst instanceof TFloatInst);
@@ -538,7 +501,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("fromcopy")
     void testCopyConstructor(Temporal source, String type) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TFloatInst tb = (TFloatInst)source.copy();
             assertEquals(tb.to_string(15),(((TFloatInst) source).to_string(15)));
@@ -559,7 +521,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("fromstring")
     void testString(String source, String type, TInterpolation interpolation, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TFloatInst tinst = new TFloatInst(source);
             assertEquals(tinst.to_string(15),expected);
@@ -579,7 +540,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("totint")
     void testToTInt(TFloat source, String type, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TInt tinst = ((TFloatInst) source).to_tint();
             assertEquals(tinst.to_string(),expected);
@@ -602,7 +562,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("bounding")
     void testBoundingBox(Temporal source, String type, Box expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.bounding_box().toString(),expected.to_period().toString());
     }
 
@@ -613,7 +572,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("interp")
     void testInterpolation(Temporal source, String type, TInterpolation expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.interpolation(),expected);
     }
 
@@ -622,7 +580,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("value_span")
     void testValueSpan(TFloat source, String type, FloatSpan expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.value_span().toString(15),expected.toString(15));
     }
 
@@ -631,7 +588,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("value_spans")
     void testValuesSpan(TInt source, String type, IntSpanSet expected) {
         functions.meos_initialize_timezone("UTC");
-functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.value_spans().toString(),expected.toString());
     }
 
@@ -642,7 +598,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("start_value")
     void testStart_value(TFloat source, String type, float expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_value(),expected);
     }
 
@@ -651,7 +606,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("end_value")
     void testEnd_value(TFloat source, String type, float expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_value(),expected);
     }
 
@@ -660,7 +614,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("min_value")
     void testMin_value(TFloat source, String type, float expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.min_value(),expected);
     }
 
@@ -669,7 +622,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("max_value")
     void testMax_value(TFloat source, String type, float expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.max_value(),expected);
     }
 
@@ -678,7 +630,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("time")
     void testTime(Temporal source, String type, tstzspanset expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.time().toString(),expected.toString());
     }
 
@@ -688,7 +639,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("period")
     void testtstzspan(Temporal source, String type, tstzspan expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.period().toString(),expected.toString());
     }
 
@@ -697,7 +647,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("period")
     void testTimespan(Temporal source, String type, tstzspan expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.timespan().toString(),expected.toString());
     }
 
@@ -706,7 +655,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("num_instant")
     void testNumInstant(Temporal source, String type, int expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.num_instants(),expected);
     }
 
@@ -715,7 +663,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("start_instant")
     void testStartInstant(Temporal source, String type, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloatInst)source.start_instant()).to_string(15),((TFloatInst)expected.start_instant()).to_string(15));
     }
 
@@ -724,7 +671,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("end_instant")
     void testEndInstant(Temporal source, String type, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloatInst)source.end_instant()).to_string(15),((TFloatInst)expected.end_instant()).to_string(15));
     }
 
@@ -734,7 +680,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("start_instant")
     void testMinInstant(Temporal source, String type, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloatInst)source.min_instant()).to_string(15),((TFloatInst)expected.min_instant()).to_string(15));
     }
 
@@ -743,7 +688,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("max_instant")
     void testMaxInstant(Temporal source, String type, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloatInst)source.max_instant()).to_string(15),((TFloatInst)expected.max_instant()).to_string(15));
     }
 
@@ -753,7 +697,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("instant_n")
     void testInstant_n(Temporal source, int n, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloatInst)source.instant_n(n)).to_string(15),((TFloatInst)expected).to_string(15));
     }
 
@@ -762,7 +705,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("num_timestamps")
     void testNumTimestamps(Temporal source, int n, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.num_timestamps(),n);
     }
 
@@ -771,7 +713,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("start_timestamps")
     void testStartTimestamps(Temporal source, int n, LocalDateTime expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_timestamp(),expected);
     }
 
@@ -780,7 +721,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("end_timestamps")
     void testEndTimestamps(Temporal source, int n, LocalDateTime expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_timestamp(),expected);
     }
 
@@ -789,7 +729,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("hash")
     void testHash(Temporal source, long n, LocalDateTime expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.hash(),n);
     }
 
@@ -798,7 +737,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("toinstant")
     void testToinstant(Temporal source, String type, TFloatInst expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TFloatInst tmp = (TFloatInst) source.to_instant();
         assertTrue(tmp instanceof TFloatInst);
         assertEquals(tmp.to_string(15),expected.to_string(15));
@@ -811,7 +749,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("tosequence")
     void testTosequence(Temporal source, String type, TInterpolation interp, TFloatSeq expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TFloatSeq tmp = (TFloatSeq) source.to_sequence(interp);
         assertTrue(tmp instanceof TFloatSeq);
         assertEquals(tmp.to_string(15),expected.to_string(15));
@@ -823,7 +760,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("tosequenceset")
     void testTosequenceset(Temporal source, String type, TInterpolation interp, TFloatSeqSet expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TFloatSeqSet tmp = (TFloatSeqSet) source.to_sequenceset(interp);
         assertTrue(tmp instanceof TFloatSeqSet);
         assertEquals(interp, tmp.interpolation());
@@ -836,7 +772,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("insert")
     void testInsert(Temporal source, String type, TFloatSeq tseq, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TFloatInst tmp = (TFloatInst) source.insert(tseq);
             assertEquals(tmp.to_string(15), ((TFloatSeq)expected).to_string(15));
@@ -856,7 +791,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("update")
     void testUpdate(Temporal source, String type, TFloatInst tseq, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TFloatInst tmp = (TFloatInst) source.update(tseq);
             assertEquals(tmp.to_string(15), ((TFloatInst)expected).to_string(15));
@@ -874,7 +808,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("append_sequence")
     void testAppendSequence(Temporal source, String type, TFloatSeq tseq, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TFloatSeq") {
             TFloatSeq tmp = (TFloatSeq) source.append_sequence(tseq);
             assertEquals(tmp.to_string(15), ((TFloatSeqSet)expected).to_string(15));
@@ -892,7 +825,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("abs")
     void testAbs(Temporal source, String type, TFloatInst tseq, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TNumber tmp = ((TNumber) source).abs();
             assertEquals(((TFloatInst)tmp).to_string(15), ((TFloatInst)source).to_string(15));
@@ -910,7 +842,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("delta_value")
     void testDeltaValue(Temporal source, String type, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-functions.meos_initialize_error_handler(errorHandler);
         if(type == "TFloatInst"){
             TNumber tmp = ((TNumber) source).delta_value();
             assertEquals(((TFloatInst)tmp).tostring(15), ((TFloatInst)expected).tostring(15));
@@ -931,7 +862,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("always_equal")
     void testAlwaysEqual(Temporal source, String type, float arg, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloat)source).always_equal(arg),expected);
         assertEquals(((TFloat)source).never_not_equal(arg),expected);
         assertEquals(((TFloat)source).ever_not_equal(arg),! expected);
@@ -944,7 +874,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("ever_equal")
     void testEverEqual(Temporal source, String type, float arg, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloat)source).ever_equal(arg),expected);
         assertEquals(((TFloat)source).always_not_equal(arg),!expected);
         assertEquals(((TFloat)source).never_equal(arg),! expected);
@@ -955,7 +884,6 @@ functions.meos_initialize_error_handler(errorHandler);
     @MethodSource("ever_greater")
     void testEverGreater(Temporal source, String type, float arg, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TFloat)source).always_less(arg),expected);
         assertEquals(((TFloat)source).never_greater_or_equal(arg),expected);
         assertEquals(((TFloat)source).ever_greater_or_equal(arg),! expected);

--- a/jmeos-core/src/test/java/basic/TGeogPointTest.java
+++ b/jmeos-core/src/test/java/basic/TGeogPointTest.java
@@ -56,7 +56,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> fromtemporal() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1.5 1.5)@2019-09-01"), "TGeogPointInst",TInterpolation.NONE, "POINT(1 1)@2019-09-01 00:00:00+00"),
                 Arguments.of(new TGeogPointSeq("{Point(1.5 1.5)@2019-09-01, Point(2.5 2.5)@2019-09-02}"), "TGeogPointSeq",TInterpolation.DISCRETE, "{POINT(1 1)@2019-09-01 00:00:00+00, POINT(2 2)@2019-09-02 00:00:00+00}"),
@@ -69,7 +68,6 @@ public class TGeogPointTest {
 
     static Stream<Arguments> from_time() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"), "TGeogPointSeq", TInterpolation.DISCRETE),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"), "TGeogPointSeqSet", TInterpolation.STEPWISE),
@@ -81,7 +79,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> fromstring() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst",TInterpolation.NONE, "POINT(1 1)@2019-09-01 00:00:00+00"),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq",TInterpolation.DISCRETE, "{POINT(1 1)@2019-09-01 00:00:00+00, POINT(2 2)@2019-09-02 00:00:00+00}"),
@@ -93,7 +90,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> bounding() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", new STBox("GEODSTBOX XT(((1, 1),(1, 1)),[2019-09-01, 2019-09-01])")    ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", new STBox("GEODSTBOX XT(((1, 1),(2, 2)),[2019-09-01, 2019-09-02])")  ),
@@ -105,7 +101,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> fromstart() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", "POINT (1 1)"    ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", "POINT (1 1)" ),
@@ -117,7 +112,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> endstart() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", "POINT (1 1)"    ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", "POINT (2 2)" ),
@@ -129,7 +123,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> test_time() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", new tstzspanset("{[2019-09-01, 2019-09-01]}") ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", new tstzspanset("{[2019-09-01, 2019-09-01], [2019-09-02, 2019-09-02]}") ),
@@ -141,7 +134,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> period() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", new tstzspan("[2019-09-01, 2019-09-01]") ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", new tstzspan("[2019-09-01, 2019-09-02]") ),
@@ -152,7 +144,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> num_instant() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", 1 ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", 2 ),
@@ -164,7 +155,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> start_instant() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("Point(1 1)@2019-09-01", "TGeogPointInst", new TGeogPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}", "TGeogPointSeq", new TGeogPointInst("Point(1 1)@2019-09-01") ),
@@ -178,7 +168,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> end_instant() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("Point(1 1)@2019-09-01", "TGeogPointInst", new TGeogPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}", "TGeogPointSeq", new TGeogPointInst("Point(2 2)@2019-09-02") ),
@@ -190,7 +179,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> asmfjson() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         String jsonString1 = "{\n" +
                 "  \"type\": \"MovingGeomPoint\",\n" +
                 "  \"bbox\": [\n" +
@@ -370,7 +358,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> min_instant() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", new TGeogPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", new TGeogPointInst("Point(1 1)@2019-09-01") ),
@@ -382,7 +369,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> max_instant() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", new TGeogPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq", new TGeogPointInst("Point(2 2)@2019-09-02") ),
@@ -394,7 +380,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> instantn() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), 0, new TGeogPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 1, new TGeogPointInst("Point(2 2)@2019-09-02") ),
@@ -406,7 +391,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> num_timestamps() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), 1),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 2),
@@ -419,7 +403,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> start_timestamps() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), LocalDateTime.of(2019, 9, 1, 0, 0,0)),
@@ -431,7 +414,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> end_timestamps() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -444,7 +426,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> hash() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
 //                Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), 382694564),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 1545137628),
@@ -456,7 +437,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> lower_inc() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), true),
                 Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), true)
@@ -467,7 +447,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> length() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), 0),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 0),
@@ -479,7 +458,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> cumullength() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), new TFloatInst("0@2019-09-01")),
                 Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), new TFloatSeq("[0@2019-09-01, 156876.14940188668@2019-09-02]")),
@@ -490,7 +468,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> speed() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), null),
                 Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), new TFloatSeq("[1.8157@2019-09-01, 1.8157@2019-09-02]")),
@@ -501,7 +478,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> xy() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), new TFloatInst("1@2019-09-01")),
                 Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), new TFloatSeq("[1@2019-09-01, 2@2019-09-02]")),
@@ -512,7 +488,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> xyz() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1 1)@2019-09-01"), new TFloatInst("1@2019-09-01")),
                 Arguments.of(new TGeogPointSeq("[Point(1 1 1)@2019-09-01, Point(2 2 2)@2019-09-02]"), new TFloatSeq("[1@2019-09-01, 2@2019-09-02]")),
@@ -523,7 +498,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> hasz() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), false),
                 Arguments.of(new TGeogPointSeq("[Point(1 1 1)@2019-09-01, Point(2 2 2)@2019-09-02]"), true),
@@ -534,7 +508,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> is_simple() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), true),
                 Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), true),
@@ -545,7 +518,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> angular_difference() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), "TGeogPointSeqSet", new TFloatSeqSet("{0@2019-09-01,0@2019-09-02}"))
         );
@@ -555,7 +527,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> togeom() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), new TGeomPointInst("Point(1 1)@2019-09-01"))
                 //Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}")),
@@ -567,7 +538,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> to_instant() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), new TGeogPointInst("Point(1 1)@2019-09-01")),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01}"), new TGeogPointInst("Point(1 1)@2019-09-01")),
@@ -580,7 +550,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> to_sequence() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), TInterpolation.LINEAR, new TGeogPointSeq("[Point(1 1)@2019-09-01]")),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), TInterpolation.DISCRETE, new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}")),
@@ -592,7 +561,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> to_sequenceset() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), TInterpolation.LINEAR, new TGeogPointSeqSet("{[Point(1 1)@2019-09-01]}")),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), TInterpolation.LINEAR, new TGeogPointSeqSet("{[Point(1 1)@2019-09-01], [Point(2 2)@2019-09-02]}")),
@@ -605,7 +573,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> set_interp() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), "TGeogPointInst", TInterpolation.DISCRETE, new TGeogPointSeq("{Point(1 1)@2019-09-01}")),
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"),"TGeogPointSeq", TInterpolation.DISCRETE, new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}")),
@@ -617,7 +584,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> round() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointInst("Point(1.123456789 1.123456789)@2019-09-01"), "TGeogPointInst", new TGeogPointInst("Point(1.12 1.12)@2019-09-01")),
                 Arguments.of(new TGeogPointSeq("{Point(1.123456789 1.123456789)@2019-09-01, Point(2.123456789 2.123456789)@2019-09-02}"),"TGeogPointSeq", new TGeogPointSeq("{Point(1.12 1.12)@2019-09-01,Point(2.12 2.12)@2019-09-02}")),
@@ -629,7 +595,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> insert() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeogPointSeq",new TGeogPointSeq("{Point(1 1)@2019-09-03}"), new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02, Point(1 1)@2019-09-03}")  ),
                 Arguments.of(new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), "TGeogPointSeqSet", new TGeogPointSeq("[Point(1 1)@2019-09-06]"), new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02],[Point(1 1)@2019-09-03, Point(1 1)@2019-09-05],[Point(1 1)@2019-09-06]}"))
@@ -640,7 +605,6 @@ public class TGeogPointTest {
 
     private static Stream<Arguments> append_sequence() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"),"TGeogPointSeq", new TGeogPointSeq("[Point(1 1)@2019-09-03]"), new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03]}")),
                 Arguments.of(new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02],[Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), "TGeogPointSeqSet", new TGeogPointSeq("[Point(1 1)@2019-09-06]"), new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02],[Point(1 1)@2019-09-03, Point(1 1)@2019-09-05],[Point(1 1)@2019-09-06]}"))
@@ -674,7 +638,6 @@ public class TGeogPointTest {
     @MethodSource("fromtemporal")
     void testFromTemporalConstructor(TGeogPoint source, String type, TInterpolation interpolation, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             GeometryFactory factory4326 = new GeometryFactory(new PrecisionModel(PrecisionModel.FLOATING), 4326);
             Point point = factory4326.createPoint(new Coordinate(1, 1));
@@ -701,7 +664,6 @@ public class TGeogPointTest {
     @MethodSource("from_time")
     void testFromBaseTimeConstructor(Time source, String type, TInterpolation interpolation) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             GeometryFactory factory4326 = new GeometryFactory(new PrecisionModel(PrecisionModel.FLOATING), 4326);
             Point p = factory4326.createPoint(new Coordinate(1, 1));
@@ -724,7 +686,6 @@ public class TGeogPointTest {
     @MethodSource("fromstring")
     void testFromStringConstructor(TGeogPoint source, String type, TInterpolation interpolation, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             TGeogPointInst ti = new TGeogPointInst(expected);
             assertTrue(ti instanceof TGeogPointInst);
@@ -748,7 +709,6 @@ public class TGeogPointTest {
     @MethodSource("fromstring")
     void testCopyConstructor(Temporal source, String type, TInterpolation interpolation, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             TGeogPointInst ti = (TGeogPointInst) source.copy();
             assertTrue(ti instanceof TGeogPointInst);
@@ -772,7 +732,6 @@ public class TGeogPointTest {
     @MethodSource("bounding")
     void testBounding(TGeogPoint source, String type, STBox expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             //assertEquals(source.bounding_box_point().toString(15), expected.toString(15));
         } else if (type == "TGeogPointSeq") {
@@ -788,7 +747,6 @@ public class TGeogPointTest {
     @MethodSource("fromstring")
     void testInterpolation(Temporal source, String type, TInterpolation interpolation, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             assertEquals(source.interpolation(),interpolation);
         } else if (type == "TGeogPointSeq") {
@@ -804,7 +762,6 @@ public class TGeogPointTest {
     @MethodSource("asmfjson")
     void testAsmfjson(Temporal source, String type, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         System.out.println(source.as_mfjson());
 //        assertEquals(source.as_mfjson(), expected);
     }
@@ -814,7 +771,6 @@ public class TGeogPointTest {
     @MethodSource("fromstart")
     void testStartvalue(TGeogPoint source, String type,  String expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_value(15).toString(), expected);
     }
 
@@ -823,7 +779,6 @@ public class TGeogPointTest {
     @MethodSource("endstart")
     void testEndvalue(TGeogPoint source, String type,  String expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_value(15).toString(), expected);
     }
 
@@ -832,7 +787,6 @@ public class TGeogPointTest {
     @MethodSource("test_time")
     void testTime(TGeogPoint source, String type,  tstzspanset expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).time().toString(), expected.toString());
     }
 
@@ -842,7 +796,6 @@ public class TGeogPointTest {
     @MethodSource("period")
     void testtstzspan(TGeogPoint source, String type,  tstzspan expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).period().toString(), expected.toString());
     }
 
@@ -851,7 +804,6 @@ public class TGeogPointTest {
     @MethodSource("period")
     void testTimeSpan(TGeogPoint source, String type,  tstzspan expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).period().toString(), expected.toString());
     }
 
@@ -859,7 +811,6 @@ public class TGeogPointTest {
     @MethodSource("num_instant")
     void testNumInst(TGeogPoint source, String type,  int expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).num_instants(), expected);
     }
 
@@ -868,7 +819,6 @@ public class TGeogPointTest {
     @MethodSource("start_instant")
     void testStartInstant(String source, String type,  TGeogPoint expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             TGeogPointInst tg = new TGeogPointInst(source);
             TGeogPointInst new_tg = (TGeogPointInst) tg.start_instant();
@@ -890,7 +840,6 @@ public class TGeogPointTest {
     @MethodSource("end_instant")
     void testEndInstant(String source, String type,  TGeogPoint expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst") {
             TGeogPointInst tg = new TGeogPointInst(source);
             TGeogPointInst new_tg = (TGeogPointInst) tg.end_instant();
@@ -911,7 +860,6 @@ public class TGeogPointTest {
     @MethodSource("min_instant")
     void testMinInst(Temporal source, String type,  TGeogPointInst expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TGeogPointInst)source.min_instant()).to_string(), expected.to_string());
     }
 
@@ -921,7 +869,6 @@ public class TGeogPointTest {
     @MethodSource("max_instant")
     void testMaxInst(Temporal source, String type,  TGeogPointInst expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TGeogPointInst)source.max_instant()).to_string(), expected.to_string());
     }
 
@@ -930,7 +877,6 @@ public class TGeogPointTest {
     @MethodSource("instantn")
     void testInstN(Temporal source, int n,  TGeogPointInst expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TGeogPointInst)source.instant_n(n)).to_string(), expected.to_string());
     }
 
@@ -939,7 +885,6 @@ public class TGeogPointTest {
     @MethodSource("num_timestamps")
     void testNumTimestamps(Temporal source, int n) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.num_timestamps(), n);
     }
 
@@ -948,7 +893,6 @@ public class TGeogPointTest {
     @MethodSource("start_timestamps")
     void testStartTimestamps(Temporal source, LocalDateTime local) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_timestamp(), local);
     }
 
@@ -957,7 +901,6 @@ public class TGeogPointTest {
     @MethodSource("end_timestamps")
     void testEndTimestamps(Temporal source, LocalDateTime local) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_timestamp(), local);
     }
 
@@ -966,7 +909,6 @@ public class TGeogPointTest {
     @MethodSource("hash")
     void testHash(Temporal source, long hash) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.hash(), hash);
     }
 
@@ -975,7 +917,6 @@ public class TGeogPointTest {
     @MethodSource("length")
     void testLength(TGeogPoint source, double hash) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TPoint)source).length(), hash);
     }
 
@@ -984,7 +925,6 @@ public class TGeogPointTest {
     @MethodSource("cumullength")
     void testCumulLength(TGeogPoint source, TFloat tfloat) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals((source).cumulative_length().to_string(15), tfloat.to_string(15));
     }
 
@@ -993,7 +933,6 @@ public class TGeogPointTest {
     @MethodSource("xy")
     void testXY(TGeogPoint source, TFloat tfloat) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.x().to_string(15), tfloat.to_string(15));
         assertEquals(source.y().to_string(15), tfloat.to_string(15));
     }
@@ -1003,7 +942,6 @@ public class TGeogPointTest {
     @MethodSource("xyz")
     void testXYZ(TGeogPoint source, TFloat tfloat) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.x().to_string(15), tfloat.to_string(15));
         assertEquals(source.y().to_string(15), tfloat.to_string(15));
         assertEquals(source.z().to_string(15), tfloat.to_string(15));
@@ -1014,7 +952,6 @@ public class TGeogPointTest {
     @MethodSource("hasz")
     void testHasz(TGeogPoint source, boolean val) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.has_z(), val);
     }
 
@@ -1023,7 +960,6 @@ public class TGeogPointTest {
     @MethodSource("is_simple")
     void testIsSimple(TGeogPoint source, boolean val) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.is_simple(), val);
     }
 
@@ -1032,7 +968,6 @@ public class TGeogPointTest {
     @MethodSource("is_simple")
     void testSRID(TGeogPoint source, boolean val) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.srid(), 4326);
     }
 
@@ -1042,7 +977,6 @@ public class TGeogPointTest {
     @MethodSource("angular_difference")
     void testAngula(TGeogPoint source, String type, TFloat val) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointSeq"){
             TFloatSeqSet tf = (TFloatSeqSet) source.angular_difference().to_degrees(true);
             assertEquals(tf.to_string(15), val.to_string(15));
@@ -1058,7 +992,6 @@ public class TGeogPointTest {
     @MethodSource("to_instant")
     void testToInstant(Temporal source, TGeogPointInst tgeog) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TGeogPointInst tmp = (TGeogPointInst) source.to_instant();
         assertTrue(tmp instanceof TGeogPointInst);
         assertEquals(tmp.to_string(),tgeog.to_string());
@@ -1069,7 +1002,6 @@ public class TGeogPointTest {
     @MethodSource("to_sequence")
     void testToSequence(Temporal source, TInterpolation interpolation, TGeogPointSeq tgeog) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TGeogPointSeq tmp = (TGeogPointSeq) source.to_sequence(interpolation);
         assertTrue(tmp instanceof TGeogPointSeq);
         assertEquals(tmp.to_string(),tgeog.to_string());
@@ -1080,7 +1012,6 @@ public class TGeogPointTest {
     @MethodSource("to_sequenceset")
     void testToSequenceSet(Temporal source, TInterpolation interpolation, TGeogPointSeqSet tgeog) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TGeogPointSeqSet tmp = (TGeogPointSeqSet) source.to_sequenceset(interpolation);
         assertTrue(tmp instanceof TGeogPointSeqSet);
         assertEquals(tmp.to_string(),tgeog.to_string());
@@ -1091,7 +1022,6 @@ public class TGeogPointTest {
     @MethodSource("set_interp")
     void testSetInterp(Temporal source, String type, TInterpolation interpolation, TGeogPointSeq tgeog) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointInst"){
             TGeogPointInst tmp = (TGeogPointInst) source.set_interpolation(interpolation);
             assertTrue(tmp instanceof TGeogPointInst);
@@ -1114,7 +1044,6 @@ public class TGeogPointTest {
     @MethodSource("round")
     void testRound(TPoint source, String type, TPoint tgeog) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TGeogPointInst" ){
             assertTrue(source instanceof TGeogPointInst);
             assertEquals(source.round(2).to_string(),tgeog.to_string());
@@ -1132,7 +1061,6 @@ public class TGeogPointTest {
     @MethodSource("insert")
     void testInsert(Temporal source, String type, Temporal add, Temporal expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeogPointSeq"){
             TGeogPointSeq tgeog = (TGeogPointSeq) source.insert(add);
             assertEquals(tgeog.to_string(), ((TGeogPointSeq) expected).to_string());
@@ -1147,7 +1075,6 @@ public class TGeogPointTest {
     @MethodSource("append_sequence")
     void testAppendSequence(Temporal source, String type, TGeogPointSeq tgeoseq, Temporal expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 
         if (type == "TGeogPointSeq"){
             TGeogPointSeq tseq = (TGeogPointSeq) source.append_sequence(tgeoseq);

--- a/jmeos-core/src/test/java/basic/TGeomPointTest.java
+++ b/jmeos-core/src/test/java/basic/TGeomPointTest.java
@@ -53,7 +53,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> fromtemporal() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1.5 1.5)@2019-09-01"), "TGeomPointInst",TInterpolation.NONE, "POINT(1 1)@2019-09-01 00:00:00+00"),
                 Arguments.of(new TGeomPointSeq("{Point(1.5 1.5)@2019-09-01, Point(2.5 2.5)@2019-09-02}"), "TGeomPointSeq",TInterpolation.DISCRETE, "{POINT(1 1)@2019-09-01 00:00:00+00, POINT(2 2)@2019-09-02 00:00:00+00}"),
@@ -66,11 +65,10 @@ public class TGeomPointTest {
 
     static Stream<Arguments> from_time() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"), "TGeomPointSeq", TInterpolation.DISCRETE),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"), "TGeomPointSeqSet", TInterpolation.LINEAR),
-                Arguments.of(new tstzspanset("{[2019-09-01, 2019-09-02],[2019-09-03, 2019-09-05]}"), "TGeomPointSeq", TInterpolation.LINEAR)
+                Arguments.of(new tstzspanset("{[2019-09-01, 2019-09-02],[2019-09-03, 2019-09-05]}"), "TGeomPointSeqSet", TInterpolation.LINEAR)
         );
     }
 
@@ -78,7 +76,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> fromstring() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst",TInterpolation.NONE, "POINT(1 1)@2019-09-01 00:00:00+00"),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq",TInterpolation.DISCRETE, "{POINT(1 1)@2019-09-01 00:00:00+00, POINT(2 2)@2019-09-02 00:00:00+00}"),
@@ -90,7 +87,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> bounding() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", new STBox("STBOX XT(((1, 1),(1, 1)),[2019-09-01, 2019-09-01])")    ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq", new STBox("STBOX XT(((1, 1),(2, 2)),[2019-09-01, 2019-09-02])")  ),
@@ -102,7 +98,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> fromstart() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", "POINT (1 1)"    ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq", "POINT (1 1)" ),
@@ -114,7 +109,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> endstart() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", "POINT (1 1)"    ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq", "POINT (2 2)" ),
@@ -126,7 +120,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> test_time() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", new tstzspanset("{[2019-09-01, 2019-09-01]}") ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq", new tstzspanset("{[2019-09-01, 2019-09-01], [2019-09-02, 2019-09-02]}") ),
@@ -138,7 +131,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> period() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", new tstzspan("[2019-09-01, 2019-09-01]") ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq", new tstzspan("[2019-09-01, 2019-09-02]") ),
@@ -149,7 +141,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> num_instant() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", 1 ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq", 2 ),
@@ -161,7 +152,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> start_instant() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("Point(1 1)@2019-09-01", "TGeomPointInst", new TGeomPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}", "TGeomPointSeq", new TGeomPointInst("Point(1 1)@2019-09-01") ),
@@ -175,7 +165,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> end_instant() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("Point(1 1)@2019-09-01", "TGeomPointInst", new TGeomPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}", "TGeomPointSeq", new TGeomPointInst("Point(2 2)@2019-09-02") ),
@@ -187,7 +176,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> asmfjson() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         String jsonString1 = "{\n" +
                 "  \"type\": \"MovingGeomPoint\",\n" +
                 "  \"bbox\": [\n" +
@@ -367,7 +355,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> min_instant() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", new TGeomPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq", new TGeomPointInst("Point(1 1)@2019-09-01") ),
@@ -379,7 +366,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> max_instant() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", new TGeomPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq", new TGeomPointInst("Point(2 2)@2019-09-02") ),
@@ -391,7 +377,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> instantn() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), 0, new TGeomPointInst("Point(1 1)@2019-09-01") ),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 1, new TGeomPointInst("Point(2 2)@2019-09-02") ),
@@ -403,7 +388,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> num_timestamps() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), 1),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 2),
@@ -416,7 +400,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> start_timestamps() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), LocalDateTime.of(2019, 9, 1, 0, 0,0)),
@@ -428,7 +411,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> end_timestamps() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -441,7 +423,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> hash() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), 382694564),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 1664033448),
@@ -453,7 +434,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> lower_inc() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), true),
                 Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), true)
@@ -464,7 +444,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> length() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), 0),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 0),
@@ -476,7 +455,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> cumullength() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), new TFloatInst("0@2019-09-01")),
                 Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), new TFloatSeq("[0@2019-09-01, 1.4142135623730951@2019-09-02]")),
@@ -487,7 +465,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> speed() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), null),
                 Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), new TFloatSeq("[1.8157@2019-09-01, 1.8157@2019-09-02]")),
@@ -498,7 +475,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> xy() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), new TFloatInst("1@2019-09-01")),
                 Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), new TFloatSeq("[1@2019-09-01, 2@2019-09-02]")),
@@ -509,7 +485,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> xyz() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1 1)@2019-09-01"), new TFloatInst("1@2019-09-01")),
                 Arguments.of(new TGeomPointSeq("[Point(1 1 1)@2019-09-01, Point(2 2 2)@2019-09-02]"), new TFloatSeq("[1@2019-09-01, 2@2019-09-02]")),
@@ -520,7 +495,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> hasz() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), false),
                 Arguments.of(new TGeomPointSeq("[Point(1 1 1)@2019-09-01, Point(2 2 2)@2019-09-02]"), true),
@@ -531,7 +505,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> is_simple() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), true),
                 Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), true),
@@ -542,7 +515,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> angular_difference() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), "TGeomPointSeqSet", new TFloatSeqSet("{0@2019-09-01,0@2019-09-02}"))
         );
@@ -552,7 +524,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> togeom() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), new TGeomPointInst("Point(1 1)@2019-09-01"))
                 //Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}")),
@@ -564,7 +535,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> to_instant() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), new TGeomPointInst("Point(1 1)@2019-09-01")),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01}"), new TGeomPointInst("Point(1 1)@2019-09-01")),
@@ -577,7 +547,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> to_sequence() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), TInterpolation.LINEAR, new TGeomPointSeq("[Point(1 1)@2019-09-01]")),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), TInterpolation.DISCRETE, new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}")),
@@ -589,7 +558,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> to_sequenceset() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), TInterpolation.LINEAR, new TGeomPointSeqSet("{[Point(1 1)@2019-09-01]}")),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), TInterpolation.LINEAR, new TGeomPointSeqSet("{[Point(1 1)@2019-09-01], [Point(2 2)@2019-09-02]}")),
@@ -602,7 +570,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> set_interp() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), "TGeomPointInst", TInterpolation.DISCRETE, new TGeomPointSeq("{Point(1 1)@2019-09-01}")),
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"),"TGeomPointSeq", TInterpolation.DISCRETE, new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}")),
@@ -614,7 +581,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> round() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointInst("Point(1.123456789 1.123456789)@2019-09-01"), "TGeomPointInst", new TGeomPointInst("Point(1.12 1.12)@2019-09-01")),
                 Arguments.of(new TGeomPointSeq("{Point(1.123456789 1.123456789)@2019-09-01, Point(2.123456789 2.123456789)@2019-09-02}"),"TGeomPointSeq", new TGeomPointSeq("{Point(1.12 1.12)@2019-09-01,Point(2.12 2.12)@2019-09-02}")),
@@ -626,7 +592,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> insert() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), "TGeomPointSeq",new TGeomPointSeq("{Point(1 1)@2019-09-03}"), new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02, Point(1 1)@2019-09-03}")  ),
                 Arguments.of(new TGeomPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), "TGeomPointSeqSet", new TGeomPointSeq("[Point(1 1)@2019-09-06]"), new TGeomPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02],[Point(1 1)@2019-09-03, Point(1 1)@2019-09-05],[Point(1 1)@2019-09-06]}"))
@@ -637,7 +602,6 @@ public class TGeomPointTest {
 
     private static Stream<Arguments> append_sequence() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"),"TGeomPointSeq", new TGeomPointSeq("[Point(1 1)@2019-09-03]"), new TGeomPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03]}")),
                 Arguments.of(new TGeomPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02],[Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), "TGeomPointSeqSet", new TGeomPointSeq("[Point(1 1)@2019-09-06]"), new TGeomPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02],[Point(1 1)@2019-09-03, Point(1 1)@2019-09-05],[Point(1 1)@2019-09-06]}"))
@@ -671,7 +635,6 @@ public class TGeomPointTest {
     @MethodSource("fromtemporal")
     void testFromTemporalConstructor(TGeomPoint source, String type, TInterpolation interpolation, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             GeometryFactory factory4326 = new GeometryFactory(new PrecisionModel(PrecisionModel.FLOATING), 4326);
             Point point = factory4326.createPoint(new Coordinate(1, 1));
@@ -698,7 +661,6 @@ public class TGeomPointTest {
     @MethodSource("from_time")
     void testFromBaseTimeConstructor(Time source, String type, TInterpolation interpolation) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             GeometryFactory factory4326 = new GeometryFactory(new PrecisionModel(PrecisionModel.FLOATING));
             Point p = factory4326.createPoint(new Coordinate(1, 1));
@@ -721,7 +683,6 @@ public class TGeomPointTest {
     @MethodSource("fromstring")
     void testFromStringConstructor(TGeomPoint source, String type, TInterpolation interpolation, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             TGeomPointInst ti = new TGeomPointInst(expected);
             assertTrue(ti instanceof TGeomPointInst);
@@ -745,7 +706,6 @@ public class TGeomPointTest {
     @MethodSource("fromstring")
     void testCopyConstructor(Temporal source, String type, TInterpolation interpolation, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             TGeomPointInst ti = (TGeomPointInst) source.copy();
             assertTrue(ti instanceof TGeomPointInst);
@@ -769,7 +729,6 @@ public class TGeomPointTest {
     @MethodSource("bounding")
     void testBounding(TGeomPoint source, String type, STBox expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             //assertEquals(source.bounding_box_point().toString(15), expected.toString(15));
         } else if (type == "TGeomPointSeq") {
@@ -785,7 +744,6 @@ public class TGeomPointTest {
     @MethodSource("fromstring")
     void testInterpolation(Temporal source, String type, TInterpolation interpolation, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             assertEquals(source.interpolation(),interpolation);
         } else if (type == "TGeomPointSeq") {
@@ -801,7 +759,6 @@ public class TGeomPointTest {
     @MethodSource("asmfjson")
     void testAsmfjson(Temporal source, String type, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         System.out.println(source.as_mfjson());
     }
 
@@ -810,7 +767,6 @@ public class TGeomPointTest {
     @MethodSource("fromstart")
     void testStartvalue(TGeomPoint source, String type,  String expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_value(15).toString(), expected);
     }
 
@@ -819,7 +775,6 @@ public class TGeomPointTest {
     @MethodSource("endstart")
     void testEndvalue(TGeomPoint source, String type,  String expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_value(15).toString(), expected);
     }
 
@@ -828,7 +783,6 @@ public class TGeomPointTest {
     @MethodSource("test_time")
     void testTime(TGeomPoint source, String type,  tstzspanset expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).time().toString(), expected.toString());
     }
 
@@ -838,7 +792,6 @@ public class TGeomPointTest {
     @MethodSource("period")
     void testtstzspan(TGeomPoint source, String type,  tstzspan expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).period().toString(), expected.toString());
     }
 
@@ -847,7 +800,6 @@ public class TGeomPointTest {
     @MethodSource("period")
     void testTimeSpan(TGeomPoint source, String type,  tstzspan expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).period().toString(), expected.toString());
     }
 
@@ -855,7 +807,6 @@ public class TGeomPointTest {
     @MethodSource("num_instant")
     void testNumInst(TGeomPoint source, String type,  int expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((Temporal)source).num_instants(), expected);
     }
 
@@ -864,7 +815,6 @@ public class TGeomPointTest {
     @MethodSource("start_instant")
     void testStartInstant(String source, String type,  TGeomPoint expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             TGeomPointInst tg = new TGeomPointInst(source);
             TGeomPointInst new_tg = (TGeomPointInst) tg.start_instant();
@@ -886,7 +836,6 @@ public class TGeomPointTest {
     @MethodSource("end_instant")
     void testEndInstant(String source, String type,  TGeomPoint expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst") {
             TGeomPointInst tg = new TGeomPointInst(source);
             TGeomPointInst new_tg = (TGeomPointInst) tg.end_instant();
@@ -907,7 +856,6 @@ public class TGeomPointTest {
     @MethodSource("min_instant")
     void testMinInst(Temporal source, String type,  TGeomPointInst expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TGeomPointInst)source.min_instant()).to_string(), expected.to_string());
     }
 
@@ -917,7 +865,6 @@ public class TGeomPointTest {
     @MethodSource("max_instant")
     void testMaxInst(Temporal source, String type,  TGeomPointInst expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TGeomPointInst)source.max_instant()).to_string(), expected.to_string());
     }
 
@@ -926,7 +873,6 @@ public class TGeomPointTest {
     @MethodSource("instantn")
     void testInstN(Temporal source, int n,  TGeomPointInst expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TGeomPointInst)source.instant_n(n)).to_string(), expected.to_string());
     }
 
@@ -935,7 +881,6 @@ public class TGeomPointTest {
     @MethodSource("num_timestamps")
     void testNumTimestamps(Temporal source, int n) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.num_timestamps(), n);
     }
 
@@ -944,7 +889,6 @@ public class TGeomPointTest {
     @MethodSource("start_timestamps")
     void testStartTimestamps(Temporal source, LocalDateTime local) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_timestamp(), local);
     }
 
@@ -953,7 +897,6 @@ public class TGeomPointTest {
     @MethodSource("end_timestamps")
     void testEndTimestamps(Temporal source, LocalDateTime local) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_timestamp(), local);
     }
 
@@ -962,7 +905,6 @@ public class TGeomPointTest {
     @MethodSource("hash")
     void testHash(Temporal source, long hash) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.hash(), hash);
     }
 
@@ -971,7 +913,6 @@ public class TGeomPointTest {
     @MethodSource("length")
     void testLength(TGeomPoint source, double hash) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TPoint)source).length(), hash);
     }
 
@@ -980,7 +921,6 @@ public class TGeomPointTest {
     @MethodSource("cumullength")
     void testCumulLength(TGeomPoint source, TFloat tfloat) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals((source).cumulative_length().to_string(15), tfloat.to_string(15));
     }
 
@@ -989,7 +929,6 @@ public class TGeomPointTest {
     @MethodSource("xy")
     void testXY(TGeomPoint source, TFloat tfloat) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.x().to_string(15), tfloat.to_string(15));
         assertEquals(source.y().to_string(15), tfloat.to_string(15));
     }
@@ -999,7 +938,6 @@ public class TGeomPointTest {
     @MethodSource("xyz")
     void testXYZ(TGeomPoint source, TFloat tfloat) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.x().to_string(15), tfloat.to_string(15));
         assertEquals(source.y().to_string(15), tfloat.to_string(15));
         assertEquals(source.z().to_string(15), tfloat.to_string(15));
@@ -1010,7 +948,6 @@ public class TGeomPointTest {
     @MethodSource("hasz")
     void testHasz(TGeomPoint source, boolean val) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.has_z(), val);
     }
 
@@ -1019,7 +956,6 @@ public class TGeomPointTest {
     @MethodSource("is_simple")
     void testIsSimple(TGeomPoint source, boolean val) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.is_simple(), val);
     }
 
@@ -1028,7 +964,6 @@ public class TGeomPointTest {
     @MethodSource("is_simple")
     void testSRID(TGeomPoint source, boolean val) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.srid(), 0);
     }
 
@@ -1038,7 +973,6 @@ public class TGeomPointTest {
     @MethodSource("angular_difference")
     void testAngula(TGeomPoint source, String type, TFloat val) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointSeq"){
             TFloatSeqSet tf = (TFloatSeqSet) source.angular_difference().to_degrees(true);
             assertEquals(tf.to_string(15), val.to_string(15));
@@ -1054,7 +988,6 @@ public class TGeomPointTest {
     @MethodSource("to_instant")
     void testToInstant(Temporal source, TGeomPointInst TGeom) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TGeomPointInst tmp = (TGeomPointInst) source.to_instant();
         assertTrue(tmp instanceof TGeomPointInst);
         assertEquals(tmp.to_string(),TGeom.to_string());
@@ -1065,7 +998,6 @@ public class TGeomPointTest {
     @MethodSource("to_sequence")
     void testToSequence(Temporal source, TInterpolation interpolation, TGeomPointSeq TGeom) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TGeomPointSeq tmp = (TGeomPointSeq) source.to_sequence(interpolation);
         assertTrue(tmp instanceof TGeomPointSeq);
         assertEquals(tmp.to_string(),TGeom.to_string());
@@ -1076,7 +1008,6 @@ public class TGeomPointTest {
     @MethodSource("to_sequenceset")
     void testToSequenceSet(Temporal source, TInterpolation interpolation, TGeomPointSeqSet TGeom) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TGeomPointSeqSet tmp = (TGeomPointSeqSet) source.to_sequenceset(interpolation);
         assertTrue(tmp instanceof TGeomPointSeqSet);
         assertEquals(tmp.to_string(),TGeom.to_string());
@@ -1087,7 +1018,6 @@ public class TGeomPointTest {
     @MethodSource("set_interp")
     void testSetInterp(Temporal source, String type, TInterpolation interpolation, TGeomPointSeq TGeom) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointInst"){
             TGeomPointInst tmp = (TGeomPointInst) source.set_interpolation(interpolation);
             assertTrue(tmp instanceof TGeomPointInst);
@@ -1110,7 +1040,6 @@ public class TGeomPointTest {
     @MethodSource("round")
     void testRound(TPoint source, String type, TPoint TGeom) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TGeomPointInst" ){
             assertTrue(source instanceof TGeomPointInst);
             assertEquals(source.round(2).to_string(),TGeom.to_string());
@@ -1128,7 +1057,6 @@ public class TGeomPointTest {
     @MethodSource("insert")
     void testInsert(Temporal source, String type, Temporal add, Temporal expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TGeomPointSeq"){
             TGeomPointSeq TGeom = (TGeomPointSeq) source.insert(add);
             assertEquals(TGeom.to_string(), ((TGeomPointSeq) expected).to_string());
@@ -1143,7 +1071,6 @@ public class TGeomPointTest {
     @MethodSource("append_sequence")
     void testAppendSequence(Temporal source, String type, TGeomPointSeq tgeoseq, Temporal expected) throws ParseException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 
         if (type == "TGeomPointSeq"){
             TGeomPointSeq tseq = (TGeomPointSeq) source.append_sequence(tgeoseq);

--- a/jmeos-core/src/test/java/basic/TIntTest.java
+++ b/jmeos-core/src/test/java/basic/TIntTest.java
@@ -37,7 +37,6 @@ public class TIntTest {
 
     private static Stream<Arguments> frombasetemporal() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TFloatInst("1.5@2019-09-01"), "TIntInst", TInterpolation.NONE),
                 Arguments.of(new TFloatSeq("[1.5@2019-09-01, 0.5@2019-09-02]"), "TIntSeq", TInterpolation.STEPWISE),
@@ -48,7 +47,6 @@ public class TIntTest {
 
     private static Stream<Arguments> frombasetime() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"), "TIntSeq", TInterpolation.DISCRETE),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"), "TIntSeq", TInterpolation.STEPWISE),
@@ -69,7 +67,6 @@ public class TIntTest {
 
     private static Stream<Arguments> fromcopy() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst"),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq"),
@@ -79,7 +76,6 @@ public class TIntTest {
 
     private static Stream<Arguments> totfloat() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", "1@2019-09-01 00:00:00+00"),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", "Interp=Step;[1@2019-09-01 00:00:00+00, 2@2019-09-02 00:00:00+00]"),
@@ -91,7 +87,6 @@ public class TIntTest {
 
     private static Stream<Arguments> bounding() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TBox("TBOXINT XT([1,1],[2019-09-01, 2019-09-01])")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new TBox("TBOXINT XT([1,2],[2019-09-01, 2019-09-02])")),
@@ -101,7 +96,6 @@ public class TIntTest {
 
     private static Stream<Arguments> interp() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", TInterpolation.NONE),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", TInterpolation.STEPWISE),
@@ -112,7 +106,6 @@ public class TIntTest {
 
     private static Stream<Arguments> value_span() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new IntSpan(1, 1, true, true)),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new IntSpan(1, 2, true, true)),
@@ -123,7 +116,6 @@ public class TIntTest {
 
     private static Stream<Arguments> value_spans() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new IntSpanSet("{[1,1]}")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new IntSpanSet("{[1,2]}")),
@@ -134,7 +126,6 @@ public class TIntTest {
 
     private static Stream<Arguments> start_value() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", 1),
@@ -145,7 +136,6 @@ public class TIntTest {
 
     private static Stream<Arguments> end_value() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", 2),
@@ -156,7 +146,6 @@ public class TIntTest {
 
     private static Stream<Arguments> min_value() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", 1),
@@ -167,7 +156,6 @@ public class TIntTest {
 
     private static Stream<Arguments> max_value() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", 2),
@@ -178,7 +166,6 @@ public class TIntTest {
 
     private static Stream<Arguments> time() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new tstzspanset("{[2019-09-01, 2019-09-01]}")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new tstzspanset("{[2019-09-01, 2019-09-02]}")),
@@ -189,7 +176,6 @@ public class TIntTest {
 
     private static Stream<Arguments> period() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new tstzspan("[2019-09-01, 2019-09-01]")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new tstzspan("[2019-09-01, 2019-09-02]")),
@@ -199,7 +185,6 @@ public class TIntTest {
 
     private static Stream<Arguments> num_instant() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq",2),
@@ -211,7 +196,6 @@ public class TIntTest {
 
     private static Stream<Arguments> start_instant() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntInst("1@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq",new TIntInst("1@2019-09-01")),
@@ -223,7 +207,6 @@ public class TIntTest {
 
     private static Stream<Arguments> end_instant() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntInst("1@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq",new TIntInst("2@2019-09-02")),
@@ -234,7 +217,6 @@ public class TIntTest {
 
     private static Stream<Arguments> max_instant() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntInst("1@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq",new TIntInst("2@2019-09-02")),
@@ -245,7 +227,6 @@ public class TIntTest {
 
     private static Stream<Arguments> instant_n() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), 0, new TIntInst("1@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), 1,new TIntInst("2@2019-09-02")),
@@ -257,7 +238,6 @@ public class TIntTest {
 
     private static Stream<Arguments> num_timestamps() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), 1, new TIntInst("1@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), 2,new TIntInst("2@2019-09-02")),
@@ -269,7 +249,6 @@ public class TIntTest {
 
     private static Stream<Arguments> start_timestamps() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), 1, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), 2, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
@@ -280,7 +259,6 @@ public class TIntTest {
 
     private static Stream<Arguments> end_timestamps() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), 1, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), 2, LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -291,7 +269,6 @@ public class TIntTest {
 
     private static Stream<Arguments> hash() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), 440045287, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
 //                Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), 3589664982l, LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -302,7 +279,6 @@ public class TIntTest {
 
     private static Stream<Arguments> toinstant() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntInst("1@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01]"), "TIntSeq", new TIntInst("1@2019-09-01")),
@@ -313,7 +289,6 @@ public class TIntTest {
 
     private static Stream<Arguments> tosequence() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", TInterpolation.NONE, new TIntSeq("[1@2019-09-01]")),
 //                Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", TInterpolation.DISCRETE, new TIntSeq("[1@2019-09-01, 2@2019-09-02]"))
@@ -324,7 +299,6 @@ public class TIntTest {
 
     private static Stream<Arguments> tosequenceset() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", TInterpolation.NONE, new TIntSeqSet("{[1@2019-09-01]}"))
 //                Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", TInterpolation.STEPWISE, new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02]}"))
@@ -335,7 +309,6 @@ public class TIntTest {
 
     private static Stream<Arguments> insert() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntSeq("{1@2019-09-03}"), new TIntSeq("{1@2019-09-01, 1@2019-09-03}")),
                 Arguments.of(new TIntSeq("{[1@2019-09-01, 2@2019-09-02]}"), "TIntSeq", new TIntSeq("[1@2019-09-03]"), new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02], [1@2019-09-03]}")),
@@ -346,7 +319,6 @@ public class TIntTest {
 
     private static Stream<Arguments> update() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntInst("2@2019-09-01"), new TIntInst("2@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new TIntInst("2@2019-09-01"), new TIntSeqSet("{[2@2019-09-01], (1@2019-09-01, 2@2019-09-02]}")),
@@ -357,7 +329,6 @@ public class TIntTest {
 
     private static Stream<Arguments> append_sequence() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new TIntSeq("[1@2019-09-03]"), new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02], [1@2019-09-03]}")),
                 Arguments.of(new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05]}"), "TIntSeqSet", new TIntSeq("[1@2019-09-06]"), new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05],[1@2019-09-06]}"))
@@ -367,7 +338,6 @@ public class TIntTest {
 
     private static Stream<Arguments> abs() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", new TIntInst("2@2019-09-01"), new TIntInst("2@2019-09-01")),
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new TIntInst("2@2019-09-01"), new TIntSeqSet("{[2@2019-09-01], (1@2019-09-01, 2@2019-09-02]}")),
@@ -378,7 +348,6 @@ public class TIntTest {
 
     private static Stream<Arguments> delta_value() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), "TIntSeq", new TIntInst("2@2019-09-01"), new TIntSeq("[1@2019-09-01, 1@2019-09-02)")),
                 Arguments.of(new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05]}"), "TIntSeqSet", new TIntInst("2@2019-09-01"), new TIntSeqSet("{[1@2019-09-01, 1@2019-09-02),[0@2019-09-03, 0@2019-09-05)}"))
@@ -389,7 +358,6 @@ public class TIntTest {
 
     private static Stream<Arguments> always_equal() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1, true ),
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 2, false ),
@@ -404,7 +372,6 @@ public class TIntTest {
 
     private static Stream<Arguments> ever_equal() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1, true ),
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 2, false ),
@@ -419,7 +386,6 @@ public class TIntTest {
 
     private static Stream<Arguments> ever_greater() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 1, false ),
                 Arguments.of(new TIntInst("1@2019-09-01"), "TIntInst", 2, true ),
@@ -453,7 +419,6 @@ public class TIntTest {
     @MethodSource("frombasetime")
     void testFromBaseTimeConstructor(Time source, String type, TInterpolation interpolation) throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TIntSeq") {
             System.out.println(source.toString());
             TIntSeq ti = (TIntSeq)TInt.from_base_time(1, source, interpolation);
@@ -475,7 +440,6 @@ public class TIntTest {
     @MethodSource("frombasetemporal")
     void testFromBaseTemporalConstructor(Temporal source, String type, TInterpolation interpolation) {
         //functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TIntInst ti = new TIntInst();
             TIntInst new_ti = (TIntInst) ti.from_base_temporal(1,source,interpolation);
@@ -503,7 +467,6 @@ public class TIntTest {
     @MethodSource("fromstring")
     void testStringConstructor(String source, String type, TInterpolation interpolation, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TIntInst tinst = new TIntInst(source);
             assertTrue(tinst instanceof TIntInst);
@@ -531,7 +494,6 @@ public class TIntTest {
     @MethodSource("fromcopy")
     void testCopyConstructor(Temporal source, String type) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TIntInst tb = (TIntInst)source.copy();
             assertEquals(tb.to_string(),(((TIntInst) source).to_string()));
@@ -552,7 +514,6 @@ public class TIntTest {
     @MethodSource("fromstring")
     void testString(String source, String type, TInterpolation interpolation, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TIntInst tinst = new TIntInst(source);
             assertEquals(tinst.to_string(),expected);
@@ -572,7 +533,6 @@ public class TIntTest {
     @MethodSource("totfloat")
     void testToTfloat(TInt source, String type, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TFloatInst tinst = (TFloatInst) source.to_tfloat();
             assertEquals(tinst.to_string(2),expected);
@@ -593,7 +553,6 @@ public class TIntTest {
     @MethodSource("bounding")
     void testBoundingBox(Temporal source, String type, Box expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.bounding_box().toString(),expected.to_period().toString());
     }
 
@@ -602,7 +561,6 @@ public class TIntTest {
     @MethodSource("interp")
     void testInterpolation(Temporal source, String type, TInterpolation expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.interpolation(),expected);
     }
 
@@ -611,7 +569,6 @@ public class TIntTest {
     @MethodSource("value_span")
     void testValueSpan(TInt source, String type, IntSpan expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.value_span().toString(),expected.toString());
     }
 
@@ -620,7 +577,6 @@ public class TIntTest {
     @MethodSource("value_spans")
     void testValuesSpan(TInt source, String type, IntSpanSet expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.value_spans().toString(),expected.toString());
     }
 
@@ -629,7 +585,6 @@ public class TIntTest {
     @MethodSource("start_value")
     void testStart_value(TInt source, String type, int expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_value(),expected);
     }
 
@@ -638,7 +593,6 @@ public class TIntTest {
     @MethodSource("end_value")
     void testEnd_value(TInt source, String type, int expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_value(),expected);
     }
 
@@ -647,7 +601,6 @@ public class TIntTest {
     @MethodSource("min_value")
     void testMin_value(TInt source, String type, int expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.min_value(),expected);
     }
 
@@ -656,7 +609,6 @@ public class TIntTest {
     @MethodSource("max_value")
     void testMax_value(TInt source, String type, int expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.max_value(),expected);
     }
 
@@ -665,7 +617,6 @@ public class TIntTest {
     @MethodSource("time")
     void testTime(Temporal source, String type, tstzspanset expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.time().toString(),expected.toString());
     }
 
@@ -675,7 +626,6 @@ public class TIntTest {
     @MethodSource("period")
     void testtstzspan(Temporal source, String type, tstzspan expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.period().toString(),expected.toString());
     }
 
@@ -684,7 +634,6 @@ public class TIntTest {
     @MethodSource("period")
     void testTimespan(Temporal source, String type, tstzspan expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.timespan().toString(),expected.toString());
     }
 
@@ -693,7 +642,6 @@ public class TIntTest {
     @MethodSource("num_instant")
     void testNumInstant(Temporal source, String type, int expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.num_instants(),expected);
     }
 
@@ -702,7 +650,6 @@ public class TIntTest {
     @MethodSource("start_instant")
     void testStartInstant(Temporal source, String type, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TIntInst)source.start_instant()).to_string(),((TIntInst)expected.start_instant()).to_string());
     }
 
@@ -711,7 +658,6 @@ public class TIntTest {
     @MethodSource("end_instant")
     void testEndInstant(Temporal source, String type, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TIntInst)source.end_instant()).to_string(),((TIntInst)expected.end_instant()).to_string());
     }
 
@@ -721,7 +667,6 @@ public class TIntTest {
     @MethodSource("start_instant")
     void testMinInstant(Temporal source, String type, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TIntInst)source.min_instant()).to_string(),((TIntInst)expected.min_instant()).to_string());
     }
 
@@ -730,7 +675,6 @@ public class TIntTest {
     @MethodSource("max_instant")
     void testMaxInstant(Temporal source, String type, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TIntInst)source.max_instant()).to_string(),((TIntInst)expected.max_instant()).to_string());
     }
 
@@ -740,7 +684,6 @@ public class TIntTest {
     @MethodSource("instant_n")
     void testInstant_n(Temporal source, int n, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TIntInst)source.instant_n(n)).to_string(),((TIntInst)expected).to_string());
     }
 
@@ -749,7 +692,6 @@ public class TIntTest {
     @MethodSource("num_timestamps")
     void testNumTimestamps(Temporal source, int n, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.num_timestamps(),n);
     }
 
@@ -758,7 +700,6 @@ public class TIntTest {
     @MethodSource("start_timestamps")
     void testStartTimestamps(Temporal source, int n, LocalDateTime expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.start_timestamp(),expected);
     }
 
@@ -767,7 +708,6 @@ public class TIntTest {
     @MethodSource("end_timestamps")
     void testEndTimestamps(Temporal source, int n, LocalDateTime expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.end_timestamp(),expected);
     }
 
@@ -776,7 +716,6 @@ public class TIntTest {
     @MethodSource("hash")
     void testHash(Temporal source, long n, LocalDateTime expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(source.hash(),n);
     }
 
@@ -785,7 +724,6 @@ public class TIntTest {
     @MethodSource("toinstant")
     void testToinstant(Temporal source, String type, TIntInst expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TIntInst tmp = (TIntInst) source.to_instant();
         assertTrue(tmp instanceof TIntInst);
         assertEquals(tmp.to_string(),expected.to_string());
@@ -798,7 +736,6 @@ public class TIntTest {
     @MethodSource("tosequence")
     void testTosequence(Temporal source, String type, TInterpolation interp, TIntSeq expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         System.out.println(source.to_sequence(interp).start_timestamp());
 //        System.out.println(source.to_sequenceset(interp));
         TIntSeq tmp = (TIntSeq) source.to_sequence(interp);
@@ -811,7 +748,6 @@ public class TIntTest {
     @MethodSource("tosequenceset")
     void testTosequenceset(Temporal source, String type, TInterpolation interp, TIntSeqSet expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         System.out.println(source.to_sequenceset(interp).start_timestamp());
         TIntSeqSet tmp = (TIntSeqSet) source.to_sequenceset(interp);
         assertTrue(tmp instanceof TIntSeqSet);
@@ -825,7 +761,6 @@ public class TIntTest {
     @MethodSource("insert")
     void testInsert(Temporal source, String type, TIntSeq tseq, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TIntInst tmp = (TIntInst) source.insert(tseq);
             assertEquals(tmp.to_string(), ((TIntSeq)expected).to_string());
@@ -845,7 +780,6 @@ public class TIntTest {
     @MethodSource("update")
     void testUpdate(Temporal source, String type, TIntInst tseq, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TIntInst tmp = (TIntInst) source.update(tseq);
             assertEquals(tmp.to_string(), ((TIntInst)expected).to_string());
@@ -862,7 +796,6 @@ public class TIntTest {
     @MethodSource("append_sequence")
     void testAppendSequence(Temporal source, String type, TIntSeq tseq, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TIntSeq") {
             TIntSeq tmp = (TIntSeq) source.append_sequence(tseq);
             assertEquals(tmp.to_string(), ((TIntSeqSet)expected).to_string());
@@ -876,7 +809,6 @@ public class TIntTest {
     @MethodSource("abs")
     void testAbs(Temporal source, String type, TIntInst tseq, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TNumber tmp = ((TNumber) source).abs();
             assertEquals(((TIntInst)tmp).to_string(), ((TIntInst)source).to_string());
@@ -894,7 +826,6 @@ public class TIntTest {
     @MethodSource("delta_value")
     void testDeltaValue(Temporal source, String type, TIntInst tseq, Temporal expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if(type == "TIntInst"){
             TNumber tmp = ((TNumber) source).delta_value();
             assertEquals(((TIntInst)tmp).to_string(), ((TIntInst)expected).to_string());
@@ -913,7 +844,6 @@ public class TIntTest {
     @MethodSource("always_equal")
     void testAlwaysEqual(Temporal source, String type, int arg, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         System.out.println(((TInt)source).never_not_equal(arg));
         System.out.println(expected);
         assertEquals(((TInt)source).always_equal(arg),expected);
@@ -928,7 +858,6 @@ public class TIntTest {
     @MethodSource("ever_equal")
     void testEverEqual(Temporal source, String type, int arg, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 //        assertEquals(((TInt)source).ever_equal(arg),expected);
         assertEquals(((TInt)source).always_not_equal(arg),!expected);
 //        assertEquals(((TInt)source).never_equal(arg),! expected);
@@ -939,7 +868,6 @@ public class TIntTest {
     @MethodSource("ever_greater")
     void testEverGreater(Temporal source, String type, int arg, boolean expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TInt)source).always_less(arg),expected);
         assertEquals(((TInt)source).never_greater_or_equal(arg),expected);
         assertEquals(((TInt)source).ever_greater_or_equal(arg),! expected);

--- a/jmeos-core/src/test/java/basic/TTextTest.java
+++ b/jmeos-core/src/test/java/basic/TTextTest.java
@@ -33,7 +33,6 @@ public class TTextTest {
     
     static Stream<Arguments> TText_string_constructor() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("AAA@2019-09-01", "TTextInst", TInterpolation.NONE, "\"AAA\"@2019-09-01 00:00:00+00"),
                 Arguments.of("{AAA@2019-09-01, BBB@2019-09-02}", "TTextSeq", TInterpolation.DISCRETE, "{\"AAA\"@2019-09-01 00:00:00+00, \"BBB\"@2019-09-02 00:00:00+00}"),
@@ -44,7 +43,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_base_time_constructor() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"), "TTextSeq", TInterpolation.DISCRETE),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"), "TTextSeqSet", TInterpolation.STEPWISE),
@@ -55,7 +53,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_copy_constructor() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", TInterpolation.NONE),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", TInterpolation.DISCRETE),
@@ -67,7 +64,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_string() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", "\"AAA\"@2019-09-01 00:00:00+00"),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq","{\"AAA\"@2019-09-01 00:00:00+00, \"BBB\"@2019-09-02 00:00:00+00}"),
@@ -79,7 +75,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_bounding() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst",new tstzspan("[2019-09-01, 2019-09-01]")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", new tstzspan("[2019-09-01, 2019-09-02]")),
@@ -91,7 +86,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_interp() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", TInterpolation.NONE),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", TInterpolation.DISCRETE),
@@ -102,7 +96,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_start() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", "AAA"),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", "AAA"),
@@ -114,7 +107,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_end() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", "AAA"),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", "BBB"),
@@ -126,7 +118,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_time() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", new tstzspanset("{[2019-09-01, 2019-09-01]}")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", new tstzspanset("{[2019-09-01, 2019-09-01], [2019-09-02, 2019-09-02]}")),
@@ -138,7 +129,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_numinst() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", 1),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", 2),
@@ -151,7 +141,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_startinst() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", new TTextInst("AAA@2019-09-01")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", new TTextInst("AAA@2019-09-01")),
@@ -163,7 +152,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_endinst() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", new TTextInst("AAA@2019-09-01")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", new TTextInst("BBB@2019-09-02")),
@@ -176,7 +164,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_mininst() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", new TTextInst("AAA@2019-09-01")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", new TTextInst("AAA@2019-09-01")),
@@ -188,7 +175,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_maxinst() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", new TTextInst("AAA@2019-09-01")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq", new TTextInst("BBB@2019-09-02")),
@@ -199,7 +185,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_instn() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", 0, new TTextInst("AAA@2019-09-01")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq",1, new TTextInst("BBB@2019-09-02")),
@@ -211,7 +196,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_numtmstp() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", 1),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq",2),
@@ -223,7 +207,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_starttmstp() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq",LocalDateTime.of(2019, 9, 1, 0, 0,0)),
@@ -234,7 +217,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_endtmstp() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", LocalDateTime.of(2019, 9, 1, 0, 0,0)),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq",LocalDateTime.of(2019, 9, 2, 0, 0,0)),
@@ -246,7 +228,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_hash() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", 1893808825),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq",1223816819),
@@ -258,7 +239,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_toinstant() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"),new TTextInst("AAA@2019-09-01")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01}"), new TTextInst("AAA@2019-09-01")),
@@ -270,7 +250,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_tosequence() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), TInterpolation.STEPWISE, new TTextSeq("[AAA@2019-09-01]")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), TInterpolation.DISCRETE,  new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}")),
@@ -282,7 +261,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_tosequenceset() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), TInterpolation.STEPWISE, new TTextSeqSet("{[AAA@2019-09-01]}")),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), TInterpolation.STEPWISE,  new TTextSeqSet("{[AAA@2019-09-01], [BBB@2019-09-02]}"))
@@ -295,7 +273,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_insert() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), new TTextSeq("{AAA@2019-09-03}"), new TTextSeq("{AAA@2019-09-01, AAA@2019-09-03}"), "TTextInst"),
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), new TTextSeq("{AAA@2019-09-03}"), new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02, AAA@2019-09-03}"), "TTextSeq"),
@@ -307,7 +284,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_update() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextInst("AAA@2019-09-01"), new TTextInst("BBB@2019-09-01"), new TTextInst("BBB@2019-09-01"), "TTextInst" ),
                 Arguments.of(new TTextSeq("[AAA@2019-09-01, BBB@2019-09-02]"), new TTextInst("BBB@2019-09-01"), new TTextSeqSet("{[BBB@2019-09-01], (AAA@2019-09-01, BBB@2019-09-02]}"), "TTextSeq"),
@@ -319,7 +295,6 @@ public class TTextTest {
 
     static Stream<Arguments> TText_appendseq() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), new TTextSeq("{AAA@2019-09-03}"),  new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02, AAA@2019-09-03}"), "TTextSeq"),
                 Arguments.of(new TTextSeqSet("{[AAA@2019-09-01, BBB@2019-09-02],[AAA@2019-09-03, AAA@2019-09-05]}"), new TTextSeq("[AAA@2019-09-06]"), new TTextSeqSet("{[AAA@2019-09-01, BBB@2019-09-02],[AAA@2019-09-03, AAA@2019-09-05],[AAA@2019-09-06]}"), "TTextSeqSet")
@@ -346,7 +321,6 @@ public class TTextTest {
     @MethodSource("TText_string_constructor")
     public void testFromStringConstructor(String value, String type, TInterpolation interp, String repr) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextInst") {
             TTextInst tb = new TTextInst(value);
             assertTrue(tb instanceof TTextInst);
@@ -370,7 +344,6 @@ public class TTextTest {
     @MethodSource("TText_base_time_constructor")
     public void testFromBaseTimeConstructor(Time base, String type, TInterpolation interp) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextInst") {
             TTextInst tb = (TTextInst) TText.from_base_time("AAA", base);
             assertTrue(tb instanceof TTextInst);
@@ -393,7 +366,6 @@ public class TTextTest {
     @MethodSource("TText_copy_constructor")
     public void testCopyConstructor(Temporal base, String type, TInterpolation interp) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextInst") {
             TTextInst tb = (TTextInst) base.copy();
             assertEquals(tb.to_string(),(((TTextInst) base).to_string()));
@@ -412,7 +384,6 @@ public class TTextTest {
     @MethodSource("TText_string")
     public void testString(Temporal base, String type, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextInst") {
             TTextInst tb = (TTextInst) base.copy();
             assertEquals(tb.to_string(),expected);
@@ -430,7 +401,6 @@ public class TTextTest {
     @MethodSource("TText_bounding")
     public void testBoundingBox(Temporal base, String type, tstzspan expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.bounding_box().toString(),expected.toString());
     }
 
@@ -440,7 +410,6 @@ public class TTextTest {
     @MethodSource("TText_interp")
     public void testInterpolation(Temporal base, String type, TInterpolation expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.interpolation(),expected);
     }
 
@@ -449,7 +418,6 @@ public class TTextTest {
     @MethodSource("TText_start")
     public void testStartValues(Temporal base, String type, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TText) base).start_value() ,expected);
     }
 
@@ -458,7 +426,6 @@ public class TTextTest {
     @MethodSource("TText_end")
     public void testEndValues(Temporal base, String type, String expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TText) base).end_value() ,expected);
     }
 
@@ -467,7 +434,6 @@ public class TTextTest {
     @MethodSource("TText_time")
     public void testTime(Temporal base, String type, tstzspanset expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.time().toString() ,expected.toString());
     }
 
@@ -476,7 +442,6 @@ public class TTextTest {
     @MethodSource("TText_bounding")
     public void testtstzspan(Temporal base, String type, tstzspan expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.period().toString() ,expected.toString());
     }
 
@@ -485,7 +450,6 @@ public class TTextTest {
     @MethodSource("TText_bounding")
     public void testSpan(Temporal base, String type, tstzspan expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.timespan().toString(),expected.toString());
     }
 
@@ -493,7 +457,6 @@ public class TTextTest {
     @MethodSource("TText_numinst")
     public void testNumInst(Temporal base, String type, int expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.num_instants(),expected);
     }
 
@@ -502,7 +465,6 @@ public class TTextTest {
     @MethodSource("TText_startinst")
     public void testStartInst(Temporal base, String type, TTextInst expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TTextInst)base.start_instant()).to_string(),expected.to_string());
     }
 
@@ -511,7 +473,6 @@ public class TTextTest {
     @MethodSource("TText_endinst")
     public void testEndInst(Temporal base, String type, TTextInst expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TTextInst)base.end_instant()).to_string(),expected.to_string());
     }
 
@@ -520,7 +481,6 @@ public class TTextTest {
     @MethodSource("TText_mininst")
     public void testMinInst(Temporal base, String type, TTextInst expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TTextInst)base.min_instant()).to_string(),expected.to_string());
     }
 
@@ -529,7 +489,6 @@ public class TTextTest {
     @MethodSource("TText_maxinst")
     public void testMaxInst(Temporal base, String type, TTextInst expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TTextInst)base.max_instant()).to_string(),expected.to_string());
     }
 
@@ -538,7 +497,6 @@ public class TTextTest {
     @MethodSource("TText_instn")
     public void testInstN(Temporal base, String type, int n, TTextInst expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(((TTextInst)base.instant_n(n)).to_string(),expected.to_string());
     }
 
@@ -547,7 +505,6 @@ public class TTextTest {
     @MethodSource("TText_numtmstp")
     public void testNumtmstmp(Temporal base, String type, int expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.num_timestamps(),expected);
     }
 
@@ -556,7 +513,6 @@ public class TTextTest {
     @MethodSource("TText_starttmstp")
     public void testStarttmstmp(Temporal base, String type, LocalDateTime expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.start_timestamp(),expected);
     }
 
@@ -565,7 +521,6 @@ public class TTextTest {
     @MethodSource("TText_endtmstp")
     public void testEndtmstmp(Temporal base, String type, LocalDateTime expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.end_timestamp(),expected);
     }
 
@@ -574,7 +529,6 @@ public class TTextTest {
     @MethodSource("TText_hash")
     public void testHash(Temporal base, String type, long expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(base.hash(),expected);
     }
 
@@ -583,7 +537,6 @@ public class TTextTest {
     @MethodSource("TText_toinstant")
     public void testToInstant(Temporal base, TTextInst type) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         Temporal tmp = base.to_instant();
         assertTrue(tmp instanceof TTextInst);
         assertEquals(((TTextInst) tmp).to_string(), type.to_string());
@@ -594,7 +547,6 @@ public class TTextTest {
     @MethodSource("TText_tosequence")
     public void testToSequence(Temporal base, TInterpolation interp, TTextSeq type) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         Temporal tmp = base.to_sequence(interp);
         assertTrue(tmp instanceof TTextSeq);
         assertEquals(((TTextSeq) tmp).to_string(), type.to_string());
@@ -606,7 +558,6 @@ public class TTextTest {
     @MethodSource("TText_tosequenceset")
     public void testToSequenceSet(Temporal base, TInterpolation interp, TTextSeqSet type) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         Temporal tmp = base.to_sequenceset(interp);
         assertTrue(tmp instanceof TTextSeqSet);
         assertEquals(((TTextSeqSet) tmp).to_string(), type.to_string());
@@ -618,7 +569,6 @@ public class TTextTest {
     @MethodSource("TText_insert")
     public void testInsert(Temporal base, Temporal base2, Temporal tseq, String type) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextInst") {
             assertEquals(((TTextInst)base.insert(base2)).to_string(), ((TTextSeq) tseq).to_string());
         } else if (type == "TTextSeq") {
@@ -633,7 +583,6 @@ public class TTextTest {
     @MethodSource("TText_update")
     public void testUpdate(Temporal base, Temporal base2, Temporal tseq, String type) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextInst") {
             assertEquals(((TTextInst)base.update(base2)).to_string(), ((TTextInst) tseq).to_string());
         } else if (type == "TTextSeq") {
@@ -649,7 +598,6 @@ public class TTextTest {
     @MethodSource("TText_appendseq")
     public void testAppendSeq(Temporal base, TSequence base2, Temporal tseq, String type) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         if (type == "TTextSeq") {
             assertEquals(((TTextSeq)base.append_sequence(base2)).to_string(), ((TTextSeq) tseq).to_string());
         } else if (type == "TTextSeqSet") {

--- a/jmeos-core/src/test/java/basic/TimestampAccessorTest.java
+++ b/jmeos-core/src/test/java/basic/TimestampAccessorTest.java
@@ -21,7 +21,6 @@ class TimestampAccessorTest {
     @BeforeAll
     static void init() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
     }
 
     private static LocalDateTime day(int d) {

--- a/jmeos-core/src/test/java/basic/ValueAtTimestampTest.java
+++ b/jmeos-core/src/test/java/basic/ValueAtTimestampTest.java
@@ -32,7 +32,6 @@ class ValueAtTimestampTest {
     @BeforeAll
     static void init() {
         GeneratedFunctions.meos_initialize_timezone("UTC");
-        GeneratedFunctions.meos_initialize_error_handler(errorHandler);
     }
 
     private static LocalDateTime day(int d) {

--- a/jmeos-core/src/test/java/boxes/STBoxTest.java
+++ b/jmeos-core/src/test/java/boxes/STBoxTest.java
@@ -33,7 +33,6 @@ public class STBoxTest {
 
     public STBoxTest() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		stbx = new STBox("STBOX X((1, 1),(2, 2))");
 		stbz = new STBox("STBOX Z((1, 1, 1),(2, 2, 2))");
 		stbt = new STBox("STBOX T([2019-09-01,2019-09-02])");
@@ -43,7 +42,6 @@ public class STBoxTest {
 
 	static Stream<Arguments> STBox_sources() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new STBox("STBOX X((1, 1),(2, 2))"), "STBOX X((1, 1),(2, 2))" ),
 				Arguments.of(new STBox("STBOX Z((1, 1, 1),(2, 2, 2))"), "STBOX Z((1, 1, 1),(2, 2, 2))" ),
@@ -112,7 +110,6 @@ public class STBoxTest {
 	@MethodSource("STBox_sources")
 	public void testFromAsConstructor(STBox box, String str) throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		STBox stb = new STBox(str);
 		assertTrue(stb.eq(box));
 	}
@@ -122,7 +119,6 @@ public class STBoxTest {
 	@MethodSource("STBox_sources")
 	public void testCopyConstructor(STBox box, String str) throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		STBox stb = box.copy();
 		assertTrue(stb.eq(box));
 		assertFalse(stb.get_inner() == box.get_inner());

--- a/jmeos-core/src/test/java/boxes/TBoxTest.java
+++ b/jmeos-core/src/test/java/boxes/TBoxTest.java
@@ -31,7 +31,6 @@ class TBoxTest {
 
     static Stream<Arguments> TBox_sources() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1, 2])"),"TBox", "TBOXFLOAT X([1, 2])" ),
                 Arguments.of(new TBox("TBOX T([2019-09-01, 2019-09-02])"), "TBox", "TBOX T([2019-09-01 00:00:00+00, 2019-09-02 00:00:00+00])" ),
@@ -41,7 +40,6 @@ class TBoxTest {
 
     static Stream<Arguments> TBox_number() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(1, "TBOXINT X([1, 2))","TBox"),
                 Arguments.of(1.5f, "TBOXFLOAT X([1.5, 1.5])", "TBox")
@@ -50,7 +48,6 @@ class TBoxTest {
 
     static Stream<Arguments> TBox_span() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new IntSpan(1, 2, true, true),"TBox", "TBOXINT X([1, 3))" ),
                 Arguments.of(new FloatSpan(1.5f, 2.5f, true, true),"TBox", "TBOXFLOAT X([1.5, 2.5])" )
@@ -60,7 +57,6 @@ class TBoxTest {
 
     static Stream<Arguments> TBox_time() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzset("{2019-09-01, 2019-09-02}"),"TBox", "TBOX T([2019-09-01 00:00:00+00, 2019-09-02 00:00:00+00])" ),
                 Arguments.of(new tstzspan("[2019-09-01, 2019-09-02]"),"TBox", "TBOX T([2019-09-01 00:00:00+00, 2019-09-02 00:00:00+00])" ),
@@ -71,7 +67,6 @@ class TBoxTest {
 
     static Stream<Arguments> TBox_basic() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1,2])"),"TBox", "TBOXFLOAT X([1, 2])" ),
                 Arguments.of(new TBox("TBOX T([2019-09-01,2019-09-02])"),"TBox", "TBOX T([2019-09-01 00:00:00+00, 2019-09-02 00:00:00+00])" ),
@@ -82,7 +77,6 @@ class TBoxTest {
 
     static Stream<Arguments> TBox_tofloatspan() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1,2])"),"TBox", new FloatSpan(1.0f, 2.0f, true, true) ),
                 Arguments.of(new TBox("TBOXFLOAT XT([1,2],[2019-09-01,2019-09-02])"), "TBox",new FloatSpan(1.0f, 2.0f, true, true))
@@ -91,7 +85,6 @@ class TBoxTest {
 
     static Stream<Arguments> TBox_toperiod() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1,2])"),"TBox", new tstzspan("[2019-09-08 02:03:00+0, 2019-09-10 02:03:00+0]")),
                 Arguments.of(new TBox("TBOXFLOAT XT([1,2],[2019-09-01,2019-09-02])"), "TBox", new tstzspan("[2019-09-08 02:03:00+0, 2019-09-10 02:03:00+0]"))
@@ -100,7 +93,6 @@ class TBoxTest {
 
     static Stream<Arguments> TBox_expandfloat() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1,2])"),"TBox", new TBox("TBOXFLOAT X([1, 2])")),
                 Arguments.of(new TBox("TBOXFLOAT XT([1,2],[2019-09-01,2019-09-02])"), "TBox", new TBox("TBOXFLOAT XT([1,2],[2019-09-01, 2019-09-02])"))
@@ -109,7 +101,6 @@ class TBoxTest {
 
     static Stream<Arguments> TBox_expandtime() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1,2])"),"TBox", new tstzspan("[2019-09-08 02:03:00+0, 2019-09-10 02:03:00+0]")),
                 Arguments.of(new TBox("TBOXFLOAT XT([1,2],[2019-09-01,2019-09-02])"), "TBox", new tstzspan("[2019-09-08 02:03:00+0, 2019-09-10 02:03:00+0]"))
@@ -120,7 +111,6 @@ class TBoxTest {
 
     static Stream<Arguments> TBox_round() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new TBox("TBOXFLOAT X([1.123456789,2.123456789])"),"TBox", new TBox("TBOXFLOAT X([1.12,2.12])")),
                 Arguments.of(new TBox("TBOXFLOAT XT([1.123456789,2.123456789],[2019-09-01, 2019-09-03])"), "TBox", new TBox("TBOXFLOAT XT([1.12,2.12],[2019-09-01, 2019-09-03])"))
@@ -142,7 +132,6 @@ class TBoxTest {
     @MethodSource("TBox_sources")
     public void testStringConstructor(TBox box, String type, String expected) throws ParseException, SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertTrue(box instanceof TBox);
         assertEquals(box.toString(),expected);
     }
@@ -152,7 +141,6 @@ class TBoxTest {
     @MethodSource("TBox_number")
     public void testFromValueNConstructor(Number val, String box, String type) throws ParseException, SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TBox new_tb = TBox.from_value_number(val);
         assertTrue(new_tb instanceof TBox);
         assertEquals(new_tb.toString(),box);
@@ -163,7 +151,6 @@ class TBoxTest {
     @MethodSource("TBox_span")
     public void testFromSpanConstructor(Span sp, String type, String expected) throws ParseException, SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TBox new_tb = TBox.from_value_span(sp);
         assertTrue(new_tb instanceof TBox);
         assertEquals(new_tb.toString(),expected);
@@ -174,7 +161,6 @@ class TBoxTest {
     @MethodSource("TBox_time")
     public void testFromTimeConstructor(Time t, String type, String expected) throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TBox new_tb = TBox.from_time(t);
         assertTrue(new_tb instanceof TBox);
         assertEquals(new_tb.toString(),expected);
@@ -186,7 +172,6 @@ class TBoxTest {
     @MethodSource("TBox_time")
     public void testCopyConstructor(Time t, String type, String expected) throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TBox new_tb = TBox.from_time(t);
         assertTrue(new_tb instanceof TBox);
         assertEquals(new_tb.toString(),expected);
@@ -197,7 +182,6 @@ class TBoxTest {
     @MethodSource("TBox_basic")
     public void testCopyConstructor(TBox t, String type, String expected) throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TBox new_tb = t.copy();
         assertTrue(new_tb instanceof TBox);
         assertEquals(new_tb.toString(), t.toString());
@@ -208,7 +192,6 @@ class TBoxTest {
     @MethodSource("TBox_basic")
     public void testStrConstructor(TBox t, String type, String expected) throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertTrue(t instanceof TBox);
         assertEquals(t.toString(), expected);
     }
@@ -217,7 +200,6 @@ class TBoxTest {
     @MethodSource("TBox_tofloatspan")
     public void testStrConstructor(TBox t, String type, Span expected) throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         FloatSpan z = t.to_floatspan();
         assertTrue(z instanceof FloatSpan);
         assertEquals(z.toString(15), ((FloatSpan)expected).toString(15));
@@ -230,7 +212,6 @@ class TBoxTest {
     @MethodSource("TBox_expandfloat")
     public void testExpandFloat(TBox t, String type, TBox expected) throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TBox tb = t.expand(1.0f);
         assertTrue(tb instanceof TBox);
         assertEquals(t.toString(15),expected.toString(15));
@@ -242,7 +223,6 @@ class TBoxTest {
     @MethodSource("TBox_round")
     public void testRound(TBox t, String type, TBox expected) throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         TBox new_tb = t.round(2);
         System.out.println(t.toString());
         System.out.println(new_tb.toString());

--- a/jmeos-core/src/test/java/collections/number/FloatSetTest.java
+++ b/jmeos-core/src/test/java/collections/number/FloatSetTest.java
@@ -33,7 +33,6 @@ public class FloatSetTest {
 //        };
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(5.0f, false ),
                 Arguments.of(new FloatSet("{5, 10}"), false )
@@ -43,7 +42,6 @@ public class FloatSetTest {
     static Stream<Arguments> FloatSet_distances() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(5.0f, 2.0f ),
                 Arguments.of(new FloatSet("{5, 10}"), 2.0f )

--- a/jmeos-core/src/test/java/collections/number/FloatSpanSetTest.java
+++ b/jmeos-core/src/test/java/collections/number/FloatSpanSetTest.java
@@ -24,7 +24,6 @@ public class FloatSpanSetTest {
     static Stream<Arguments> IntSpan_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("(7, 10)", 8, 10, true, false),
                 Arguments.of("[7, 10]", 7, 11, true, false)
@@ -34,7 +33,6 @@ public class FloatSpanSetTest {
     static Stream<Arguments> IntSpan_mulsources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("7", "10", 7, 10),
                 Arguments.of(7, 10, 7, 10),
@@ -45,7 +43,6 @@ public class FloatSpanSetTest {
     static Stream<Arguments> Bound_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(true,true),
                 Arguments.of(true,false),

--- a/jmeos-core/src/test/java/collections/number/FloatSpanTest.java
+++ b/jmeos-core/src/test/java/collections/number/FloatSpanTest.java
@@ -24,7 +24,6 @@ public class FloatSpanTest {
     static Stream<Arguments> IntSpan_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("(2.5, 5.21)", 2.5f, 5.21f, false, false),
                 Arguments.of("[2.5, 5.21]", 2.5f, 5.21f, true, true)
@@ -34,7 +33,6 @@ public class FloatSpanTest {
     static Stream<Arguments> IntSpan_mulsources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("2.5", "5.21", 2.5f, 5.21f),
                 Arguments.of(2.5f, 5.21f, 2.5f, 5.21f),
@@ -45,7 +43,6 @@ public class FloatSpanTest {
     static Stream<Arguments> Bound_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(true,true),
                 Arguments.of(true,false),

--- a/jmeos-core/src/test/java/collections/number/IntSetTest.java
+++ b/jmeos-core/src/test/java/collections/number/IntSetTest.java
@@ -27,7 +27,6 @@ public class IntSetTest {
     static Stream<Arguments> IntSet_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(5, false ),
                 Arguments.of(new IntSet("{5, 10}"), false )
@@ -37,7 +36,6 @@ public class IntSetTest {
     static Stream<Arguments> IntSet_distances() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(5, 2 ),
                 Arguments.of(new IntSet("{5, 10}"), 2 )

--- a/jmeos-core/src/test/java/collections/number/IntSpanSetTest.java
+++ b/jmeos-core/src/test/java/collections/number/IntSpanSetTest.java
@@ -27,7 +27,6 @@ public class IntSpanSetTest {
     static Stream<Arguments> IntSpan_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("(7, 10)", 8, 10, true, false),
                 Arguments.of("[7, 10]", 7, 11, true, false)
@@ -37,7 +36,6 @@ public class IntSpanSetTest {
     static Stream<Arguments> IntSpan_mulsources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("7", "10", 7, 10),
                 Arguments.of(7, 10, 7, 10),
@@ -48,7 +46,6 @@ public class IntSpanSetTest {
     static Stream<Arguments> Bound_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(true,true),
                 Arguments.of(true,false),

--- a/jmeos-core/src/test/java/collections/number/IntSpanTest.java
+++ b/jmeos-core/src/test/java/collections/number/IntSpanTest.java
@@ -24,7 +24,6 @@ public class IntSpanTest {
     static Stream<Arguments> IntSpan_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("(7, 10)", 8, 10, true, false),
                 Arguments.of("[7, 10]", 7, 11, true, false)
@@ -34,7 +33,6 @@ public class IntSpanTest {
     static Stream<Arguments> IntSpan_mulsources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("7", "10", 7, 10),
                 Arguments.of(7, 10, 7, 10),
@@ -45,7 +43,6 @@ public class IntSpanTest {
     static Stream<Arguments> Bound_sources() throws SQLException {
         error_handler_fn errorHandler = new error_handler();
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(true,true),
                 Arguments.of(true,false),

--- a/jmeos-core/src/test/java/collections/time/DateSetOperationsTest.java
+++ b/jmeos-core/src/test/java/collections/time/DateSetOperationsTest.java
@@ -24,7 +24,6 @@ class DateSetOperationsTest {
 
     DateSetOperationsTest() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
     }
 
     @Test

--- a/jmeos-core/src/test/java/collections/time/DateSetTest.java
+++ b/jmeos-core/src/test/java/collections/time/DateSetTest.java
@@ -32,7 +32,6 @@ class DateSetTest {
 
     DateSetTest() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         dset = new dateset("{2019-09-25, 2019-09-26, 2019-09-27}");
         dset2 = new dateset("{2019-09-08, 2019-09-10}");
     }

--- a/jmeos-core/src/test/java/collections/time/DateSpanSetTest.java
+++ b/jmeos-core/src/test/java/collections/time/DateSpanSetTest.java
@@ -30,7 +30,6 @@ class DateSpanSetTest {
 
     DateSpanSetTest() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         dsset = new datespanset("{[2019-09-08, 2019-09-10], [2019-09-11, 2019-09-12]}");
         dsset2 = new datespanset("{[2020-09-08, 2020-09-10], [2020-09-11, 2020-09-12]}");
     }

--- a/jmeos-core/src/test/java/collections/time/DateSpanTest.java
+++ b/jmeos-core/src/test/java/collections/time/DateSpanTest.java
@@ -29,7 +29,6 @@ class DateSpanTest {
 
     DateSpanTest() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         dspan = new datespan("[2019-09-25, 2019-09-27]");
         dspan2 = new datespan("[2019-09-08, 2019-09-10)");
     }

--- a/jmeos-core/src/test/java/collections/time/TsTzSetTest.java
+++ b/jmeos-core/src/test/java/collections/time/TsTzSetTest.java
@@ -32,7 +32,6 @@ class TsTzSetTest {
 
     private static Stream<Arguments> times() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
                 Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -45,7 +44,6 @@ class TsTzSetTest {
 
     public void assert_tstzset_equality(tstzset vset, List<LocalDateTime> timestamps){
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(vset.num_elements(), timestamps.size());
     }
 
@@ -54,7 +52,6 @@ class TsTzSetTest {
     @Test
     public void testStringConstructor(){
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         List<LocalDateTime> list = new ArrayList<>();
         list.add(LocalDateTime.of(2019, 9, 1, 0, 0,0));
         list.add(LocalDateTime.of(2019, 9, 2, 0, 0,0));
@@ -65,7 +62,6 @@ class TsTzSetTest {
     @Test
     public void testHexwkbConstructor() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 //        tstzset tsett = types.collections.time.tstzset.from_hexwkb("012100000040021FFE3402000000B15A26350200");
         String hexwkb_string= tset.as_hexwkb();
 		System.out.println(hexwkb_string);
@@ -83,7 +79,6 @@ class TsTzSetTest {
     @Test
     public void testFromAsConstructor() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         tstzset newtset = new tstzset("{2019-09-01 00:00:00+0, 2019-09-02 00:00:00+0, 2019-09-03 00:00:00+0}");
         assertEquals(tset.toString(), newtset.toString());
     }
@@ -92,7 +87,6 @@ class TsTzSetTest {
     @Test
     public void testCopyConstructor() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         tstzset tsett = tset;
         assertEquals(tset.toString(),tsett.toString());
     }
@@ -101,7 +95,6 @@ class TsTzSetTest {
     @Test
     public void testStrOutput() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(tset.toString(),"{\"2019-09-01 00:00:00+00\", \"2019-09-02 00:00:00+00\", \"2019-09-03 00:00:00+00\"}");
     }
 
@@ -109,7 +102,6 @@ class TsTzSetTest {
     @Test
     public void testTimestampConversion() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         tstzspanset pset = new tstzspanset("{[2019-09-01 00:00:00+00, 2019-09-01 00:00:00+00], [2019-09-02 00:00:00+00, 2019-09-02 00:00:00+00], [2019-09-03 00:00:00+00, 2019-09-03 00:00:00+00]}");
         tstzspanset converted = tset.to_spanset();
         System.out.println(converted.toString());
@@ -120,7 +112,6 @@ class TsTzSetTest {
     @Test
     public void testtstzsetConversion() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         tstzspan p = new tstzspan("[2019-09-01 00:00:00+00, 2019-09-03 00:00:00+00]");
         tstzspan converted = tset.to_span();
         System.out.println(converted.toString());
@@ -131,14 +122,12 @@ class TsTzSetTest {
     @Test
     public void testNumTimestamps() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(tset.num_elements(),3);
     }
 
     @Test
     public void testStartTimestamps() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(tset.start_element(),LocalDateTime.of(2019, 9, 1, 0, 0,0));
     }
 
@@ -146,14 +135,12 @@ class TsTzSetTest {
     @Test
     public void testEndTimestamps() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(tset.end_element(),LocalDateTime.of(2019, 9, 3, 0, 0,0));
     }
 
     @Test
     public void testHash() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(tset.hash(),527267058);
     }
 
@@ -161,7 +148,6 @@ class TsTzSetTest {
     @Test
     public void testIsContainedInFunction() throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         assertFalse(tset.is_contained_in(tmp_set));
     }
@@ -170,7 +156,6 @@ class TsTzSetTest {
     @Test
     public void testOverlapsFunction() throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         assertFalse(tset.overlaps(tmp_set));
     }
@@ -179,7 +164,6 @@ class TsTzSetTest {
     @Test
     public void testIsBeforeFunction() throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         assertTrue(tset.is_before(tmp_set));
     }
@@ -187,7 +171,6 @@ class TsTzSetTest {
     @Test
     public void testIsOverOrBeforeFunction() throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         assertTrue(tset.is_over_or_before(tmp_set));
     }
@@ -196,7 +179,6 @@ class TsTzSetTest {
     @Test
     public void testIsAfterFunction() throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         assertFalse(tset.is_after(tmp_set));
     }
@@ -204,7 +186,6 @@ class TsTzSetTest {
     @Test
     public void testIsOverOrAfterFunction() throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         assertFalse(tset.is_over_or_after(tmp_set));
     }
@@ -212,7 +193,6 @@ class TsTzSetTest {
     @Test
     public void testDistanceFunction() throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         tstzset tmp_set = new tstzset("{2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0}");
         System.out.println(Duration.ofSeconds((long) functions.distance_tstzset_tstzset(tset.get_inner(), tmp_set.get_inner())));
         tset.distance(tmp_set);
@@ -223,7 +203,6 @@ class TsTzSetTest {
     @MethodSource("times")
     public void testIntersection(Time other, boolean expected) throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         this.tset.intersection(other);
     }
 
@@ -231,7 +210,6 @@ class TsTzSetTest {
     @MethodSource("times")
     public void testUnion(Time other, boolean expected) throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         this.tset.union(other);
     }
 
@@ -240,7 +218,6 @@ class TsTzSetTest {
     @MethodSource("times")
     public void testMinus(Time other, boolean expected) throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         this.tset.minus(other);
     }
 

--- a/jmeos-core/src/test/java/collections/time/TsTzSpanSetTest.java
+++ b/jmeos-core/src/test/java/collections/time/TsTzSpanSetTest.java
@@ -42,7 +42,6 @@ class TsTzSpanSetTest {
 	
 	private static Stream<Arguments> temporals_adjacent() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -57,7 +56,6 @@ class TsTzSpanSetTest {
 
 	private static Stream<Arguments> temporals_iscontained() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -72,7 +70,6 @@ class TsTzSpanSetTest {
 
 	private static Stream<Arguments> temporals_contains() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -87,7 +84,6 @@ class TsTzSpanSetTest {
 
 	private static Stream<Arguments> temporals_overlaps() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -102,7 +98,6 @@ class TsTzSpanSetTest {
 
 	private static Stream<Arguments> temporals_same() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -117,7 +112,6 @@ class TsTzSpanSetTest {
 
 	private static Stream<Arguments> temporals_before() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -132,7 +126,6 @@ class TsTzSpanSetTest {
 
 	private static Stream<Arguments> temporals_after() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -147,7 +140,6 @@ class TsTzSpanSetTest {
 
 	private static Stream<Arguments> temporals_overbefore() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -162,7 +154,6 @@ class TsTzSpanSetTest {
 
 	private static Stream<Arguments> temporals_overafter() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -177,7 +168,6 @@ class TsTzSpanSetTest {
 
 	private static Stream<Arguments> intersection() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true)
@@ -186,7 +176,6 @@ class TsTzSpanSetTest {
 
 	private static Stream<Arguments> other() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true)
 		);
@@ -202,7 +191,6 @@ class TsTzSpanSetTest {
 	@Test
 	public void testStringConstructor(){
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		System.out.println(pset.toString());
 		assert_tstzspanset_equality(this.pset,null);
 	}
@@ -210,7 +198,6 @@ class TsTzSpanSetTest {
 	@Test
 	public void testtstzspansetListConstructor(){
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		List<tstzspan> lst = new ArrayList<tstzspan>();
 		lst.add(new tstzspan("[2019-09-01, 2019-09-02]"));
 		lst.add(new tstzspan("[2019-09-03, 2019-09-04]"));
@@ -223,7 +210,6 @@ class TsTzSpanSetTest {
 	@Test
 	public void testCopyConstructor(){
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		tstzspanset new_pset = new tstzspanset(pset.copy());
 		assertEquals(this.pset.toString(),new_pset.toString());
 	}
@@ -232,7 +218,6 @@ class TsTzSpanSetTest {
 	@Test
 	public void testTotstzset(){
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.to_period().toString(), new tstzspan("[2019-09-01, 2019-09-04]").toString());
 	}
 
@@ -240,7 +225,6 @@ class TsTzSpanSetTest {
 	@Test
 	public void testNumTimestamps(){
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.num_timestamps(),4);
 		assertEquals(this.pset2.num_timestamps(),3);
 	}
@@ -248,7 +232,6 @@ class TsTzSpanSetTest {
 	@Test
 	public void testStartTimestamps(){
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.start_timestamp(), LocalDateTime.of(2019,9,1,0,0,0));
 		assertEquals(this.pset2.start_timestamp(),LocalDateTime.of(2019,9,1,0,0,0));
 	}
@@ -257,7 +240,6 @@ class TsTzSpanSetTest {
 	@Test
 	public void testEndTimestamps(){
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.end_timestamp(),LocalDateTime.of(2019,9,4,0,0,0));
 		assertEquals(this.pset2.end_timestamp(),LocalDateTime.of(2019,9,4,0,0,0));
 	}
@@ -266,7 +248,6 @@ class TsTzSpanSetTest {
 	@Test
 	public void testNumtstzsets(){
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.num_periods(),2);
 		assertEquals(this.pset2.num_periods(),2);
 	}
@@ -275,7 +256,6 @@ class TsTzSpanSetTest {
 	@Test
 	public void testStarttstzset(){
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.start_period().toString(),new tstzspan("[2019-09-01 00:00:00+00, 2019-09-02 00:00:00+00]").toString());
 	}
 
@@ -283,7 +263,6 @@ class TsTzSpanSetTest {
 	@Test
 	public void testEndtstzset(){
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.end_period().toString(),new tstzspan("[2019-09-03 00:00:00+00, 2019-09-04 00:00:00+00]").toString());
 	}
 
@@ -301,7 +280,6 @@ class TsTzSpanSetTest {
 	@MethodSource("temporals_adjacent")
 	public void testAdjacency(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_adjacent(other), expected);
 	}
 
@@ -309,7 +287,6 @@ class TsTzSpanSetTest {
 	@MethodSource("temporals_iscontained")
 	public void testIsContainedIn(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_contained_in(other), expected);
 
 	}
@@ -319,7 +296,6 @@ class TsTzSpanSetTest {
 	@MethodSource("temporals_contains")
 	public void testContains(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.contains(other), expected);
 
 	}
@@ -329,7 +305,6 @@ class TsTzSpanSetTest {
 	@MethodSource("temporals_overlaps")
 	public void testOverlaps(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.overlaps(other), expected);
 	}
 
@@ -338,7 +313,6 @@ class TsTzSpanSetTest {
 	@MethodSource("temporals_same")
 	public void testIsSame(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_same(other), expected);
 	}
 
@@ -348,7 +322,6 @@ class TsTzSpanSetTest {
 	@MethodSource("temporals_before")
 	public void testIsBefore(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_before(other), expected);
 	}
 
@@ -358,7 +331,6 @@ class TsTzSpanSetTest {
 	@MethodSource("temporals_after")
 	public void testIsAfter(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_after(other), expected);
 	}
 
@@ -367,7 +339,6 @@ class TsTzSpanSetTest {
 	@MethodSource("temporals_overbefore")
 	public void testIsOverOrBefore(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_over_or_before(other), expected);
 
 	}
@@ -377,7 +348,6 @@ class TsTzSpanSetTest {
 	@MethodSource("temporals_overafter")
 	public void testIsOverOrAfter(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.pset.is_over_or_after(other), expected);
 
 	}
@@ -388,7 +358,6 @@ class TsTzSpanSetTest {
 	@MethodSource("intersection")
 	public void testIntersection(Time other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		this.pset.intersection(other);
 	}
 
@@ -396,7 +365,6 @@ class TsTzSpanSetTest {
 	@MethodSource("intersection")
 	public void testMinus(Time other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		this.pset.minus(other);
 	}
 
@@ -404,7 +372,6 @@ class TsTzSpanSetTest {
 	@MethodSource("intersection")
 	public void testUnion(Time other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		this.pset.union(other);
 	}
 
@@ -413,7 +380,6 @@ class TsTzSpanSetTest {
 	@MethodSource("other")
 	public void testEqual(Time t) throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertNotEquals(this.pset, t);
 	}
 
@@ -422,7 +388,6 @@ class TsTzSpanSetTest {
 	@MethodSource("other")
 	public void testNotEqual(Time t) throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.pset.notEquals(t));
 	}
 
@@ -430,7 +395,6 @@ class TsTzSpanSetTest {
 	@MethodSource("other")
 	public void testLessThan(Time t) throws SQLException, OperationNotSupportedException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.pset.lessThan(t));
 	}
 
@@ -438,7 +402,6 @@ class TsTzSpanSetTest {
 	@MethodSource("other")
 	public void testLessThanOrEqual(Time t) throws SQLException, OperationNotSupportedException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.pset.lessThanOrEqual(t));
 	}
 
@@ -446,7 +409,6 @@ class TsTzSpanSetTest {
 	@MethodSource("other")
 	public void testGreaterThan(Time t) throws SQLException, OperationNotSupportedException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.pset.greaterThan(t));
 	}
 
@@ -454,7 +416,6 @@ class TsTzSpanSetTest {
 	@MethodSource("other")
 	public void testGreaterThanOrEqual(Time t) throws SQLException, OperationNotSupportedException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertFalse(this.pset.greaterThanOrEqual(t));
 	}
 

--- a/jmeos-core/src/test/java/collections/time/TsTzSpanTest.java
+++ b/jmeos-core/src/test/java/collections/time/TsTzSpanTest.java
@@ -43,7 +43,6 @@ class TsTzSpanTest {
 
 	static Stream<Arguments> tstzspan_constructor() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of("(2019-09-08 00:00:00+0, 2019-09-10 00:00:00+0)",LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0), false,false),
 				Arguments.of("[2019-09-08 00:00:00+0, 2019-09-10 00:00:00+0]", LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0), true,true)
@@ -52,7 +51,6 @@ class TsTzSpanTest {
 
 	static Stream<Arguments> tstzspan_constructor2() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of("2019-09-08 00:00:00+0", "2019-09-10 00:00:00+0",LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0))
 				);
@@ -60,7 +58,6 @@ class TsTzSpanTest {
 
 	static Stream<Arguments> tstzspan_constructor3() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0), LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0))
 		);
@@ -68,7 +65,6 @@ class TsTzSpanTest {
 
 	static Stream<Arguments> tstzspan_constructor4() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of("2019-09-08 00:00:00+0", LocalDateTime.of(2019, 9, 10, 0, 0),LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0))
 		);
@@ -77,7 +73,6 @@ class TsTzSpanTest {
 
 	static Stream<Arguments> tstzspan_constructor5() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(true,true),
 				Arguments.of(true,false),
@@ -88,7 +83,6 @@ class TsTzSpanTest {
 
 	private static Stream<Arguments> temporals_adjacent() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -103,7 +97,6 @@ class TsTzSpanTest {
 
 	private static Stream<Arguments> temporals_iscontained() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -118,7 +111,6 @@ class TsTzSpanTest {
 
 	private static Stream<Arguments> temporals_contains() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -133,7 +125,6 @@ class TsTzSpanTest {
 
 	private static Stream<Arguments> temporals_overlaps() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -148,7 +139,6 @@ class TsTzSpanTest {
 
 	private static Stream<Arguments> temporals_same() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -163,7 +153,6 @@ class TsTzSpanTest {
 
 	private static Stream<Arguments> temporals_before() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -178,7 +167,6 @@ class TsTzSpanTest {
 
 	private static Stream<Arguments> temporals_after() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), false),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), false),
@@ -193,7 +181,6 @@ class TsTzSpanTest {
 
 	private static Stream<Arguments> temporals_overbefore() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -208,7 +195,6 @@ class TsTzSpanTest {
 
 	private static Stream<Arguments> temporals_overafter() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true),
@@ -223,7 +209,6 @@ class TsTzSpanTest {
 
 	private static Stream<Arguments> temporals_distance() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), 0.0),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), 0.0),
@@ -235,7 +220,6 @@ class TsTzSpanTest {
 
 	private static Stream<Arguments> intersection() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true),
 				Arguments.of(new tstzspanset("{(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0), (2021-01-01 00:00:00+0, 2021-01-31 00:00:00+0)}"), true)
@@ -245,7 +229,6 @@ class TsTzSpanTest {
 
 	private static Stream<Arguments> other() {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		return Stream.of(
 				Arguments.of(new tstzspan("(2020-01-01 00:00:00+0, 2020-01-31 00:00:00+0)"), true)
 		);
@@ -277,7 +260,6 @@ class TsTzSpanTest {
 	@MethodSource("tstzspan_constructor")
 	public void testtstzspanConstructor(String source, LocalDateTime lower, LocalDateTime upper, boolean lower_inc, boolean upper_inc) throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		tstzspan p = new tstzspan(source);
 		assert_tstzspan_equality(p,lower,upper,lower_inc,upper_inc);
 	}
@@ -286,7 +268,6 @@ class TsTzSpanTest {
 	@MethodSource("tstzspan_constructor2")
 	public void testtstzspanConstructor2(String lower, String upper, LocalDateTime lowerv, LocalDateTime upperv) throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		tstzspan p = new tstzspan(lower,upper);
 		assert_tstzspan_equality(p,lowerv,upperv,true,false);
 	}
@@ -296,7 +277,6 @@ class TsTzSpanTest {
 	@MethodSource("tstzspan_constructor3")
 	public void testtstzspanConstructor3(LocalDateTime lower, LocalDateTime upper, LocalDateTime lowerv, LocalDateTime upperv) throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		tstzspan p = new tstzspan(lower,upper);
 		assert_tstzspan_equality(p,lowerv,upperv,true,false);
 	}
@@ -306,7 +286,6 @@ class TsTzSpanTest {
 	@MethodSource("tstzspan_constructor4")
 	public void testtstzspanConstructor4(String lower, LocalDateTime upper, LocalDateTime lowerv, LocalDateTime upperv) throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		tstzspan p = new tstzspan(lower,upper);
 		assert_tstzspan_equality(p,lowerv,upperv,true,false);
 	}
@@ -314,7 +293,6 @@ class TsTzSpanTest {
 	@Test
 	public void testtstzspanBounds() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		tstzspan p = new tstzspan("2019-09-08 00:00:00+0", "2019-09-10 00:00:00+0");
 		assert_tstzspan_equality(p, LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0),true,false);
 	}
@@ -324,7 +302,6 @@ class TsTzSpanTest {
 	@MethodSource("tstzspan_constructor5")
 	public void testtstzspanIncluBounds(boolean lower,boolean upper) throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		tstzspan p = new tstzspan("2019-09-08 00:00:00+0", "2019-09-10 00:00:00+0",lower,upper);
 		assert_tstzspan_equality(p, LocalDateTime.of(2019, 9, 8, 0, 0), LocalDateTime.of(2019, 9, 10, 0, 0),lower,upper);
 	}
@@ -333,7 +310,6 @@ class TsTzSpanTest {
 	@Test
 	public void testHexwkbConstructor() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 //		tstzspan p = types.collections.time.tstzspan.from_hexwkb("012100000040021FFE3402000000B15A26350200");
 		String hexwkb_string= tstzspan.as_hexwkb();
 //		System.out.println(hexwkb_string);
@@ -345,14 +321,12 @@ class TsTzSpanTest {
 	@Test
 	public void testFromAsConstructor() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertNotEquals(this.tstzspan,new tstzspan("(2019-09-08 00:00:00+00, 2019-09-10 00:00:00+00)"));
 	}
 
 	@Test
 	public void testCopyConstructor() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		tstzspan other = this.tstzspan.copy();
 		assertNotEquals(this.tstzspan, other);
 		assertEquals(other.toString(), this.tstzspan.toString());
@@ -361,7 +335,6 @@ class TsTzSpanTest {
 	@Test
 	public void testtstzspanOut() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.tstzspan.toString(), "(2019-09-08 00:00:00+00, 2019-09-10 00:00:00+00)");
 	}
 
@@ -369,7 +342,6 @@ class TsTzSpanTest {
 	@Test
 	public void testTotstzspanSet() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		tstzspanset pset = tstzspan.to_spanset();
 		System.out.println(pset.toString());
 		String spanset_string= pset.toString();
@@ -382,7 +354,6 @@ class TsTzSpanTest {
 	@Test
 	public void testUpperAccessors() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.tstzspan.lower(), LocalDateTime.of(2019, 9, 8, 0, 0));
 		assertEquals(this.tstzspan2.lower(), LocalDateTime.of(2019, 9, 8, 2, 3));
 	}
@@ -391,7 +362,6 @@ class TsTzSpanTest {
 	@Test
 	public void testLowerAccessors() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.tstzspan.upper(), LocalDateTime.of(2019, 9, 10, 0, 0));
 		assertEquals(this.tstzspan2.upper(), LocalDateTime.of(2019, 9, 10, 2, 3));
 	}
@@ -399,7 +369,6 @@ class TsTzSpanTest {
 	@Test
 	public void testLowerIncAccessors() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertFalse(this.tstzspan.lower_inc());
 		assertTrue(this.tstzspan2.lower_inc());
 	}
@@ -407,7 +376,6 @@ class TsTzSpanTest {
 	@Test
 	public void testUpperIncAccessors() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertFalse(this.tstzspan.upper_inc());
 		assertTrue(this.tstzspan2.upper_inc());
 	}
@@ -416,7 +384,6 @@ class TsTzSpanTest {
 	@Test
 	public void testDurationInSeconds() throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 //		System.out.println(tstzspan.toString());
 		types.collections.time.tstzspan tst= new tstzspan("(2019-09-08 00:00:00+00, 2022-10-25 00:05:00+00)");
 //		System.out.println(tst.duration());
@@ -440,7 +407,6 @@ class TsTzSpanTest {
 	@MethodSource("temporals_adjacent")
 	public void testAdjacency(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		STBox st= new STBox(functions.tstzspan_to_stbox(p.get_inner()));
 		System.out.println(st.toString(15));
 		assertEquals(this.p.is_adjacent(other), expected);
@@ -450,7 +416,6 @@ class TsTzSpanTest {
 	@MethodSource("temporals_iscontained")
 	public void testIsContainedIn(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.p.is_contained_in(other), expected);
 
 	}
@@ -460,7 +425,6 @@ class TsTzSpanTest {
 	@MethodSource("temporals_contains")
     public void testContains(TemporalObject other, boolean expected) throws Exception {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(this.p.contains(other), expected);
 
     }
@@ -470,7 +434,6 @@ class TsTzSpanTest {
 	@MethodSource("temporals_overlaps")
 	public void testOverlaps(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.p.overlaps(other), expected);
 	}
 
@@ -479,7 +442,6 @@ class TsTzSpanTest {
 	@MethodSource("temporals_same")
 	public void testIsSame(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.p.is_same(other), expected);
 	}
 
@@ -489,7 +451,6 @@ class TsTzSpanTest {
 	@MethodSource("temporals_before")
 	public void testIsBefore(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.p.is_before(other), expected);
 	}
 
@@ -499,7 +460,6 @@ class TsTzSpanTest {
 	@MethodSource("temporals_after")
 	public void testIsAfter(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.p.is_after(other), expected);
 	}
 
@@ -508,7 +468,6 @@ class TsTzSpanTest {
 	@MethodSource("temporals_overbefore")
 	public void testIsOverOrBefore(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertEquals(this.p.is_over_or_before(other), expected);
 
 	}
@@ -518,7 +477,6 @@ class TsTzSpanTest {
 	@MethodSource("temporals_overafter")
 	public void testIsOverOrAfter(TemporalObject other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		STBox st= new STBox(functions.tstzspan_to_stbox(p.get_inner()));
 		System.out.println(st.toString(15));
 		assertEquals(this.p.is_over_or_after(other), expected);
@@ -531,7 +489,6 @@ class TsTzSpanTest {
 	@MethodSource("temporals_distance")
 	public void testDistance(TemporalObject other, double expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		STBox st= new STBox("STBOX ZT(((1.0, 2.0, 3.0),(4.0, 5.0, 6.0)),[2001-01-01, 2001-01-02])");
 		double dist= p.distance(st);
 		System.out.println(dist);
@@ -545,7 +502,6 @@ class TsTzSpanTest {
 	@MethodSource("intersection")
 	public void testIntersection(Time other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		this.p.intersection(other);
 	}
 
@@ -553,7 +509,6 @@ class TsTzSpanTest {
 	@MethodSource("intersection")
 	public void testMinus(Time other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		this.p.minus(other);
 	}
 
@@ -561,7 +516,6 @@ class TsTzSpanTest {
 	@MethodSource("intersection")
 	public void testUnion(Time other, boolean expected) throws Exception {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		this.p.union(other);
 	}
 
@@ -571,7 +525,6 @@ class TsTzSpanTest {
 	@MethodSource("other")
 	public void testEqual(Time t) throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertFalse(this.tstzspan.equals(t));
 	}
 
@@ -580,7 +533,6 @@ class TsTzSpanTest {
 	@MethodSource("other")
 	public void testNotEqual(Time t) throws SQLException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.tstzspan.notEquals(t));
 	}
 
@@ -588,7 +540,6 @@ class TsTzSpanTest {
 	@MethodSource("other")
 	public void testLessThan(Time t) throws SQLException, OperationNotSupportedException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.tstzspan.lessThan(t));
 	}
 
@@ -596,7 +547,6 @@ class TsTzSpanTest {
 	@MethodSource("other")
 	public void testLessThanOrEqual(Time t) throws SQLException, OperationNotSupportedException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.tstzspan.lessThanOrEqual(t));
 	}
 
@@ -604,7 +554,6 @@ class TsTzSpanTest {
 	@MethodSource("other")
 	public void testGreaterThan(Time t) throws SQLException, OperationNotSupportedException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertTrue(this.tstzspan.greaterThan(t));
 	}
 
@@ -612,7 +561,6 @@ class TsTzSpanTest {
 	@MethodSource("other")
 	public void testGreaterThanOrEqual(Time t) throws SQLException, OperationNotSupportedException {
 		functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
 		assertFalse(this.tstzspan.greaterThanOrEqual(t));
 	}
 

--- a/jmeos-core/src/test/java/functions/MeosArgumentErrorBranchTest.java
+++ b/jmeos-core/src/test/java/functions/MeosArgumentErrorBranchTest.java
@@ -1,5 +1,7 @@
 package functions;
 
+import functions.GeneratedFunctions;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import types.basic.tfloat.TFloatInst;
@@ -35,8 +37,7 @@ class MeosArgumentErrorBranchTest {
 
     @BeforeAll
     static void initMeos() {
-        functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(HANDLER);
+        GeneratedFunctions.meos_initialize_timezone("UTC");
     }
 
     @BeforeEach
@@ -146,14 +147,14 @@ class MeosArgumentErrorBranchTest {
             @DisplayName("intspan_make(300, 100) catchable as MeosArgumentError")
             void invertedSpan_catchableAsMeosArgumentError() {
                 assertThrows(MeosArgumentError.class,
-                        () -> functions.intspan_make(300, 100, true, true));
+                        () -> GeneratedFunctions.intspan_make(300, 100, true, true));
             }
 
             @Test
             @DisplayName("intspan_make(300, 100) catchable as MeosException")
             void invertedSpan_catchableAsMeosException() {
                 assertThrows(MeosException.class,
-                        () -> functions.intspan_make(300, 100, true, true));
+                        () -> GeneratedFunctions.intspan_make(300, 100, true, true));
             }
         }
     }
@@ -261,14 +262,14 @@ class MeosArgumentErrorBranchTest {
             @DisplayName("creating a sequence from no instants and 0 counts: MeosInvalidArgError")
             void sequenceFromNull_throwsMeosInvalidArgError() {
                 assertThrows(MeosInvalidArgError.class,
-                        () -> functions.tsequence_make(null, 0, true, true, TInterpolation.LINEAR.getValue(), false));
+                        () -> GeneratedFunctions.tsequence_make(null, 0, true, true, TInterpolation.LINEAR.getValue(), false));
             }
 
             @Test
             @DisplayName("creating a sequence from no instants and 0 counts: MeosException")
             void sequenceFromNull_throwsMeosException() {
                 assertThrows(MeosException.class,
-                        () -> functions.tsequence_make(null, 0, true, true, TInterpolation.LINEAR.getValue(), false));
+                        () -> GeneratedFunctions.tsequence_make(null, 0, true, true, TInterpolation.LINEAR.getValue(), false));
             }
         }
     }
@@ -494,21 +495,21 @@ class MeosArgumentErrorBranchTest {
             @DisplayName("intspan_make(300, 100): MeosInvalidArgValueError (inverted bounds)")
             void invertedSpan_throwsMeosInvalidArgValueError() {
                 assertThrows(MeosInvalidArgValueError.class,
-                        () -> functions.intspan_make(300, 100, true, true));
+                        () -> GeneratedFunctions.intspan_make(300, 100, true, true));
             }
 
             @Test
             @DisplayName("intspan_make(300, 100) catchable as MeosArgumentError")
             void invertedSpan_catchableAsMeosArgumentError() {
                 assertThrows(MeosArgumentError.class,
-                        () -> functions.intspan_make(300, 100, true, true));
+                        () -> GeneratedFunctions.intspan_make(300, 100, true, true));
             }
 
             @Test
             @DisplayName("intspan_make(300, 100) catchable as MeosException")
             void invertedSpan_catchableAsMeosException() {
                 assertThrows(MeosException.class,
-                        () -> functions.intspan_make(300, 100, true, true));
+                        () -> GeneratedFunctions.intspan_make(300, 100, true, true));
             }
         }
     }

--- a/jmeos-core/src/test/java/functions/MeosErrorHandlerTest.java
+++ b/jmeos-core/src/test/java/functions/MeosErrorHandlerTest.java
@@ -29,7 +29,6 @@ class MeosErrorHandlerTest {
     @BeforeAll
     static void initMeos() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(HANDLER);
     }
 
     /*

--- a/jmeos-core/src/test/java/functions/MeosExceptionTest.java
+++ b/jmeos-core/src/test/java/functions/MeosExceptionTest.java
@@ -26,7 +26,6 @@ class MeosExceptionTest {
     @BeforeAll
     static void initMeos() {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(HANDLER);
     }
 
     @BeforeEach

--- a/jmeos-core/src/test/java/functions/MeosInternalErrorBranchTest.java
+++ b/jmeos-core/src/test/java/functions/MeosInternalErrorBranchTest.java
@@ -1,5 +1,7 @@
 package functions;
 
+import functions.GeneratedFunctions;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import types.basic.tfloat.TFloatInst;
@@ -38,8 +40,7 @@ class MeosInternalErrorBranchTest {
 
     @BeforeAll
     static void initMeos() {
-        functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(HANDLER);
+        GeneratedFunctions.meos_initialize_timezone("UTC");
     }
 
     @BeforeEach
@@ -597,7 +598,7 @@ class MeosInternalErrorBranchTest {
             void divByZero_throwsExpectedType() {
                 TFloatInst sog = new TFloatInst("12.5@2024-06-01 08:00:00+00");
                 Exception ex = assertThrows(MeosException.class,
-                        () -> functions.div_tfloat_float(sog.getInner(), 0.0));
+                        () -> GeneratedFunctions.div_tfloat_float(sog.getInner(), 0.0));
                 assertTrue(
                         ex instanceof MeosDivisionByZeroError,
                         "Expected MeosDivisionByZeroError, got: " + ex.getClass().getSimpleName());
@@ -608,7 +609,7 @@ class MeosInternalErrorBranchTest {
             void divByZero_catchableAsMeosException() {
                 TFloatInst sog = new TFloatInst("12.5@2024-06-01 08:00:00+00");
                 assertThrows(MeosException.class,
-                        () -> functions.div_tfloat_float(sog.getInner(), 0.0));
+                        () -> GeneratedFunctions.div_tfloat_float(sog.getInner(), 0.0));
             }
         }
     }
@@ -741,7 +742,7 @@ class MeosInternalErrorBranchTest {
             //void enormousCorruptWkb_throwsMeosMemoryAllocError() {
             //    String hugeWkb = "FF".repeat(100_000);
             //    assertThrows(MeosMemoryAllocError.class, // FIXME MeoWKBInputError was thrown
-            //            () -> functions.temporal_from_hexwkb(hugeWkb));
+            //            () -> GeneratedFunctions.temporal_from_hexwkb(hugeWkb));
             //}
 
             @Test
@@ -749,7 +750,7 @@ class MeosInternalErrorBranchTest {
             void enormousCorruptWkb_throwsMeosException() {
                 String hugeWkb = "FF".repeat(100_000);
                 assertThrows(MeosException.class,
-                        () -> functions.temporal_from_hexwkb(hugeWkb));
+                        () -> GeneratedFunctions.temporal_from_hexwkb(hugeWkb));
             }
         }
     }

--- a/jmeos-core/src/test/java/functions/MeosIoErrorBranchTest.java
+++ b/jmeos-core/src/test/java/functions/MeosIoErrorBranchTest.java
@@ -1,5 +1,7 @@
 package functions;
 
+import functions.GeneratedFunctions;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import types.basic.tpoint.tgeom.TGeomPointInst;
@@ -39,8 +41,7 @@ class MeosIoErrorBranchTest {
 
     @BeforeAll
     static void initMeos() {
-        functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(HANDLER);
+        GeneratedFunctions.meos_initialize_timezone("UTC");
     }
 
     @BeforeEach
@@ -324,21 +325,21 @@ class MeosIoErrorBranchTest {
             @DisplayName("tgeompoint_from_mfjson(truncated) → MeosMfJsonInputError (code 20)")
             void truncatedMfJson_throwsMeosMfJsonInputError() {
                 assertThrows(MeosMfJsonInputError.class,
-                        () -> functions.tgeompoint_from_mfjson(TRUNCATED));
+                        () -> GeneratedFunctions.tgeompoint_from_mfjson(TRUNCATED));
             }
 
             @Test
             @DisplayName("tgeompoint_from_mfjson(truncated) catchable as MeosIoError")
             void truncatedMfJson_catchableAsMeosIoError() {
                 assertThrows(MeosIoError.class,
-                        () -> functions.tgeompoint_from_mfjson(TRUNCATED));
+                        () -> GeneratedFunctions.tgeompoint_from_mfjson(TRUNCATED));
             }
 
             @Test
             @DisplayName("tgeompoint_from_mfjson(truncated) catchable as MeosException")
             void truncatedMfJson_catchableAsMeosException() {
                 assertThrows(MeosException.class,
-                        () -> functions.tgeompoint_from_mfjson(TRUNCATED));
+                        () -> GeneratedFunctions.tgeompoint_from_mfjson(TRUNCATED));
             }
         }
     }
@@ -928,21 +929,21 @@ class MeosIoErrorBranchTest {
             @DisplayName("temporal_from_hexwkb(corrupt): MeosWkbInputError")
             void corruptWkb_throwsMeosWkbInputError() {
                 assertThrows(MeosWkbInputError.class,
-                        () -> functions.temporal_from_hexwkb(CORRUPT));
+                        () -> GeneratedFunctions.temporal_from_hexwkb(CORRUPT));
             }
 
             @Test
             @DisplayName("temporal_from_hexwkb(corrupt) catchable as MeosIoError")
             void corruptWkb_catchableAsMeosIoError() {
                 assertThrows(MeosIoError.class,
-                        () -> functions.temporal_from_hexwkb(CORRUPT));
+                        () -> GeneratedFunctions.temporal_from_hexwkb(CORRUPT));
             }
 
             @Test
             @DisplayName("temporal_from_hexwkb(corrupt) catchable as MeosException")
             void corruptWkb_catchableAsMeosException() {
                 assertThrows(MeosException.class,
-                        () -> functions.temporal_from_hexwkb(CORRUPT));
+                        () -> GeneratedFunctions.temporal_from_hexwkb(CORRUPT));
             }
         }
     }
@@ -1231,21 +1232,21 @@ class MeosIoErrorBranchTest {
             @DisplayName("tgeompoint_from_geojson(truncated) → MeosGeoJsonInputError (code 26)")
             void invalidGeoJson_throwsMeosGeoJsonInputError() {
                 assertThrows(MeosGeoJsonInputError.class,
-                        () -> functions.geo_from_geojson(INVALID_GEOJSON));
+                        () -> GeneratedFunctions.geo_from_geojson(INVALID_GEOJSON));
             }
 
             @Test
             @DisplayName("tgeompoint_from_geojson(truncated) catchable as MeosIoError")
             void invalidGeoJson_catchableAsMeosIoError() {
                 assertThrows(MeosIoError.class,
-                        () -> functions.geo_from_geojson(INVALID_GEOJSON));
+                        () -> GeneratedFunctions.geo_from_geojson(INVALID_GEOJSON));
             }
 
             @Test
             @DisplayName("tgeompoint_from_geojson(truncated) catchable as MeosException")
             void invalidGeoJson_catchableAsMeosException() {
                 assertThrows(MeosException.class,
-                        () -> functions.geo_from_geojson(INVALID_GEOJSON));
+                        () -> GeneratedFunctions.geo_from_geojson(INVALID_GEOJSON));
             }
         }*/
     }

--- a/jmeos-core/src/test/java/temporal/InterpolationTest.java
+++ b/jmeos-core/src/test/java/temporal/InterpolationTest.java
@@ -25,7 +25,6 @@ public class InterpolationTest {
 
     Stream<Arguments> TInterp() throws SQLException {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         return Stream.of(
                 Arguments.of("discrete", TInterpolation.DISCRETE),
                 Arguments.of("linear", TInterpolation.LINEAR),
@@ -39,7 +38,6 @@ public class InterpolationTest {
     @MethodSource("TInterp")
     public void testFromString(String base, TInterpolation expected) {
         functions.meos_initialize_timezone("UTC");
-        functions.meos_initialize_error_handler(errorHandler);
         assertEquals(TInterpolation.fromString(base),expected);
     }
 }

--- a/jmeos-core/src/test/resources/junit-platform.properties
+++ b/jmeos-core/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent
+junit.jupiter.execution.parallel.mode.classes.default = concurrent


### PR DESCRIPTION
MEOS keeps its session timezone, collation cache, PROJ and GEOS contexts and RNGs in
thread-local storage, so a thread that has not initialised MEOS reads uninitialised state:
a text comparison reaches `varstr_cmp` with no collation and the process dies. A
single-threaded suite does not expose this, because one thread initialises MEOS for the
whole run; a concurrent one aborts partway with `exit 134`.

This enables parallel test execution, which makes the failure visible, and closes it.

**Per-thread initialisation in the generated surface.** `FunctionsGenerator` emits
`ensureReady()` and calls it at the top of every wrapper. What MEOS holds per thread and
per process differ, so the two are set up apart: `meos_initialize()` and the error handler
run once under a lock — `meos_initialize()` resets the single process-wide handler to
MEOS's own default, which ends the process on an error — while the thread-local timezone
and collation run for every thread. A build-failing check rejects any emitted wrapper that
reaches the library without the guard, so a later regeneration keeps it.

**A thread-local error mirror.** `MeosErrorHandler` records the error MEOS reports, and
MEOS reports it on the calling thread with a thread-local error number, so the mirror is
thread-local too. One shared slot lets a thread consume or clear an error raised on another.

**No handler installs in the object layer.** `ConversionUtils`, `TBox` and `STBox` install
a print-only handler process-wide, which replaces the recording handler other threads rely
on and loses their exceptions. The per-thread guard installs the right handler, so these
are removed; the tests that install one for the same reason drop it too.

Reporting errors correctly surfaces one that the print-only handler masks:
`TGeomPoint.from_base_time` passes a `tstzspanset` to the `tstzset` constructor. It now
calls `tpointseqset_from_base_tstzspanset` and returns a sequence set, and its test labels
that case accordingly.

`mvn clean test` with parallel execution against a libmeos built from MobilityDB master:
102 code generation tests and 1760 FFI tests, no failures, across two runs.