### PR TITLE
Generate the Temporal OO restrictions

### DIFF
--- a/codegen/src/main/java/ObjectLayerGenerator.java
+++ b/codegen/src/main/java/ObjectLayerGenerator.java
@@ -36,7 +36,7 @@ public class ObjectLayerGenerator {
     private static final String CLASS = "Temporal";
 
     /** The object-model roles this surface generates. */
-    private static final Set<String> ROLES = Set.of("accessor", "conversion", "predicate");
+    private static final Set<String> ROLES = Set.of("accessor", "conversion", "predicate", "restriction");
 
     /** Enum type names from the catalog; a param of one of these maps to a Java int in the surface. */
     private final Set<String> enumNames = new HashSet<>();
@@ -234,7 +234,7 @@ public class ObjectLayerGenerator {
             if ((name.equals("n") || name.equals("i")) && ooName.endsWith("N")) {
                 indexed = true;
             }
-            Arg arg = marshalArg(pC, name);
+            Arg arg = marshalArg(pC, name, fnName);
             if (arg == null) {
                 defer(ooName, "argument " + name + " of type " + pC + " needs object/collection marshalling");
                 return null;
@@ -297,9 +297,11 @@ public class ObjectLayerGenerator {
      * How to marshal one argument to the wrapper, or {@code null} if it needs a pattern this slice does
      * not emit (an object/collection pointer). A scalar and a {@code TimestampTz} pass straight through
      * (the wrapper takes the primitive resp. the {@code OffsetDateTime}); an {@code interpType} and an
-     * {@code Interval *} convert through the same helpers the hand layer uses.
+     * {@code Interval *} convert through the same helpers the hand layer uses. A set/span/spanset
+     * argument is a time wrapper when the method restricts by time (its backing function names the tstz
+     * type) and the generic collection over the base value otherwise.
      */
-    private static Arg marshalArg(String pC, String name) {
+    private static Arg marshalArg(String pC, String name, String fnName) {
         String scalar = switch (pC) {
             case "bool"                              -> "boolean";
             case "int", "int32", "int32_t",
@@ -313,20 +315,25 @@ public class ObjectLayerGenerator {
         if (scalar != null) {
             return new Arg(scalar, name, name);
         }
+        boolean time = fnName.contains("tstz");
         return switch (pC) {
             case "interpType"  -> new Arg("TInterpolation", name, name + ".getValue()");
             case "Interval *"  -> new Arg("java.time.Duration", name,
                     "utils.ConversionUtils.timedelta_to_interval(" + name + ")");
             case "TimestampTz" -> new Arg("java.time.OffsetDateTime", name, name);
+            case "char *"      -> new Arg("String", name, name);
             // A temporal object argument is passed as a Temporal and forwarded as its inner pointer;
             // MEOS validates the concrete subtype (a TInstant *, a TSequence *) at the boundary.
             case "Temporal *", "TInstant *", "TSequence *", "TSequenceSet *"
                                -> new Arg("Temporal", name, name + ".getInner()");
-            // A Temporal's time domain is always the tstz family, so its set/span/spanset arguments are
-            // the time wrappers, forwarded as their inner pointer.
-            case "Set *"       -> new Arg("types.collections.time.tstzset", name, name + ".get_inner()");
-            case "Span *"      -> new Arg("types.collections.time.tstzspan", name, name + ".get_inner()");
-            case "SpanSet *"   -> new Arg("types.collections.time.tstzspanset", name, name + ".get_inner()");
+            // A time restriction takes the tstz wrapper; a value restriction takes the generic
+            // collection over the base value. Both are forwarded as their inner pointer.
+            case "Set *"       -> new Arg(time ? "types.collections.time.tstzset"
+                                               : "types.collections.base.Set<?>", name, name + ".get_inner()");
+            case "Span *"      -> new Arg(time ? "types.collections.time.tstzspan"
+                                               : "types.collections.base.Span<?>", name, name + ".get_inner()");
+            case "SpanSet *"   -> new Arg(time ? "types.collections.time.tstzspanset"
+                                               : "types.collections.base.SpanSet<?>", name, name + ".get_inner()");
             default            -> null;
         };
     }

--- a/jmeos-core/src/test/java/types/temporal/generated/GeneratedTemporalParityTest.java
+++ b/jmeos-core/src/test/java/types/temporal/generated/GeneratedTemporalParityTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import types.basic.tfloat.TFloatInst;
 import types.basic.tfloat.TFloatSeq;
 import types.basic.tfloat.TFloatSeqSet;
+import types.collections.number.FloatSet;
 import types.collections.time.tstzspan;
 import types.temporal.Temporal;
 import types.temporal.TemporalType;
@@ -256,5 +257,30 @@ public class GeneratedTemporalParityTest {
         // Equal temporals compare equal; ordering is strict against a greater one.
         assertEquals(true, g.eq(aCopy));
         assertEquals(true, g.lt(b));
+    }
+
+    @Test
+    void restrictionsMatchTheLibrary() {
+        TFloatSeq a = new TFloatSeq("[1@2019-09-01, 2@2019-09-02, 3@2019-09-03]");
+        Pointer p = a.getInner();
+        GeneratedTemporal g = gen(a);
+
+        // No-argument and timestamp restrictions.
+        assertEquals(id(GeneratedFunctions.temporal_at_max(p)), id(g.atMax()));
+        assertEquals(id(GeneratedFunctions.temporal_at_min(p)), id(g.atMin()));
+        OffsetDateTime t = OffsetDateTime.parse("2019-09-02T00:00:00Z");
+        assertEquals(id(GeneratedFunctions.temporal_at_timestamptz(p, t)), id(g.atTimestamptz(t)));
+
+        // Time-collection restriction (tstz wrapper).
+        tstzspan period = new tstzspan("[2019-09-01 00:00:00+00, 2019-09-02 00:00:00+00]");
+        assertEquals(id(GeneratedFunctions.temporal_at_tstzspan(p, period.get_inner())),
+                id(g.atTstzspan(period)));
+
+        // Value-collection restriction (a value set of floats, marshalled through the generic base Set).
+        FloatSet values = new FloatSet("{1, 2}");
+        assertEquals(id(GeneratedFunctions.temporal_at_values(p, values.get_inner())),
+                id(g.atValues(values)));
+        assertEquals(id(GeneratedFunctions.temporal_minus_values(p, values.get_inner())),
+                id(g.minusValues(values)));
     }
 }


### PR DESCRIPTION
## What

Includes the object model's `restriction` role. A restriction takes a time value, a time collection or a value collection and returns the temporal restricted to (`at*`) or with (`minus*`) it. The collection marshalling distinguishes the two domains:

- a **time** restriction takes the `tstz` wrapper (`tstzset`/`tstzspan`/`tstzspanset`)
- a **value** restriction takes the generic collection over the base value (`Set<?>`/`Span<?>`/`SpanSet<?>`)

both forwarded as their inner pointer; MEOS validates the concrete element type at the boundary.

This adds the fourteen `at`/`minus` methods to the generated `GeneratedTemporal` surface, for 80 in total: `atMax`/`atMin`/`minusMax`/`minusMin`, `at`/`minusTimestamptz`, `at`/`minusTstz{set,span,spanset}`, and `at`/`minusValues`.

The **value-collection** form (`atValues(Set<?>)`) belongs to the generic `Temporal`; the single base-value form (`atValue`) lives on the typed subclasses (`tfloat_at_value`→`TFloat`, `tint_at_value`→`TInt`), where the base type is known.

## Test

The parity test compares each against the direct `GeneratedFunctions` call across the no-argument, timestamp, time-collection and value-collection forms. The full jmeos-core suite stays green.