### PR TITLE
Publish the jar as a release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Publish the jar
+
+# The jar the JVM consumers bind reaches them as a release asset rather than as a
+# file in the tree. Publishing a release builds it and attaches it; a manual run
+# builds it and keeps it as a run artifact, so the path is exercisable without
+# cutting a release.
+#
+# It is built by tools/regen-from-catalog.sh, the same script CI and
+# tools/refresh-from-master.sh call, against a catalog and a libmeos derived from
+# one MobilityDB commit in this run — so a published jar carries the surface that
+# commit defines, and the script's own check refuses a jar whose suite did not run.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Build the jar and attach it to the release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      # The catalog and the all-families libmeos, from one MobilityDB commit,
+      # through the shared composite action the other workflows use.
+      - name: Provision MEOS catalog + libmeos
+        id: provision
+        uses: MobilityDB/MEOS-API/.github/actions/provision-meos@master
+        with:
+          mobilitydb-ref: master
+          build-libmeos: "true"
+
+      - name: Build the jar
+        env:
+          CATALOG: ${{ steps.provision.outputs.catalog-path }}
+          LIBMEOS: /usr/local/lib/libmeos.so
+        run: tools/regen-from-catalog.sh
+
+      # The catalog stamps the MobilityDB commit it was derived from, so the run
+      # states which surface the published jar carries.
+      - name: Name the surface the jar carries
+        run: |
+          python3 -c "import json;print('MobilityDB commit:', json.load(open('codegen/input/meos-idl.json'))['sourceCommit'])"
+          ls -l jar/
+
+      # A release gets the assets attached to it; a manual run keeps them on the
+      # run, which is what makes this workflow exercisable without a release.
+      - name: Attach the jars to the release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" jar/JMEOS.jar jar/JMEOS-fat.jar --clobber
+
+      - name: Keep the jars on the run
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jmeos-jars
+          path: jar/*.jar
+          if-no-files-found: error


### PR DESCRIPTION
The jar the JVM consumers bind reaches them from a release rather than from the
tree. Publishing a release builds `JMEOS.jar` and `JMEOS-fat.jar` and attaches
both; a manual run builds them and keeps them as run artifacts, so the path can
be exercised without cutting a release.

`tools/regen-from-catalog.sh` builds them — the same script the CI build and
`tools/refresh-from-master.sh` call — against a catalog and an all-families
libmeos derived from one MobilityDB commit in the same run. A published jar
therefore carries the surface that commit defines, the run names the commit from
the catalog's own `sourceCommit` stamp, and the script refuses a jar whose suite
did not run.

