### PR TITLE
Check the tree before building it

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,20 @@ on:
     branches-ignore: gh-pages
 
 jobs:
+  # The tree is checked before anything is built: the four rules read
+  # `git ls-files` and nothing else, so a finding arrives in seconds rather than
+  # after a libmeos build. The rules live in MEOS-API beside the catalog and the
+  # provisioning recipe, so this repository carries no copy of them to go stale.
+  hygiene:
+    name: Tree hygiene
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Refuse tracked build output, skipped suites and stale pins
+        uses: MobilityDB/MEOS-API/.github/actions/check-tree-hygiene@master
+
   build:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Four states this repository can reach are invisible to a build that succeeds:
build output tracked in the tree, a suite kept from running by a skip flag, a
clone pinned off master or onto a fork, and a Dockerfile nothing builds. Each was
found in a binding tree rather than imagined — a 5.9 MB `libmeos.so` that a local
run loaded while CI loaded a freshly built one, answering for fewer families than
the catalog the generator reads, is what this closes.

The rules are `tools/check-tree-hygiene.py` in MEOS-API, beside the catalog and
the provisioning recipe, so this repository carries no copy of them to go stale.
They are their own job rather than a step of the build, because they read
`git ls-files` and nothing else: a finding arrives in seconds instead of after a
libmeos build.
