### PR TITLE
Keep the built jar out of the tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,11 @@ build/
 ### Ignore pid error log files ###
 *.log
 
-### Ignore Fat Jar generated with mvn package ####
-jar/JMEOS-fat.jar
+### The jars mvn package writes. Both are build output: the plain JMEOS.jar the
+### JVM consumers install as org.jmeos:meos, and the fat jar beside it. Neither
+### belongs in the tree, and ignoring the directory is what keeps a jar built in
+### a working copy from being committed back.
+jar/
 
 ### ignore maven-shade-plugin generated dependendcy-reduced-pom.xml ###
 dependency-reduced-pom.xml


### PR DESCRIPTION
`mvn package` writes two jars into `jar/`: the plain `JMEOS.jar` the JVM
consumers install as `org.jmeos:meos`, and the fat jar beside it. Both are
build output, so the directory is ignored rather than the fat jar alone — an
ignore list naming one of the two leaves the other a file git offers to commit,
which is how a binary reaches a tree that tracks none.

The tree tracks no jar: `jar/` holds nothing under version control and no `.jar`
path exists anywhere in it.

