### PR TITLE
Generate the Temporal OO array accessors as List folds

### DIFF
--- a/codegen/src/main/java/ObjectLayerGenerator.java
+++ b/codegen/src/main/java/ObjectLayerGenerator.java
@@ -170,13 +170,32 @@ public class ObjectLayerGenerator {
             defer(ooName, "receiver is " + recv + ", not Temporal *");
             return null;
         }
-        JsonNode shape = fn.path("shape");
-        if (shape.path("outParams").isArray() && shape.path("outParams").size() > 0) {
-            defer(ooName, "has out-parameter(s) — array/bool+result folding");
+        List<String> outParams = new ArrayList<>();
+        for (JsonNode o : fn.path("shape").path("outParams")) {
+            outParams.add(o.asText());
+        }
+        String retC = cleanType(fn.path("returnType").path("c").asText());
+
+        // Array-fold: a `count` out-parameter alongside an array return folds to a List. Emit the clean
+        // shape only — the sole out-parameter is `count` and the sole non-receiver parameter is that
+        // count — so the fold needs nothing but the receiver. A second out-parameter (timeSplit's bins),
+        // extra arguments, or a struct-array element (Span *) stays for a later slice.
+        String arrayElement = arrayElementSubtype(retC);
+        boolean scalarArray = retC.equals("TimestampTz *");
+        if ((arrayElement != null || scalarArray)
+                && outParams.equals(List.of("count"))
+                && params.size() == 2 && params.get(1).path("name").asText().equals("count")) {
+            String rt = scalarArray
+                    ? "java.util.List<java.time.OffsetDateTime>"
+                    : "java.util.List<Temporal>";
+            return new Method(ooName, fnName, rt, scalarArray ? "scalarArray" : "objectArray",
+                    arrayElement, List.of());
+        }
+        if (!outParams.isEmpty()) {
+            defer(ooName, "out-parameter(s) " + outParams + " — array/bool+result folding");
             return null;
         }
 
-        String retC = cleanType(fn.path("returnType").path("c").asText());
         String returnType;
         String returnKind;
         String returnSubtype = temporalReturn(retC);
@@ -228,6 +247,20 @@ public class ObjectLayerGenerator {
             case "TInstant *"       -> "TEMPORAL_INSTANT";
             case "TSequence *"      -> "TEMPORAL_SEQUENCE";
             case "TSequenceSet *"   -> "TEMPORAL_SEQUENCE_SET";
+            default                 -> null;
+        };
+    }
+
+    /**
+     * The {@code TemporalType} constant for the elements of a temporal-array return ({@code T **}), or
+     * {@code null} if the return is not such an array.
+     */
+    private static String arrayElementSubtype(String retC) {
+        return switch (retC) {
+            case "Temporal **"      -> "getTemporalType()";
+            case "TInstant **"      -> "TEMPORAL_INSTANT";
+            case "TSequence **"     -> "TEMPORAL_SEQUENCE";
+            case "TSequenceSet **"  -> "TEMPORAL_SEQUENCE_SET";
             default                 -> null;
         };
     }
@@ -346,11 +379,34 @@ public class ObjectLayerGenerator {
             case "temporal" -> "\t\treturn Factory.create_temporal(" + invocation
                     + ", getCustomType(), " + m.returnSubtype + ");\n";
             case "interval" -> "\t\treturn utils.ConversionUtils.interval_to_timedelta(" + invocation + ");\n";
+            case "objectArray" -> arrayFoldBody(m, "Factory.create_temporal(_array.getPointer("
+                    + "(long) _i * Long.BYTES), getCustomType(), " + m.returnSubtype + ")");
+            case "scalarArray" -> arrayFoldBody(m, "utils.TimestampTzConverter.toOffsetDateTime("
+                    + "_array.getLong((long) _i * Long.BYTES))");
             default         -> "\t\treturn " + invocation + ";\n";
         };
         return "\tdefault " + m.returnType + " " + m.ooName + "(" + sig + ") {\n"
                 + body
                 + "\t}\n\n";
+    }
+
+    /**
+     * The body of an array-fold method: allocate the count buffer, call the wrapper (which writes the
+     * count and returns the array), then read each element with {@code elementExpr} into a List. The
+     * count out-parameter gives the length, so the loop never over-reads.
+     */
+    private static String arrayFoldBody(Method m, String elementExpr) {
+        String elementType = m.returnType.substring(
+                m.returnType.indexOf('<') + 1, m.returnType.lastIndexOf('>'));
+        return "\t\tjnr.ffi.Runtime _rt = jnr.ffi.Runtime.getSystemRuntime();\n"
+                + "\t\tPointer _count = jnr.ffi.Memory.allocate(_rt, Integer.BYTES);\n"
+                + "\t\tPointer _array = GeneratedFunctions." + m.fnName + "(getInner(), _count);\n"
+                + "\t\tint _n = _count.getInt(0);\n"
+                + "\t\tjava.util.List<" + elementType + "> _out = new java.util.ArrayList<>(_n);\n"
+                + "\t\tfor (int _i = 0; _i < _n; _i++) {\n"
+                + "\t\t\t_out.add(" + elementExpr + ");\n"
+                + "\t\t}\n"
+                + "\t\treturn _out;\n";
     }
 
     // -------------------------------------------------------------------------

