### PR TITLE
Generate the Temporal OO output methods

### DIFF
--- a/codegen/src/main/java/ObjectLayerGenerator.java
+++ b/codegen/src/main/java/ObjectLayerGenerator.java
@@ -36,7 +36,8 @@ public class ObjectLayerGenerator {
     private static final String CLASS = "Temporal";
 
     /** The object-model roles this surface generates. */
-    private static final Set<String> ROLES = Set.of("accessor", "conversion", "predicate", "restriction");
+    private static final Set<String> ROLES =
+            Set.of("accessor", "conversion", "predicate", "restriction", "output");
 
     /** Enum type names from the catalog; a param of one of these maps to a Java int in the surface. */
     private final Set<String> enumNames = new HashSet<>();
@@ -191,8 +192,16 @@ public class ObjectLayerGenerator {
             return new Method(ooName, fnName, rt, scalarArray ? "scalarArray" : "objectArray",
                     arrayElement, List.of());
         }
-        if (!outParams.isEmpty()) {
-            defer(ooName, "out-parameter(s) " + outParams + " — array/bool+result folding");
+        // A size_t* out-parameter is the throwaway byte-count of the *_as_wkb / *_as_hexwkb family; the
+        // wrapper allocates, forwards and discards it, so the generated method never passes it.
+        List<String> unfolded = new ArrayList<>();
+        for (String o : outParams) {
+            if (!isSizeOut(params, o)) {
+                unfolded.add(o);
+            }
+        }
+        if (!unfolded.isEmpty()) {
+            defer(ooName, "out-parameter(s) " + unfolded + " — array/bool+result folding");
             return null;
         }
 
@@ -216,6 +225,10 @@ public class ObjectLayerGenerator {
             // A Temporal's spanset is its time domain, a tstzspanset.
             returnType = "types.collections.time.tstzspanset";
             returnKind = "tstzspanset";
+        } else if (retC.equals("uint8_t *")) {
+            // The WKB byte buffer, returned as a raw pointer (its length is folded away by the wrapper).
+            returnType = "Pointer";
+            returnKind = "direct";
         } else {
             defer(ooName, "return type " + retC + " needs collection/box/struct wrapping");
             return null;
@@ -229,6 +242,9 @@ public class ObjectLayerGenerator {
         List<Arg> args = new ArrayList<>();
         for (int i = 1; i < params.size(); i++) {
             JsonNode p = params.get(i);
+            if (outParams.contains(p.path("name").asText())) {
+                continue; // a folded size_t* out-param the wrapper supplies itself
+            }
             String pC = cleanType(p.path("cType").asText());
             String name = sanitize(p.path("name").asText());
             if ((name.equals("n") || name.equals("i")) && ooName.endsWith("N")) {
@@ -304,6 +320,8 @@ public class ObjectLayerGenerator {
     private static Arg marshalArg(String pC, String name, String fnName) {
         String scalar = switch (pC) {
             case "bool"                              -> "boolean";
+            case "int8", "int8_t",
+                 "uint8", "uint8_t"                  -> "byte";
             case "int", "int32", "int32_t",
                  "uint32", "uint32_t"                -> "int";
             case "long", "int64", "int64_t",
@@ -340,6 +358,16 @@ public class ObjectLayerGenerator {
 
     private void defer(String ooName, String reason) {
         deferred.add(ooName + " — " + reason);
+    }
+
+    /** Whether the named parameter is a {@code size_t *} out-parameter the wrapper folds internally. */
+    private static boolean isSizeOut(JsonNode params, String name) {
+        for (JsonNode p : params) {
+            if (p.path("name").asText().equals(name)) {
+                return cleanType(p.path("cType").asText()).contains("size_t");
+            }
+        }
+        return false;
     }
 
     private static String cleanType(String c) {

--- a/jmeos-core/src/test/java/types/temporal/generated/GeneratedTemporalParityTest.java
+++ b/jmeos-core/src/test/java/types/temporal/generated/GeneratedTemporalParityTest.java
@@ -20,6 +20,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Proves the generated {@link GeneratedTemporal} surface is wired correctly and behaves like the hand
@@ -282,5 +283,19 @@ public class GeneratedTemporalParityTest {
                 id(g.atValues(values)));
         assertEquals(id(GeneratedFunctions.temporal_minus_values(p, values.get_inner())),
                 id(g.minusValues(values)));
+    }
+
+    @Test
+    void outputMatchesTheLibrary() {
+        TFloatSeq a = new TFloatSeq("[1@2019-09-01, 2@2019-09-02]");
+        Pointer p = a.getInner();
+        GeneratedTemporal g = gen(a);
+
+        // The hex-WKB and MF-JSON strings match the direct call; the size_out is folded by the wrapper.
+        assertEquals(GeneratedFunctions.temporal_as_hexwkb(p, (byte) 4), g.asHEXWKB((byte) 4));
+        assertEquals(GeneratedFunctions.temporal_as_mfjson(p, true, 3, 6, null),
+                g.asMFJSON(true, 3, 6, null));
+        // The WKB buffer is returned as a raw pointer.
+        assertNotNull(g.asWKB((byte) 4));
     }
 }


### PR DESCRIPTION
## What

Includes the object model's `output` role. A `size_t` out-parameter is the throwaway byte-count of the WKB family, which the wrapper allocates and discards, so the generated method drops it; the remaining `variant` argument is a `byte`.

This adds:
- `asHEXWKB(byte variant)` and `asMFJSON(boolean, int, int, String)` → `String`
- `asWKB(byte variant)` → the raw byte buffer as a `Pointer`

for 83 methods in total.

## Test

The parity test compares the hex-WKB and MF-JSON strings against the direct `GeneratedFunctions` call. The full jmeos-core suite stays green.