### PR TITLE
Generate the Temporal OO comparison predicates

### DIFF
--- a/codegen/src/main/java/ObjectLayerGenerator.java
+++ b/codegen/src/main/java/ObjectLayerGenerator.java
@@ -35,8 +35,8 @@ public class ObjectLayerGenerator {
     /** The class whose OO surface this run emits. */
     private static final String CLASS = "Temporal";
 
-    /** Roles included in this slice. */
-    private static final Set<String> ROLES = Set.of("accessor", "conversion");
+    /** The object-model roles this surface generates. */
+    private static final Set<String> ROLES = Set.of("accessor", "conversion", "predicate");
 
     /** Enum type names from the catalog; a param of one of these maps to a Java int in the surface. */
     private final Set<String> enumNames = new HashSet<>();

--- a/jmeos-core/src/test/java/types/temporal/generated/GeneratedTemporalParityTest.java
+++ b/jmeos-core/src/test/java/types/temporal/generated/GeneratedTemporalParityTest.java
@@ -235,4 +235,26 @@ public class GeneratedTemporalParityTest {
         assertEquals(id(GeneratedFunctions.temporal_delete_tstzspan(p, period.get_inner(), false)),
                 id(g.deleteTstzspan(period, false)));
     }
+
+    @Test
+    void comparisonPredicatesMatchTheLibrary() {
+        TFloatSeq a = new TFloatSeq("[1@2019-09-01, 2@2019-09-02]");
+        TFloatSeq b = new TFloatSeq("[3@2019-09-03, 4@2019-09-04]");
+        TFloatSeq aCopy = new TFloatSeq("[1@2019-09-01, 2@2019-09-02]");
+        Pointer pa = a.getInner();
+        Pointer pb = b.getInner();
+        GeneratedTemporal g = gen(a);
+
+        assertEquals(GeneratedFunctions.temporal_cmp(pa, pb), g.cmp(b));
+        assertEquals(GeneratedFunctions.temporal_eq(pa, pb), g.eq(b));
+        assertEquals(GeneratedFunctions.temporal_ne(pa, pb), g.ne(b));
+        assertEquals(GeneratedFunctions.temporal_lt(pa, pb), g.lt(b));
+        assertEquals(GeneratedFunctions.temporal_le(pa, pb), g.le(b));
+        assertEquals(GeneratedFunctions.temporal_gt(pa, pb), g.gt(b));
+        assertEquals(GeneratedFunctions.temporal_ge(pa, pb), g.ge(b));
+
+        // Equal temporals compare equal; ordering is strict against a greater one.
+        assertEquals(true, g.eq(aCopy));
+        assertEquals(true, g.lt(b));
+    }
 }


### PR DESCRIPTION
## What

Includes the object model's `predicate` role in the generated surface. Each predicate takes another temporal and returns a scalar, which the existing marshalling already covers:

- `cmp` → `int`
- `eq`, `ne`, `lt`, `le`, `gt`, `ge` → `boolean`

This adds seven methods to the generated `GeneratedTemporal` surface, for 66 in total — no new marshalling, the temporal-object argument and scalar return are already handled.

## Test

The parity test compares each predicate against the direct `GeneratedFunctions` call and checks equality and strict ordering on known operands. The full jmeos-core suite stays green.