--- a/jmeos-core/src/test/java/types/temporal/generated/GeneratedTemporalParityTest.java
+++ b/jmeos-core/src/test/java/types/temporal/generated/GeneratedTemporalParityTest.java
@@ -1,7 +1,9 @@
 package types.temporal.generated;
 
 import functions.GeneratedFunctions;
+import jnr.ffi.Memory;
 import jnr.ffi.Pointer;
+import jnr.ffi.Runtime;
 import org.junit.jupiter.api.Test;
 import types.basic.tfloat.TFloatInst;
 import types.basic.tfloat.TFloatSeq;
@@ -13,6 +15,7 @@ import utils.ConversionUtils;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -151,5 +154,43 @@ public class GeneratedTemporalParityTest {
         assertEquals(id(GeneratedFunctions.temporal_tsample(p,
                         ConversionUtils.timedelta_to_interval(d1), origin, TInterpolation.LINEAR.getValue())),
                 id(g.tsample(d1, origin, TInterpolation.LINEAR)));
+    }
+
+    /** The length the count out-parameter reports for one of the array accessors. */
+    private static int directCount(Pointer array, Pointer count) {
+        return array == null ? 0 : count.getInt(0);
+    }
+
+    @Test
+    void arrayAccessorsMatchTheLibrary() {
+        TFloatSeqSet ss = new TFloatSeqSet(
+                "{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05]}");
+        Pointer p = ss.getInner();
+        GeneratedTemporal g = gen(ss);
+        Runtime rt = Runtime.getSystemRuntime();
+
+        // Object array (TInstant **) folds to List<Temporal>; compare length and element identity.
+        Pointer c = Memory.allocate(rt, Integer.BYTES);
+        Pointer arr = GeneratedFunctions.temporal_instants(p, c);
+        List<Temporal> instants = g.instants();
+        assertEquals(directCount(arr, c), instants.size());
+        for (int i = 0; i < instants.size(); i++) {
+            assertEquals(id(arr.getPointer((long) i * Long.BYTES)), id(instants.get(i)));
+        }
+
+        Pointer c2 = Memory.allocate(rt, Integer.BYTES);
+        assertEquals(directCount(GeneratedFunctions.temporal_segments(p, c2), c2), g.segments().size());
+        Pointer c3 = Memory.allocate(rt, Integer.BYTES);
+        assertEquals(directCount(GeneratedFunctions.temporal_sequences(p, c3), c3), g.sequences().size());
+
+        // Scalar array (TimestampTz *) folds to List<OffsetDateTime>; the values are the converted int64s.
+        Pointer c4 = Memory.allocate(rt, Integer.BYTES);
+        Pointer tsArr = GeneratedFunctions.temporal_timestamps(p, c4);
+        List<OffsetDateTime> timestamps = g.timestamps();
+        assertEquals(directCount(tsArr, c4), timestamps.size());
+        for (int i = 0; i < timestamps.size(); i++) {
+            assertEquals(utils.TimestampTzConverter.toOffsetDateTime(tsArr.getLong((long) i * Long.BYTES)),
+                    timestamps.get(i));
+        }
     }
 }


### PR DESCRIPTION
## What

Teaches `ObjectLayerGenerator` to fold an array return with a `count` out-parameter into a `List`. When a method's only out-parameter is `count` and its only non-receiver parameter is that count, the generated method allocates the count buffer, calls the wrapper, and reads each element into a `List` using the length the count reports:

- `TInstant **` / `TSequence **` / `TSequenceSet **` / `Temporal **` → `List<Temporal>` (each element wrapped through `Factory` with the element subtype)
- `TimestampTz *` → `List<OffsetDateTime>`

This adds `instants`, `segments`, `sequences` and `timestamps` to the generated `GeneratedTemporal` surface, for 44 methods in total.

Richer shapes stay for a later slice: a second out-parameter (`timeSplit`'s bins), extra arguments (`splitNSpans`), or a struct-array element (`Span *`).

## Test

The parity test folds each array through the generated method and compares it against the raw array read directly from the library — element identity for the object arrays, converted value for the timestamps. The full jmeos-core suite stays green.