### PR TITLE
Generate the Temporal OO methods taking a temporal object argument

### DIFF
--- a/codegen/src/main/java/ObjectLayerGenerator.java
+++ b/codegen/src/main/java/ObjectLayerGenerator.java
@@ -310,6 +310,10 @@ public class ObjectLayerGenerator {
             case "Interval *"  -> new Arg("java.time.Duration", name,
                     "utils.ConversionUtils.timedelta_to_interval(" + name + ")");
             case "TimestampTz" -> new Arg("java.time.OffsetDateTime", name, name);
+            // A temporal object argument is passed as a Temporal and forwarded as its inner pointer;
+            // MEOS validates the concrete subtype (a TInstant *, a TSequence *) at the boundary.
+            case "Temporal *", "TInstant *", "TSequence *", "TSequenceSet *"
+                               -> new Arg("Temporal", name, name + ".getInner()");
             default            -> null;
         };
     }

--- a/jmeos-core/src/test/java/types/temporal/generated/GeneratedTemporalParityTest.java
+++ b/jmeos-core/src/test/java/types/temporal/generated/GeneratedTemporalParityTest.java
@@ -193,4 +193,27 @@ public class GeneratedTemporalParityTest {
                     timestamps.get(i));
         }
     }
+
+    @Test
+    void objectArgumentsMatchTheLibrary() {
+        TFloatSeq a = new TFloatSeq("[1@2019-09-01, 2@2019-09-02]");
+        TFloatSeq b = new TFloatSeq("[3@2019-09-03, 4@2019-09-04]");
+        TFloatInst inst = new TFloatInst("5@2019-09-05");
+        Pointer pa = a.getInner();
+        GeneratedTemporal g = gen(a);
+
+        // A temporal object argument is forwarded as its inner pointer.
+        assertEquals(id(GeneratedFunctions.temporal_merge(pa, b.getInner())), id(g.merge(b)));
+        assertEquals(GeneratedFunctions.temporal_frechet_distance(pa, b.getInner()), g.frechetDistance(b));
+        assertEquals(id(GeneratedFunctions.temporal_insert(pa, b.getInner(), true)), id(g.insert(b, true)));
+        assertEquals(id(GeneratedFunctions.temporal_append_tsequence(pa, b.getInner(), false)),
+                id(g.appendTsequence(b, false)));
+
+        // appendTinstant mixes an object, an interpolation, an interval and scalar arguments.
+        assertEquals(
+                id(GeneratedFunctions.temporal_append_tinstant(pa, inst.getInner(),
+                        TInterpolation.LINEAR.getValue(), 0.0,
+                        ConversionUtils.timedelta_to_interval(Duration.ofDays(1)), false)),
+                id(g.appendTinstant(inst, TInterpolation.LINEAR, 0.0, Duration.ofDays(1), false)));
+    }
 }


### PR DESCRIPTION
## What

Extends `ObjectLayerGenerator`'s argument marshalling so a temporal object argument (`Temporal *`, `TInstant *`, `TSequence *` or `TSequenceSet *`) is accepted as a `Temporal` and forwarded as its inner pointer. MEOS validates the concrete subtype (that an append target is a `TInstant *`, say) at the boundary.

This adds ten methods to the generated `GeneratedTemporal` surface, for 54 in total:

- `merge`, `insert`, `update`
- the `frechet`, `dynamic-time-warp`, `Hausdorff`, `average-Hausdorff` and `LCSS` distances
- `appendTsequence` and `appendTinstant` — the latter combining an object, an interpolation, an interval and scalar arguments, exercising the whole argument-marshalling set at once

## Test

The parity test calls each generated method and the equivalent direct `GeneratedFunctions` call with the same operands, comparing the temporal results by identity and the distances by value. The full jmeos-core suite stays green.