### PR TITLE
Build a MEOS interval from a Duration through the interval parser

### DIFF
--- a/jmeos-core/src/main/java/utils/ConversionUtils.java
+++ b/jmeos-core/src/main/java/utils/ConversionUtils.java
@@ -58,19 +58,22 @@ public class ConversionUtils {
 
 
 	public static Pointer timedelta_to_interval(Duration td){
-		int years = 0;
-		int month = 0;
-		int weeks = 0;
-		int days = (int)td.toDays();
-		int hours = (int)td.toHours();
-		int minutes = (int)td.toMinutes();
-		double seconds = (double)td.toSeconds();
-		return GeneratedFunctions.interval_make(years,month,weeks,days,hours,minutes,seconds);
+		// Build the interval from a canonical, locale-independent text form parsed by MEOS. Each
+		// component carries only its own part of the duration (whole days, then the hours, minutes
+		// and seconds remaining within the last day). This avoids interval_make, whose trailing
+		// double seconds argument mis-marshals across the FFI and yields a corrupt interval.
+		long days = td.toDaysPart();
+		int hours = td.toHoursPart();
+		int minutes = td.toMinutesPart();
+		int seconds = td.toSecondsPart();
+		int micros = td.toNanosPart() / 1000;
+		String text = String.format("%d days %d hours %d minutes %d.%06d seconds",
+				days, hours, minutes, seconds, micros);
+		return GeneratedFunctions.interval_in(text, -1);
 	}
 
 	public static Duration interval_to_timedelta(Pointer p){
 		String res= GeneratedFunctions.interval_out(p);
-		System.out.println(res);
 		Pattern pattern = Pattern.compile("(\\d+)\\s+days(?:\\s+(\\d{2}):(\\d{2}):(\\d{2}))?");
 		Matcher matcher = pattern.matcher(res);
 
@@ -93,7 +96,6 @@ public class ConversionUtils {
 			// Calculate the total duration in seconds
 			long totalSeconds = days * 86400L + hours * 3600L + minutes * 60L + seconds;
 
-			System.out.println(Duration.ofSeconds(totalSeconds));
 			// Create and return the Duration object
 			return Duration.ofSeconds(totalSeconds);
 		} else {

--- a/jmeos-core/src/test/java/utils/ConversionUtilsIntervalTest.java
+++ b/jmeos-core/src/test/java/utils/ConversionUtilsIntervalTest.java
@@ -1,0 +1,39 @@
+package utils;
+
+import functions.GeneratedFunctions;
+import jnr.ffi.Pointer;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that a {@link Duration} survives conversion to a MEOS interval and back.
+ *
+ * <p>Before the fix, {@code timedelta_to_interval} forwarded the total hours, minutes and seconds
+ * alongside the whole days, so a multi-day duration was counted several times over and inflated into
+ * an out-of-range interval — a later use of that interval (e.g. scaling a temporal) then failed with
+ * "the interval must be positive".
+ */
+public class ConversionUtilsIntervalTest {
+
+    @Test
+    void durationRoundTripsThroughAMeosInterval() {
+        Duration[] durations = {
+                Duration.ofDays(2),
+                Duration.ofDays(3).plusHours(4).plusMinutes(5).plusSeconds(6),
+                Duration.ofDays(10).plusHours(23).plusMinutes(59).plusSeconds(59),
+        };
+        for (Duration d : durations) {
+            Pointer interval = ConversionUtils.timedelta_to_interval(d);
+            assertEquals(d, ConversionUtils.interval_to_timedelta(interval), "round-trip of " + d);
+        }
+    }
+
+    @Test
+    void wholeDaysProduceTheExpectedIntervalText() {
+        Pointer interval = ConversionUtils.timedelta_to_interval(Duration.ofDays(2));
+        assertEquals("2 days", GeneratedFunctions.interval_out(interval));
+    }
+}


### PR DESCRIPTION
## What

`ConversionUtils.timedelta_to_interval` is the single place the binding turns a Java `Duration` into a MEOS interval; every time-shift/scale/sample path in the object layer goes through it. This change builds the interval from a canonical, locale-independent text form parsed by MEOS (`interval_in`), with each field carrying only its own part of the duration: whole days, then the hours/minutes/seconds remaining within the last day.

## Why

`interval_make` receives `toHours()`/`toMinutes()`/`toSeconds()` — totals that already include the whole days — so a multi-day duration counts the same span several times over. Its trailing `double` seconds argument also mis-marshals across the FFI, so even `Duration.ofDays(2)` yields a corrupt interval with a large negative time component. A consumer that validates the interval (e.g. `temporal_scale_time`) then rejects it with "the interval must be positive"; a shift-only path silently uses the wrong value. Routing through the MEOS text parser fixes the arithmetic and avoids the fragile mixed int/double call.

This also drops two stray `System.out.println` statements from the interval conversions.

## Test

`ConversionUtilsIntervalTest` round-trips several multi-day durations `Duration → interval → Duration` (which throws on a corrupt interval) and checks that whole days render as the expected interval text. The full jmeos-core suite stays green.