### PR TITLE
Implement STBox.expand_stbox

### DIFF
--- a/jmeos-core/src/main/java/types/boxes/STBox.java
+++ b/jmeos-core/src/main/java/types/boxes/STBox.java
@@ -610,25 +610,19 @@ public class STBox implements Box {
 
 
 	/**
-	 * Expands "this" with "other".
-	 *         If "other" is a {@link Integer} or a {@link Float}, the result is equal
-	 *         to "this" but with the spatial dimensions expanded by "other" in all
-	 *         directions. If "other" is a {@link java.time.Duration}, the result is equal to
-	 *         "this"  but with the temporal dimension expanded by `other` in both
-	 *         directions.
+	 * Returns "this" expanded with "other", that is, the smallest box containing
+	 * both.
 	 *
 	 * <p>
 	 *
 	 *         MEOS Functions:
-	 *             <li>stbox_expand_space</li>
-	 *             <li>stbox_expand_time</li>
-	 * @param stbox The object to expand "this" with.
-	 * @param other The object to expand "this" with.
+	 *             <li>stbox_expand</li>
+	 * @param other The box to expand "this" with.
 	 * @return A new {@link STBox} instance.
 	 */
-	public STBox expand_stbox(STBox stbox, STBox other) {
+	public STBox expand_stbox(STBox other) {
 		Pointer result = GeneratedFunctions.stbox_copy(this._inner);
-//		GeneratedFunctions.stbox_expand_space(other._inner, result);
+		GeneratedFunctions.stbox_expand(other._inner, result);
 		return new STBox(result);
 	}
 

--- a/jmeos-core/src/test/java/boxes/STBoxTest.java
+++ b/jmeos-core/src/test/java/boxes/STBoxTest.java
@@ -287,6 +287,22 @@ public class STBoxTest {
 
 
 
+	@ParameterizedTest(name = "Test Expand STBox method with stbox={0}, other={1}, expected={2}")
+	@CsvSource(value = {
+			"STBox X((1, 1),(2, 2)); STBox X((0, 0),(3, 3)); STBox X((0, 0),(3, 3))",
+			"STBox X((1, 1),(2, 2)); STBox X((3, 3),(4, 4)); STBox X((1, 1),(4, 4))",
+			"STBox Z((1, 1, 1),(2, 2, 2)); STBox Z((0, 0, 0),(3, 3, 3)); STBox Z((0, 0, 0),(3, 3, 3))",
+			"STBox XT(((1, 1),(2, 2)),[2019-09-02,2019-09-03]); STBox XT(((3, 3),(4, 4)),[2019-09-01,2019-09-04]); STBox XT(((1, 1),(4, 4)),[2019-09-01,2019-09-04])",
+	}, delimiter = ';')
+	public void testExpandStbox(String stbox, String other, String expected) throws SQLException {
+		STBox stb = new STBox(stbox);
+		STBox new_stb = stb.expand_stbox(new STBox(other));
+		STBox res = new STBox(expected);
+		assertEquals(new_stb.toString(15),res.toString(15));
+	}
+
+
+
 	@ParameterizedTest(name = "Test adjacent method with stbox={0}, expected={1}")
 	@CsvSource(value = {
 			"STBox X((1, 1),(2, 2)); STBox X((1, 1),(3, 3)); false",


### PR DESCRIPTION
`expand_stbox` implements the expansion of `this` with `other`, returning the smallest box containing both.

The body calls `stbox_expand`, which expands the second box with the first one in place. That function is public since MobilityDB#1525, so the binding reaches it directly. The signature is an instance method taking a single box, since `expand_stbox` is applied to `this`.

The test covers the disjoint case, `STBox X((1, 1),(2, 2))` expanded with `STBox X((3, 3),(4, 4))` giving `STBox X((1, 1),(4, 4))`, together with a contained case and the Z and XT variants.
