### PR TITLE
Generate the Temporal OO methods over its time collections

### DIFF
--- a/codegen/src/main/java/ObjectLayerGenerator.java
+++ b/codegen/src/main/java/ObjectLayerGenerator.java
@@ -208,6 +208,14 @@ public class ObjectLayerGenerator {
         } else if (scalarReturn(retC) != null) {
             returnType = scalarReturn(retC);
             returnKind = "direct";
+        } else if (retC.equals("Span *")) {
+            // A Temporal's span is its time extent, a tstzspan.
+            returnType = "types.collections.time.tstzspan";
+            returnKind = "tstzspan";
+        } else if (retC.equals("SpanSet *")) {
+            // A Temporal's spanset is its time domain, a tstzspanset.
+            returnType = "types.collections.time.tstzspanset";
+            returnKind = "tstzspanset";
         } else {
             defer(ooName, "return type " + retC + " needs collection/box/struct wrapping");
             return null;
@@ -314,6 +322,11 @@ public class ObjectLayerGenerator {
             // MEOS validates the concrete subtype (a TInstant *, a TSequence *) at the boundary.
             case "Temporal *", "TInstant *", "TSequence *", "TSequenceSet *"
                                -> new Arg("Temporal", name, name + ".getInner()");
+            // A Temporal's time domain is always the tstz family, so its set/span/spanset arguments are
+            // the time wrappers, forwarded as their inner pointer.
+            case "Set *"       -> new Arg("types.collections.time.tstzset", name, name + ".get_inner()");
+            case "Span *"      -> new Arg("types.collections.time.tstzspan", name, name + ".get_inner()");
+            case "SpanSet *"   -> new Arg("types.collections.time.tstzspanset", name, name + ".get_inner()");
             default            -> null;
         };
     }
@@ -383,6 +396,8 @@ public class ObjectLayerGenerator {
             case "temporal" -> "\t\treturn Factory.create_temporal(" + invocation
                     + ", getCustomType(), " + m.returnSubtype + ");\n";
             case "interval" -> "\t\treturn utils.ConversionUtils.interval_to_timedelta(" + invocation + ");\n";
+            case "tstzspan" -> "\t\treturn new types.collections.time.tstzspan(" + invocation + ");\n";
+            case "tstzspanset" -> "\t\treturn new types.collections.time.tstzspanset(" + invocation + ");\n";
             case "objectArray" -> arrayFoldBody(m, "Factory.create_temporal(_array.getPointer("
                     + "(long) _i * Long.BYTES), getCustomType(), " + m.returnSubtype + ")");
             case "scalarArray" -> arrayFoldBody(m, "utils.TimestampTzConverter.toOffsetDateTime("

--- a/jmeos-core/src/test/java/types/temporal/generated/GeneratedTemporalParityTest.java
+++ b/jmeos-core/src/test/java/types/temporal/generated/GeneratedTemporalParityTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import types.basic.tfloat.TFloatInst;
 import types.basic.tfloat.TFloatSeq;
 import types.basic.tfloat.TFloatSeqSet;
+import types.collections.time.tstzspan;
 import types.temporal.Temporal;
 import types.temporal.TemporalType;
 import types.temporal.TInterpolation;
@@ -215,5 +216,23 @@ public class GeneratedTemporalParityTest {
                         TInterpolation.LINEAR.getValue(), 0.0,
                         ConversionUtils.timedelta_to_interval(Duration.ofDays(1)), false)),
                 id(g.appendTinstant(inst, TInterpolation.LINEAR, 0.0, Duration.ofDays(1), false)));
+    }
+
+    @Test
+    void timeCollectionsMatchTheLibrary() {
+        TFloatSeq a = new TFloatSeq("[1@2019-09-01, 2@2019-09-02, 3@2019-09-03]");
+        Pointer p = a.getInner();
+        GeneratedTemporal g = gen(a);
+
+        // Collection returns are wrapped in the time types; compare their output text to the direct call.
+        assertEquals(GeneratedFunctions.span_out(GeneratedFunctions.temporal_to_tstzspan(p), 15),
+                GeneratedFunctions.span_out(g.toTstzspan().get_inner(), 15));
+        assertEquals(GeneratedFunctions.spanset_out(GeneratedFunctions.temporal_time(p), 15),
+                GeneratedFunctions.spanset_out(g.time().get_inner(), 15));
+
+        // A collection argument is forwarded as its inner pointer.
+        tstzspan period = new tstzspan("[2019-09-02 00:00:00+00, 2019-09-03 00:00:00+00]");
+        assertEquals(id(GeneratedFunctions.temporal_delete_tstzspan(p, period.get_inner(), false)),
+                id(g.deleteTstzspan(period, false)));
     }
 }


### PR DESCRIPTION
## What

`Span`, `SpanSet` and `Set` are template collections parameterised by element type. A `Temporal`'s time domain is their `timestamptz` instantiation, so its set/span/spanset arguments and returns are the `tstz` wrappers. This extends `ObjectLayerGenerator` to marshal them:

- `Set *` / `Span *` / `SpanSet *` argument → `tstzset` / `tstzspan` / `tstzspanset`, forwarded as its inner pointer
- `Span *` return → `tstzspan`; `SpanSet *` return → `tstzspanset`, each wrapping the returned pointer

This adds `toTstzspan` and `time` (returns) and `deleteTstzset`, `deleteTstzspan`, `deleteTstzspanset` (arguments) to the generated `GeneratedTemporal` surface, for 59 methods in total.

The collection-type mapping is domain-aware: a `Temporal`'s collections are always the time instantiation. When the generator later covers `TNumber`, its value collections resolve to the numeric instantiation instead.

Array-of-span returns (`spans`, the split families, `timeBins`) still await the struct-array slice.

## Test

The parity test compares each generated collection method against the direct `GeneratedFunctions` call — output text for the wrapped returns, temporal identity for the collection-argument method. The full jmeos-core suite stays green.