### PR TITLE
Pin the hashes a temporal value answers from the instants it holds

### DIFF
--- a/jmeos-core/src/test/java/basic/TBoolTest.java
+++ b/jmeos-core/src/test/java/basic/TBoolTest.java
@@ -222,10 +222,10 @@ public class TBoolTest {
     static Stream<Arguments> TBool_hash() throws SQLException {
         GeneratedFunctions.meos_initialize_timezone("UTC");
         return Stream.of(
-                Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", 440045287),
+                Arguments.of(new TBoolInst("True@2019-09-01"), "TBoolInst", 440045318),
 //                Arguments.of(new TBoolSeq("{True@2019-09-01, False@2019-09-02}"), "TBoolSeq",2385901957l),
 //                Arguments.of(new TBoolSeq("[True@2019-09-01, False@2019-09-02]"), "TBoolSeq", 2385901957l),
-                Arguments.of(new TBoolSeqSet("{[True@2019-09-01, False@2019-09-02],[True@2019-09-03, True@2019-09-05]}"), "TBoolSeqSet",1543175996)
+                Arguments.of(new TBoolSeqSet("{[True@2019-09-01, False@2019-09-02],[True@2019-09-03, True@2019-09-05]}"), "TBoolSeqSet",1190925880)
         );
     }
 

--- a/jmeos-core/src/test/java/basic/TFloatTest.java
+++ b/jmeos-core/src/test/java/basic/TFloatTest.java
@@ -276,8 +276,8 @@ public class TFloatTest {
     private static Stream<Arguments> hash() throws SQLException {
         GeneratedFunctions.meos_initialize_timezone("UTC");
         return Stream.of(
-                Arguments.of(new TFloatInst("1.5@2019-09-01"), 1307112078, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
-                Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), 1935376725, LocalDateTime.of(2019, 9, 2, 0, 0,0))
+                Arguments.of(new TFloatInst("1.5@2019-09-01"), 1307112109, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
+                Arguments.of(new TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]"), -1130512577, LocalDateTime.of(2019, 9, 2, 0, 0,0))
 //                Arguments.of(new TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"), 4247071962l, LocalDateTime.of(2019, 9, 5, 0, 0,0))
         );
     }

--- a/jmeos-core/src/test/java/basic/TGeogPointTest.java
+++ b/jmeos-core/src/test/java/basic/TGeogPointTest.java
@@ -427,9 +427,9 @@ public class TGeogPointTest {
         GeneratedFunctions.meos_initialize_timezone("UTC");
         return Stream.of(
 //                Arguments.of(new TGeogPointInst("Point(1 1)@2019-09-01"), 382694564),
-                Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 1545137628),
-                Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), 1545137628),
-                Arguments.of(new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), 1008965061)
+                Arguments.of(new TGeogPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), -1520751674),
+                Arguments.of(new TGeogPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), -1520751674),
+                Arguments.of(new TGeogPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), 429936847)
         );
     }
 

--- a/jmeos-core/src/test/java/basic/TGeomPointTest.java
+++ b/jmeos-core/src/test/java/basic/TGeomPointTest.java
@@ -423,9 +423,9 @@ public class TGeomPointTest {
     private static Stream<Arguments> hash() {
         GeneratedFunctions.meos_initialize_timezone("UTC");
         return Stream.of(
-                Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), 382694564),
-                Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), 1664033448),
-                Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), 1664033448)
+                Arguments.of(new TGeomPointInst("Point(1 1)@2019-09-01"), 382694595),
+                Arguments.of(new TGeomPointSeq("{Point(1 1)@2019-09-01, Point(2 2)@2019-09-02}"), -1401855854),
+                Arguments.of(new TGeomPointSeq("[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02]"), -1401855854)
 //                Arguments.of(new TGeomPointSeqSet("{[Point(1 1)@2019-09-01, Point(2 2)@2019-09-02], [Point(1 1)@2019-09-03, Point(1 1)@2019-09-05]}"), 2878566103l)
         );
     }

--- a/jmeos-core/src/test/java/basic/TIntTest.java
+++ b/jmeos-core/src/test/java/basic/TIntTest.java
@@ -269,9 +269,9 @@ public class TIntTest {
     private static Stream<Arguments> hash() throws SQLException {
         GeneratedFunctions.meos_initialize_timezone("UTC");
         return Stream.of(
-                Arguments.of(new TIntInst("1@2019-09-01"), 440045287, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
+                Arguments.of(new TIntInst("1@2019-09-01"), 440045318, LocalDateTime.of(2019, 9, 1, 0, 0,0)),
 //                Arguments.of(new TIntSeq("[1@2019-09-01, 2@2019-09-02]"), 3589664982l, LocalDateTime.of(2019, 9, 2, 0, 0,0)),
-                Arguments.of(new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05]}"), 205124107l, LocalDateTime.of(2019, 9, 5, 0, 0,0))
+                Arguments.of(new TIntSeqSet("{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05]}"), -1633977015l, LocalDateTime.of(2019, 9, 5, 0, 0,0))
         );
     }
 

--- a/jmeos-core/src/test/java/basic/TTextTest.java
+++ b/jmeos-core/src/test/java/basic/TTextTest.java
@@ -228,9 +228,9 @@ public class TTextTest {
     static Stream<Arguments> TText_hash() throws SQLException {
         GeneratedFunctions.meos_initialize_timezone("UTC");
         return Stream.of(
-                Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", 1893808825),
-                Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq",1223816819),
-                Arguments.of(new TTextSeq("[AAA@2019-09-01, BBB@2019-09-02]"), "TTextSeq",1223816819)
+                Arguments.of(new TTextInst("AAA@2019-09-01"), "TTextInst", 1893808856),
+                Arguments.of(new TTextSeq("{AAA@2019-09-01, BBB@2019-09-02}"), "TTextSeq",-1842072483),
+                Arguments.of(new TTextSeq("[AAA@2019-09-01, BBB@2019-09-02]"), "TTextSeq",-1842072483)
 //                Arguments.of(new TTextSeqSet("{[AAA@2019-09-01, BBB@2019-09-02],[AAA@2019-09-03, AAA@2019-09-05]}"), "TTextSeqSet", 2199213310l)
         );
     }


### PR DESCRIPTION
MobilityDB answers equality, the B-tree order and the hash from the function a
temporal value denotes rather than from the way it is spelled, so temporal_hash
reads the instants in time order and nothing else. Every temporal hash therefore
changes, and the values pinned here were the ones the previous rule produced.

The pinned hashes are the ones the library answers. Two spellings of one value
now hash alike, which is what a hash opclass asks of values that compare equal:
the discrete sequence and the sequence of the same instants share -1401855854 as
temporal geometry points, -1520751674 as geographies and -1842072483 as texts.

