### PR TITLE
Refuse a skip, and a suite that shrank

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -85,4 +85,18 @@ jobs:
         run: echo "LD_LIBRARY_PATH=$(pwd)/jmeos-core/src/" >> $GITHUB_ENV
 
       - name: Build with Maven
-        run: mvn clean install
+        run: |
+          set -o pipefail
+          mvn clean install | tee "$RUNNER_TEMP/build.log"
+
+      # The build's own summary states two things this job's conclusion does
+      # not: a test reported SKIPPED asserts nothing while the job still reads
+      # success, and a test the run never collects appears in no count at all,
+      # so removing one leaves the skip number at zero. The floor is what
+      # guards the second. Raise it when the suite grows; lowering it belongs
+      # in the commit that accounts for the removal.
+      - name: Refuse a skip, and a suite that shrank
+        uses: MobilityDB/MEOS-API/.github/actions/check-test-outcome@master
+        with:
+          log: ${{ runner.temp }}/build.log
+          min-tests: "1894"


### PR DESCRIPTION
The build's own summary states two things this job's conclusion does not. A test
reported SKIPPED asserts nothing while the job still reads success — one flag is
enough to reach it, and MobilityFlink's binding module under
`-Dmeos.enabled=false` reports `Tests run: 7, Failures: 0, Errors: 0, Skipped: 7`
beside `BUILD SUCCESS`, its whole MEOS surface disabled under a green build.

A test the run never collects is worse, because it appears in no count at all: a
surefire `<excludes>`, a `-Dtest=` filter, a class renamed out of `*Test` or a
deleted file all leave the skip number at zero. Once skipping is refused, removing
a test is the remaining way to stop running it, so the total carries a floor.

The rules live in MEOS-API beside the catalog and the tree-hygiene check, so this
repository carries no copy of them. The build is teed to a log under
`set -o pipefail`, so `tee` cannot mask a failing build, and the check reads the
summary from it.
