### PR TITLE
Build the image from the tree it ships, at every family

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# The image copies this tree in, so it takes the sources and leaves everything a
+# build produces — the container builds its own.
+.git
+target
+jar
+*.so

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,14 @@ RUN apt-get update \
   && apt-get update \
   && apt-get install -y java-21-amazon-corretto-jdk 
 
-# BUILD MobilityDB
+# BUILD MobilityDB. GeneratedFunctions is emitted from the catalog of master
+# with every family on, so the library has to answer for that same surface:
+# -DALL=ON is the flag CMakeLists.txt turns into the family list, and without it
+# the jar names symbols libmeos does not carry.
 RUN git clone --depth 1 https://github.com/MobilityDB/MobilityDB.git -b master /usr/local/src/MobilityDB
-#RUN git clone --depth 1 https://github.com/estebanzimanyi/MobilityDB.git -b tpoint_fix /usr/local/src/MobilityDB
 RUN mkdir -p /usr/local/src/MobilityDB/build
 RUN cd /usr/local/src/MobilityDB/build && \
-    cmake -DMEOS=ON .. && \
+    cmake -DMEOS=ON -DALL=ON .. && \
     make -j$(nproc) && \
     make install && \
     ldconfig
@@ -34,8 +36,10 @@ COPY --from=maven:3.9.6-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.
 
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
-# ADD PROJECT MobilityDB-JMEOS
-RUN git clone --branch fix-tests-using-docker https://github.com/MobilityDB/JMEOS /usr/local/jmeos
+# ADD PROJECT MobilityDB-JMEOS. The image carries the tree it is built from
+# rather than cloning this repository into itself: a clone names a ref, and a ref
+# named here is one nothing updates.
+COPY . /usr/local/jmeos
 
 # Copy libmeos.so to src/ (used by JarLibraryLoader on Linux)
 RUN cp /usr/local/lib/libmeos.so /usr/local/jmeos/src/libmeos.so

--- a/README_JAR.md
+++ b/README_JAR.md
@@ -81,10 +81,10 @@ RUN apt-get update \
   && apt-get install -y java-21-amazon-corretto-jdk
 
 # Compile MobilityDB with MEOS (generates libmeos.so)
-RUN git clone https://github.com/MobilityDB/MobilityDB.git -b stable-1.3 /usr/local/src/MobilityDB
+RUN git clone https://github.com/MobilityDB/MobilityDB.git -b master /usr/local/src/MobilityDB
 RUN mkdir -p /usr/local/src/MobilityDB/build
 RUN cd /usr/local/src/MobilityDB/build && \
-    cmake -DMEOS=ON .. && \
+    cmake -DMEOS=ON -DALL=ON .. && \
     make -j$(nproc) && \
     make install && \
     ldconfig
@@ -121,8 +121,9 @@ CMD ["java", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "-Djava.library.p
 ```
 
 Note:
-- when cloning MobilityDB in the Dockerfile, you might want to change its version, e.g. "-b stable-1.3" instead of "-b master" depending on your needs (functions such as geom_in only available in meos_geo.h):  
-  ```Ln 16: RUN git clone https://github.com/MobilityDB/MobilityDB.git -b master```
+- build MobilityDB from `master` with `-DALL=ON`, as above. The jar's `GeneratedFunctions` is emitted from the catalog of master with every family on, so a library built from a release branch, or without the family flag, lacks symbols the jar names — the call fails at run time rather than at build time:  
+  ```RUN git clone https://github.com/MobilityDB/MobilityDB.git -b master```  
+  ```    cmake -DMEOS=ON -DALL=ON .. && \```
 - do not forget to adapt the entrypoint parameters to your project:
   - the parameters of target/ here depending on the artifactId and version of your pom, here:   
   ```target/untitled-1.0-SNAPSHOT.jar:/tmp/JMEOS-fat.jar"```


### PR DESCRIPTION
`Dockerfile` cloned this repository into itself at the branch
`fix-tests-using-docker`, so the image never carried the tree it was built from
and the ref it named was one nothing updates. It copies the tree in instead,
which leaves no ref to go stale, and `.dockerignore` keeps out what a build
produces. The dead line beside it, a commented clone of a personal fork at
`tpoint_fix`, goes with it.

Both the image and the `README_JAR.md` recipe configured MobilityDB without
`-DALL=ON`, and the recipe cloned `stable-1.3` while advising the reader to
prefer it over master. `GeneratedFunctions` is emitted from the catalog of master
with every family on, so a library built either way lacks symbols the jar names,
and the call fails at run time rather than at build time. Both build master with
the family flag, and the note says why rather than the reverse.

Nothing in the repository builds this image, which is how its refs rotted
unnoticed. `tools/check-tree-hygiene.py` reports the tree clean on all four
rules; it read three findings here before.

